### PR TITLE
Add review MVP and align README with trust-runtime roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 🦞 sego
 
 <p align="center">
-  <strong>The AI coding agent that learns from every run.</strong><br>
-  Open-source · Rust-native · Model-agnostic · Self-evolving
+  <strong>Engineering Trust Runtime for AI coding.</strong><br>
+  Open-source · Rust-native · Model-agnostic · Review-first
 </p>
 
 <p align="center">
@@ -16,31 +16,29 @@
 
 ## Why sego exists
 
-There are hundreds of AI coding tools. Every single one follows the same pattern:
+AI coding tools are good at producing changes. The hard part is proving those changes are safe to merge.
 
-```
-Input task → Execute → Output result → End (start from scratch next time)
-```
+Sego focuses on the trust layer between code generation and delivery:
 
-**sego is different.** It runs the same loop, but adds something none of them have:
+**Generate** with Claude Code, Codex, Cursor, OpenHands, or any other authoring tool.
+**Use Sego** to review the diff, verify evidence, preserve engineering memory, and prepare the change for shipping.
 
-```
-Input task → Execute → Record lane events → Output result
-                          ↓
-              Diagnose failures (11 types)
-                          ↓
-              Match recovery recipe (7 built-in)
-                          ↓
-              Auto-heal → Policy engine learns → Better next time
-```
+---
 
-**Three things sego gives you that no other tool does:**
+### Product Direction
 
-1. **Record** — Every session is tracked as structured Lane Events. You know exactly what happened, what failed, and why.
-2. **Recover** — 11 failure types auto-classified. 7 built-in recovery recipes. sego fixes itself before asking for help.
-3. **Evolve** — Policy engine learns from history. Green Contract enforces quality. Your agent gets smarter every run.
+Sego is evolving from an agentic CLI into an **Engineering Trust Runtime**:
 
-> **You don't just use sego. sego learns how you work.**
+1. **Review** — inspect diffs with read-only, evidence-based code review.
+2. **Verify** — connect findings to tests, builds, lint, and reproducible evidence.
+3. **Memory** — retain accepted findings, false positives, missed issues, and project rules.
+4. **Ship** — produce auditable PR/commit reports and release gates.
+
+The first milestone is the real `/review` command.
+
+Sego also retains its existing capabilities: self-learning workflow recording, failure auto-recovery, policy engine, and Green Contract quality gates — these form the foundation for the trust runtime.
+
+---
 
 ---
 
@@ -146,6 +144,13 @@ sego --resume latest          # Continue last session
 sego status                   # Workspace snapshot
 sego doctor                   # System diagnostics
 sego --output-format json status  # Machine-readable output
+
+# Code review commands
+sego /review                  # Review workspace diff
+sego /review staged           # Review staged changes only
+sego /review unstaged         # Review unstaged changes only
+sego /review path/to/file.rs  # Review a path-scoped diff
+sego review                   # Workflow/session review (not code review)
 ```
 
 ### Model Support
@@ -168,6 +173,7 @@ rust/
 │   ├── api/                    # Anthropic-compatible client + SSE streaming
 │   ├── commands/               # Slash command registry (/help, /status, /cost...)
 │   ├── runtime/                # Core loop, sessions, permissions, MCP, prompts
+│   │   ├── code_review/        # Review scope, prompt contract, finding schema
 │   │   ├── lane_events.rs      #   ─┐
 │   │   ├── recovery_recipes.rs #    ├─ Self-learning system
 │   │   ├── policy_engine.rs    #    │
@@ -512,7 +518,26 @@ All data helps improve recovery recipes, efficiency benchmarks, and API compatib
 
 ## Roadmap
 
-### Done
+### Phase 1: AI Review Runtime
+- [x] `/review` MVP — read-only, scope-aware, evidence-based code review
+- [x] DeepSeek `reasoning_content` compatibility
+- [ ] structured finding parser
+- [ ] diff hash binding
+- [ ] review artifacts (`.sego`)
+
+### Phase 2: AI Trust Runtime
+- [ ] `/verify` — connect findings to tests, builds, lint, reproducible evidence
+- [ ] evidence collection and attestation
+- [ ] `.sego` local memory
+- [ ] AgentGit-backed session memory
+
+### Phase 3: AI Engineering Runtime
+- [ ] data-flow impact review
+- [ ] worktree lanes
+- [ ] PR adapter
+- [ ] CI gate
+
+### Existing (retained foundation)
 - [x] Anthropic API + SSE streaming
 - [x] Interactive REPL + one-shot prompt
 - [x] 40+ built-in tools (bash, file ops, search, web, agents, MCP, LSP)
@@ -523,13 +548,6 @@ All data helps improve recovery recipes, efficiency benchmarks, and API compatib
 - [x] Green Contract — 4-level quality enforcement
 - [x] Session persistence + resume
 - [x] Multi-provider ready (any Anthropic-compatible API)
-
-### Next up
-- [ ] `sego review` — structured workflow analysis command
-- [ ] `sego learn` — historical trend analysis and optimization suggestions
-- [ ] Pre-built binary releases (GitHub Releases)
-- [ ] Plugin marketplace
-- [ ] Team dashboard (web UI for Lane Events across team members)
 
 ---
 
@@ -554,6 +572,6 @@ MIT © 2026 sego contributors
 ---
 
 <p align="center">
-  <strong>sego — The AI coding agent that learns from every run.</strong><br>
-  <sub>Open source. Rust native. Model free. Always improving.</sub>
+  <strong>Sego — Engineering Trust Runtime for AI coding.</strong><br>
+  <sub>Build with any AI. Review, verify, and ship with evidence.</sub>
 </p>

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -16,6 +16,8 @@ use super::{Provider, ProviderFuture};
 
 pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
 pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+pub const DEFAULT_DEEPSEEK_BASE_URL: &str = "https://api.deepseek.com/v1";
+pub const DEFAULT_MIMO_BASE_URL: &str = "https://api.moonshot.cn/v1";
 const REQUEST_ID_HEADER: &str = "request-id";
 const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
 const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
@@ -32,6 +34,8 @@ pub struct OpenAiCompatConfig {
 
 const XAI_ENV_VARS: &[&str] = &["XAI_API_KEY"];
 const OPENAI_ENV_VARS: &[&str] = &["OPENAI_API_KEY"];
+const DEEPSEEK_ENV_VARS: &[&str] = &["DEEPSEEK_API_KEY"];
+const MIMO_ENV_VARS: &[&str] = &["MIMO_API_KEY"];
 
 impl OpenAiCompatConfig {
     #[must_use]
@@ -53,11 +57,34 @@ impl OpenAiCompatConfig {
             default_base_url: DEFAULT_OPENAI_BASE_URL,
         }
     }
+
+    #[must_use]
+    pub const fn deepseek() -> Self {
+        Self {
+            provider_name: "DeepSeek",
+            api_key_env: "DEEPSEEK_API_KEY",
+            base_url_env: "DEEPSEEK_BASE_URL",
+            default_base_url: DEFAULT_DEEPSEEK_BASE_URL,
+        }
+    }
+
+    #[must_use]
+    pub const fn mimo() -> Self {
+        Self {
+            provider_name: "MiMo",
+            api_key_env: "MIMO_API_KEY",
+            base_url_env: "MIMO_BASE_URL",
+            default_base_url: DEFAULT_MIMO_BASE_URL,
+        }
+    }
+
     #[must_use]
     pub fn credential_env_vars(self) -> &'static [&'static str] {
         match self.provider_name {
             "xAI" => XAI_ENV_VARS,
             "OpenAI" => OPENAI_ENV_VARS,
+            "DeepSeek" => DEEPSEEK_ENV_VARS,
+            "MiMo" => MIMO_ENV_VARS,
             _ => &[],
         }
     }
@@ -81,7 +108,11 @@ impl OpenAiCompatClient {
     #[must_use]
     pub fn new(api_key: impl Into<String>, config: OpenAiCompatConfig) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(30))
+                .timeout(Duration::from_secs(600))
+                .build()
+                .expect("failed to build HTTP client"),
             api_key: api_key.into(),
             config,
             base_url: read_base_url(config),
@@ -351,6 +382,19 @@ impl StreamState {
         }
 
         for choice in chunk.choices {
+            if let Some(reasoning_content) = choice
+                .delta
+                .reasoning_content
+                .filter(|value| !value.is_empty())
+            {
+                events.push(StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
+                    index: 0,
+                    delta: ContentBlockDelta::ThinkingDelta {
+                        thinking: reasoning_content,
+                    },
+                }));
+            }
+
             if let Some(content) = choice.delta.content.filter(|value| !value.is_empty()) {
                 if !self.text_started {
                     self.text_started = true;
@@ -533,6 +577,8 @@ struct ChatMessage {
     #[serde(default)]
     content: Option<String>,
     #[serde(default)]
+    reasoning_content: Option<String>,
+    #[serde(default)]
     tool_calls: Vec<ResponseToolCall>,
 }
 
@@ -579,6 +625,8 @@ struct ChunkDelta {
     #[serde(default)]
     content: Option<String>,
     #[serde(default)]
+    reasoning_content: Option<String>,
+    #[serde(default)]
     tool_calls: Vec<DeltaToolCall>,
 }
 
@@ -621,7 +669,7 @@ fn build_chat_completion_request(request: &MessageRequest, config: OpenAiCompatC
         }));
     }
     for message in &request.messages {
-        messages.extend(translate_message(message));
+        messages.extend(translate_message(message, config));
     }
 
     let mut payload = json!({
@@ -646,10 +694,12 @@ fn build_chat_completion_request(request: &MessageRequest, config: OpenAiCompatC
     payload
 }
 
-fn translate_message(message: &InputMessage) -> Vec<Value> {
+fn translate_message(message: &InputMessage, config: OpenAiCompatConfig) -> Vec<Value> {
     match message.role.as_str() {
         "assistant" => {
+            let preserve_reasoning_content = matches!(config.provider_name, "DeepSeek");
             let mut text = String::new();
+            let mut reasoning_content = String::new();
             let mut tool_calls = Vec::new();
             for block in &message.content {
                 match block {
@@ -662,19 +712,29 @@ fn translate_message(message: &InputMessage) -> Vec<Value> {
                             "arguments": input.to_string(),
                         }
                     })),
+                    InputContentBlock::Thinking { thinking, .. } if preserve_reasoning_content => {
+                        reasoning_content.push_str(thinking);
+                    }
+                    InputContentBlock::Thinking { .. } => {}
                     InputContentBlock::ToolResult { .. }
-                    | InputContentBlock::Thinking { .. }
                     | InputContentBlock::RedactedThinking { .. } => {}
                 }
             }
-            if text.is_empty() && tool_calls.is_empty() {
+            if text.is_empty() && reasoning_content.is_empty() && tool_calls.is_empty() {
                 Vec::new()
             } else {
-                vec![json!({
-                    "role": "assistant",
-                    "content": (!text.is_empty()).then_some(text),
-                    "tool_calls": tool_calls,
-                })]
+                let mut msg = serde_json::Map::new();
+                msg.insert("role".to_string(), json!("assistant"));
+                if !text.is_empty() {
+                    msg.insert("content".to_string(), json!(text));
+                }
+                if !reasoning_content.is_empty() {
+                    msg.insert("reasoning_content".to_string(), json!(reasoning_content));
+                }
+                if !tool_calls.is_empty() {
+                    msg.insert("tool_calls".to_string(), json!(tool_calls));
+                }
+                vec![Value::Object(msg)]
             }
         }
         _ => message
@@ -746,6 +806,14 @@ fn normalize_response(
         .next()
         .ok_or(ApiError::InvalidSseFrame("chat completion response missing choices"))?;
     let mut content = Vec::new();
+    if let Some(reasoning_content) =
+        choice.message.reasoning_content.filter(|value| !value.is_empty())
+    {
+        content.push(OutputContentBlock::Thinking {
+            thinking: reasoning_content,
+            signature: None,
+        });
+    }
     if let Some(text) = choice.message.content.filter(|value| !value.is_empty()) {
         content.push(OutputContentBlock::Text { text });
     }
@@ -904,12 +972,13 @@ impl StringExt for String {
 mod tests {
     use super::{
         build_chat_completion_request, chat_completions_endpoint, normalize_finish_reason,
-        openai_tool_choice, parse_tool_arguments, OpenAiCompatClient, OpenAiCompatConfig,
+        normalize_response, openai_tool_choice, parse_tool_arguments, ChatChoice, ChatCompletionResponse,
+        ChatMessage, OpenAiCompatClient, OpenAiCompatConfig,
     };
     use crate::error::ApiError;
     use crate::types::{
-        InputContentBlock, InputMessage, MessageRequest, ToolChoice, ToolDefinition,
-        ToolResultContentBlock,
+        InputContentBlock, InputMessage, MessageRequest, OutputContentBlock, ToolChoice,
+        ToolDefinition, ToolResultContentBlock,
     };
     use serde_json::json;
     use std::sync::{Mutex, OnceLock};
@@ -986,6 +1055,97 @@ mod tests {
         );
 
         assert!(payload.get("stream_options").is_none());
+    }
+
+    #[test]
+    fn deepseek_request_translation_preserves_reasoning_content() {
+        let payload = build_chat_completion_request(
+            &MessageRequest {
+                model: "deepseek-v4-pro".to_string(),
+                max_tokens: 64,
+                messages: vec![InputMessage {
+                    role: "assistant".to_string(),
+                    content: vec![
+                        InputContentBlock::Thinking {
+                            thinking: "internal reasoning".to_string(),
+                            signature: None,
+                        },
+                        InputContentBlock::Text { text: "Final answer".to_string() },
+                    ],
+                }],
+                system: None,
+                tools: None,
+                tool_choice: None,
+                stream: false,
+            },
+            OpenAiCompatConfig::deepseek(),
+        );
+
+        assert_eq!(payload["messages"][0]["role"], json!("assistant"));
+        assert_eq!(payload["messages"][0]["content"], json!("Final answer"));
+        assert_eq!(
+            payload["messages"][0]["reasoning_content"],
+            json!("internal reasoning")
+        );
+    }
+
+    #[test]
+    fn openai_request_translation_drops_reasoning_content() {
+        let payload = build_chat_completion_request(
+            &MessageRequest {
+                model: "gpt-4.1".to_string(),
+                max_tokens: 64,
+                messages: vec![InputMessage {
+                    role: "assistant".to_string(),
+                    content: vec![
+                        InputContentBlock::Thinking {
+                            thinking: "internal reasoning".to_string(),
+                            signature: None,
+                        },
+                        InputContentBlock::Text { text: "Final answer".to_string() },
+                    ],
+                }],
+                system: None,
+                tools: None,
+                tool_choice: None,
+                stream: false,
+            },
+            OpenAiCompatConfig::openai(),
+        );
+
+        assert!(payload["messages"][0].get("reasoning_content").is_none());
+        assert_eq!(payload["messages"][0]["content"], json!("Final answer"));
+    }
+
+    #[test]
+    fn deepseek_response_normalization_preserves_reasoning_content() {
+        let response = normalize_response(
+            "deepseek-v4-pro",
+            ChatCompletionResponse {
+                id: "chatcmpl_1".to_string(),
+                model: "deepseek-v4-pro".to_string(),
+                choices: vec![ChatChoice {
+                    message: ChatMessage {
+                        role: "assistant".to_string(),
+                        content: Some("Final answer".to_string()),
+                        reasoning_content: Some("internal reasoning".to_string()),
+                        tool_calls: Vec::new(),
+                    },
+                    finish_reason: Some("stop".to_string()),
+                }],
+                usage: None,
+            },
+        )
+        .expect("response should normalize");
+
+        assert!(matches!(
+            &response.content[0],
+            OutputContentBlock::Thinking { thinking, .. } if thinking == "internal reasoning"
+        ));
+        assert!(matches!(
+            &response.content[1],
+            OutputContentBlock::Text { text } if text == "Final answer"
+        ));
     }
 
     #[test]

--- a/rust/crates/runtime/src/code_review/context.rs
+++ b/rust/crates/runtime/src/code_review/context.rs
@@ -1,0 +1,39 @@
+use super::ReviewScope;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewTarget {
+    pub scope: ReviewScope,
+    pub git_status: String,
+    pub staged_diff: String,
+    pub unstaged_diff: String,
+}
+
+impl ReviewTarget {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.staged_diff.trim().is_empty() && self.unstaged_diff.trim().is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewContext {
+    pub target: ReviewTarget,
+    pub project_rules: Vec<String>,
+}
+
+impl ReviewContext {
+    #[must_use]
+    pub fn new(target: ReviewTarget) -> Self {
+        Self {
+            target,
+            project_rules: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_project_rules(mut self, project_rules: Vec<String>) -> Self {
+        self.project_rules = project_rules;
+        self
+    }
+}
+

--- a/rust/crates/runtime/src/code_review/mod.rs
+++ b/rust/crates/runtime/src/code_review/mod.rs
@@ -1,0 +1,12 @@
+mod context;
+mod prompt;
+mod report;
+mod scope;
+mod severity;
+
+pub use context::{ReviewContext, ReviewTarget};
+pub use prompt::{build_review_prompt, ReviewPromptOptions};
+pub use report::{ReviewFinding, ReviewReport};
+pub use scope::{ReviewScope, ReviewScopeParseError};
+pub use severity::ReviewSeverity;
+

--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -1,0 +1,164 @@
+use super::{ReviewContext, ReviewScope};
+
+const DEFAULT_MAX_DIFF_CHARS: usize = 24_000;
+const DEFAULT_MAX_RULE_CHARS: usize = 6_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReviewPromptOptions {
+    pub max_diff_chars: usize,
+    pub max_rule_chars: usize,
+}
+
+impl Default for ReviewPromptOptions {
+    fn default() -> Self {
+        Self {
+            max_diff_chars: DEFAULT_MAX_DIFF_CHARS,
+            max_rule_chars: DEFAULT_MAX_RULE_CHARS,
+        }
+    }
+}
+
+#[must_use]
+pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions) -> String {
+    let mut prompt = vec![
+        "You are Sego Review Agent.".to_string(),
+        "Mode: read-only code review. Do not modify files, run write operations, commit, or change permissions.".to_string(),
+        format!("Review scope: {}", context.target.scope.label()),
+        String::new(),
+        "Task: review the current git diff for correctness, regressions, security risks, data-flow drift, missing tests, and maintainability issues.".to_string(),
+        "Findings must be specific and evidence-based. Avoid broad summaries unless there are no findings.".to_string(),
+        String::new(),
+        "Output contract:".to_string(),
+        "- Start with findings, ordered by severity.".to_string(),
+        "- For each finding include: severity, file/path, line or hunk if available, evidence, risk, suggestion, confidence, and verification hint.".to_string(),
+        "- If no issues are found, say exactly: No findings.".to_string(),
+        "- Do not claim tests passed unless evidence is provided in the context.".to_string(),
+        String::new(),
+    ];
+
+    if !context.project_rules.is_empty() {
+        prompt.push("Project rules:".to_string());
+        prompt.push(truncate_for_prompt(
+            &context.project_rules.join("\n\n"),
+            options.max_rule_chars,
+        ));
+        prompt.push(String::new());
+    }
+
+    if !context.target.git_status.trim().is_empty() {
+        prompt.push("Git status:".to_string());
+        prompt.push(fenced("text", context.target.git_status.trim()));
+        prompt.push(String::new());
+    }
+
+    let diff = diff_for_scope(context);
+    if diff.trim().is_empty() {
+        prompt.push("Diff: no current changes for this review scope.".to_string());
+    } else {
+        prompt.push("Diff:".to_string());
+        prompt.push(fenced(
+            "diff",
+            &truncate_for_prompt(&diff, options.max_diff_chars),
+        ));
+    }
+
+    prompt.join("\n")
+}
+
+fn diff_for_scope(context: &ReviewContext) -> String {
+    match &context.target.scope {
+        ReviewScope::Workspace | ReviewScope::Path(_) => {
+            let mut sections = Vec::new();
+            if !context.target.staged_diff.trim().is_empty() {
+                sections.push(format!(
+                    "Staged changes:\n{}",
+                    context.target.staged_diff.trim_end()
+                ));
+            }
+            if !context.target.unstaged_diff.trim().is_empty() {
+                sections.push(format!(
+                    "Unstaged changes:\n{}",
+                    context.target.unstaged_diff.trim_end()
+                ));
+            }
+            sections.join("\n\n")
+        }
+        ReviewScope::Staged => context.target.staged_diff.clone(),
+        ReviewScope::Unstaged => context.target.unstaged_diff.clone(),
+    }
+}
+
+fn fenced(language: &str, body: &str) -> String {
+    format!("```{language}\n{body}\n```")
+}
+
+fn truncate_for_prompt(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+
+    let truncated = value.chars().take(max_chars).collect::<String>();
+    format!(
+        "{truncated}\n\n[truncated: original content exceeded {max_chars} characters]"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_review_prompt, ReviewPromptOptions};
+    use crate::code_review::{ReviewContext, ReviewScope, ReviewTarget};
+
+    #[test]
+    fn prompt_declares_read_only_review_contract() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::Workspace,
+            git_status: "## main\n M src/lib.rs".to_string(),
+            staged_diff: String::new(),
+            unstaged_diff: "diff --git a/src/lib.rs b/src/lib.rs\n".to_string(),
+        });
+
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+
+        assert!(prompt.contains("You are Sego Review Agent."));
+        assert!(prompt.contains("Mode: read-only code review."));
+        assert!(prompt.contains("severity, file/path, line or hunk"));
+        assert!(prompt.contains("diff --git a/src/lib.rs b/src/lib.rs"));
+    }
+
+    #[test]
+    fn prompt_handles_empty_diff() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::Staged,
+            git_status: "## main".to_string(),
+            staged_diff: String::new(),
+            unstaged_diff: "diff --git a/src/lib.rs b/src/lib.rs\n".to_string(),
+        });
+
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+
+        assert!(prompt.contains("Review scope: staged"));
+        assert!(prompt.contains("Diff: no current changes for this review scope."));
+        assert!(!prompt.contains("diff --git a/src/lib.rs b/src/lib.rs"));
+    }
+
+    #[test]
+    fn prompt_truncates_large_diff() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::Unstaged,
+            git_status: String::new(),
+            staged_diff: String::new(),
+            unstaged_diff: "x".repeat(100),
+        });
+
+        let prompt = build_review_prompt(
+            &context,
+            ReviewPromptOptions {
+                max_diff_chars: 12,
+                max_rule_chars: 12,
+            },
+        );
+
+        assert!(prompt.contains("[truncated: original content exceeded 12 characters]"));
+    }
+}
+

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -1,0 +1,31 @@
+use super::ReviewSeverity;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewFinding {
+    pub severity: ReviewSeverity,
+    pub file: String,
+    pub line: Option<u32>,
+    pub title: String,
+    pub evidence: String,
+    pub risk: String,
+    pub suggestion: String,
+    pub confidence: f32,
+    pub verification_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReviewReport {
+    pub findings: Vec<ReviewFinding>,
+    pub raw_text: String,
+}
+
+impl ReviewReport {
+    #[must_use]
+    pub fn no_findings(raw_text: impl Into<String>) -> Self {
+        Self {
+            findings: Vec::new(),
+            raw_text: raw_text.into(),
+        }
+    }
+}
+

--- a/rust/crates/runtime/src/code_review/scope.rs
+++ b/rust/crates/runtime/src/code_review/scope.rs
@@ -1,0 +1,95 @@
+use std::fmt;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewScope {
+    Workspace,
+    Staged,
+    Unstaged,
+    Path(PathBuf),
+}
+
+impl ReviewScope {
+    pub fn parse(input: Option<&str>) -> Result<Self, ReviewScopeParseError> {
+        let Some(raw) = input.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(Self::Workspace);
+        };
+
+        match raw {
+            "workspace" | "all" | "." => Ok(Self::Workspace),
+            "staged" | "--staged" | "cached" | "--cached" => Ok(Self::Staged),
+            "unstaged" | "--unstaged" | "working" | "worktree" => Ok(Self::Unstaged),
+            value if value.starts_with('-') => Err(ReviewScopeParseError::UnsupportedFlag {
+                value: value.to_string(),
+            }),
+            value => Ok(Self::Path(PathBuf::from(value))),
+        }
+    }
+
+    #[must_use]
+    pub fn label(&self) -> String {
+        match self {
+            Self::Workspace => "workspace".to_string(),
+            Self::Staged => "staged".to_string(),
+            Self::Unstaged => "unstaged".to_string(),
+            Self::Path(path) => format!("path:{}", path.display()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewScopeParseError {
+    UnsupportedFlag { value: String },
+}
+
+impl fmt::Display for ReviewScopeParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedFlag { value } => write!(
+                formatter,
+                "unsupported /review scope flag `{value}` (expected staged, unstaged, workspace, or a file path)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ReviewScopeParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReviewScope, ReviewScopeParseError};
+
+    #[test]
+    fn parses_empty_scope_as_workspace() {
+        assert_eq!(ReviewScope::parse(None), Ok(ReviewScope::Workspace));
+        assert_eq!(ReviewScope::parse(Some("  ")), Ok(ReviewScope::Workspace));
+    }
+
+    #[test]
+    fn parses_named_scopes() {
+        assert_eq!(ReviewScope::parse(Some("workspace")), Ok(ReviewScope::Workspace));
+        assert_eq!(ReviewScope::parse(Some("staged")), Ok(ReviewScope::Staged));
+        assert_eq!(ReviewScope::parse(Some("--cached")), Ok(ReviewScope::Staged));
+        assert_eq!(ReviewScope::parse(Some("unstaged")), Ok(ReviewScope::Unstaged));
+        assert_eq!(ReviewScope::parse(Some("worktree")), Ok(ReviewScope::Unstaged));
+    }
+
+    #[test]
+    fn parses_path_scope() {
+        assert_eq!(
+            ReviewScope::parse(Some("rust/crates/runtime/src/lib.rs")),
+            Ok(ReviewScope::Path("rust/crates/runtime/src/lib.rs".into()))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_flags() {
+        assert_eq!(
+            ReviewScope::parse(Some("--json")),
+            Err(ReviewScopeParseError::UnsupportedFlag {
+                value: "--json".to_string(),
+            })
+        );
+    }
+}
+

--- a/rust/crates/runtime/src/code_review/severity.rs
+++ b/rust/crates/runtime/src/code_review/severity.rs
@@ -1,0 +1,9 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ReviewSeverity {
+    Critical,
+    High,
+    Medium,
+    Low,
+    Info,
+}
+

--- a/rust/crates/runtime/src/community_learning.rs
+++ b/rust/crates/runtime/src/community_learning.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize};
 use crate::workflow::WorkflowSnapshot;
 
 const TELEMETRY_CONFIG_FILE: &str = "telemetry.json";
+#[allow(dead_code)]
 const REPORT_ENDPOINT: &str = "https://sego-telemetry.example.com/api/v1/report";
 
 /// Anonymous telemetry payload sent to community server.
@@ -200,6 +201,7 @@ fn now_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::green_contract::GreenLevel;
     use std::fs;
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -8,6 +8,7 @@ mod bash;
 pub mod bash_validation;
 mod bootstrap;
 pub mod branch_lock;
+pub mod code_review;
 pub mod community_learning;
 mod compact;
 mod config;
@@ -49,6 +50,10 @@ pub mod workflow;
 pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::BranchLockRegistry;
+pub use code_review::{
+    build_review_prompt, ReviewContext, ReviewFinding, ReviewPromptOptions, ReviewReport,
+    ReviewScope, ReviewScopeParseError, ReviewSeverity, ReviewTarget,
+};
 pub use compact::{
     compact_session, estimate_session_tokens, format_compact_summary,
     get_compact_continuation_message, should_compact, CompactionConfig, CompactionResult,

--- a/rust/crates/runtime/src/workflow/store.rs
+++ b/rust/crates/runtime/src/workflow/store.rs
@@ -69,6 +69,7 @@ pub struct WorkflowTrends {
 /// Persistent store for workflow data.
 #[derive(Debug, Clone)]
 pub struct WorkflowStore {
+    #[allow(dead_code)]
     root: PathBuf,
     sessions_dir: PathBuf,
     trends_path: PathBuf,
@@ -211,6 +212,8 @@ impl WorkflowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::workflow::SessionSummary;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn initializes_workflow_directories() {
@@ -250,7 +253,7 @@ mod tests {
 
         let report = SessionReport {
             session_id: "s1".to_string(),
-            session_summary: super::report::SessionSummary::default(),
+            session_summary: SessionSummary::default(),
             efficiency_score: 85.0,
             failure_count: 1,
             recovery_attempts: 1,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -24,8 +24,9 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    resolve_startup_auth_source, AnthropicClient, AuthSource, ContentBlockDelta, InputContentBlock,
-    InputMessage, MessageRequest, MessageResponse, OutputContentBlock, PromptCache,
+    detect_provider_kind, ProviderClient, ProviderKind,
+    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
+    OutputContentBlock,
     StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
@@ -47,8 +48,9 @@ use runtime::{
     resolve_sandbox_status, save_oauth_credentials,
     workflow::{SessionReport, WorkflowSnapshot, WorkflowStore},
     ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
-    ContentBlock, ConversationMessage, ConversationRuntime, DiffScope, LaneBlocker, LaneContext,
-    LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass,
+    build_review_prompt, ContentBlock, ConversationMessage, ConversationRuntime, DiffScope,
+    LaneBlocker, LaneContext, LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus,
+    LaneFailureClass, ReviewContext, ReviewPromptOptions, ReviewScope, ReviewTarget,
     McpServerManager, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest, OAuthConfig,
     OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, ProjectContext, PromptCacheEvent,
     ResolvedPermissionMode, ReviewStatus, RuntimeError, Session, TokenUsage, ToolError,
@@ -59,26 +61,23 @@ use serde_json::json;
 use tools::{GlobalToolRegistry, RuntimeToolDefinition, ToolSearchOutput};
 
 fn default_model() -> String {
-    std::env::var("ANTHROPIC_MODEL").unwrap_or_else(|_| "claude-opus-4-7".to_string())
+    std::env::var("DEEPSEEK_MODEL")
+        .or_else(|_| std::env::var("ANTHROPIC_MODEL"))
+        .unwrap_or_else(|_| "deepseek-chat".to_string())
 }
+
 fn max_tokens_for_model(model: &str) -> u32 {
-    if model.contains("opus") {
-        32_000
-    } else {
-        64_000
-    }
+    // DeepSeek, MiMo, and GPT all support 64K output
+    64_000
 }
 
 fn context_window_limit(model: &str) -> u32 {
-    // Approximate context window sizes for common models
     if model.contains("deepseek") || model.contains("v4") {
         1_000_000 // DeepSeek V4 supports 1M context
-    } else if model.contains("opus") {
-        200_000
-    } else if model.contains("sonnet") {
-        200_000
-    } else if model.contains("haiku") {
-        200_000
+    } else if model.contains("mimo") {
+        128_000 // MiMo supports 128K context
+    } else if model.starts_with("gpt") {
+        128_000 // GPT models 128K context
     } else {
         128_000 // conservative default
     }
@@ -203,6 +202,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             LiveCli::new(model, true, allowed_tools, permission_mode)?
                 .run_turn_with_output(&prompt, output_format)?
         }
+        CliAction::CodeReview { scope, model, allowed_tools, permission_mode } => {
+            run_code_review_cli(model, allowed_tools, permission_mode, scope.as_deref())?
+        }
         CliAction::Login => run_login()?,
         CliAction::Logout => run_logout()?,
         CliAction::Init => run_init()?,
@@ -256,6 +258,12 @@ enum CliAction {
         prompt: String,
         model: String,
         output_format: CliOutputFormat,
+        allowed_tools: Option<AllowedToolSet>,
+        permission_mode: PermissionMode,
+    },
+    CodeReview {
+        scope: Option<String>,
+        model: String,
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
     },
@@ -461,7 +469,9 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             }
             Ok(CliAction::Prompt { prompt, model, output_format, allowed_tools, permission_mode })
         }
-        other if other.starts_with('/') => parse_direct_slash_cli_action(&rest),
+        other if other.starts_with('/') => {
+            parse_direct_slash_cli_action(&rest, model, allowed_tools, permission_mode)
+        }
         _other => Ok(CliAction::Prompt {
             prompt: rest.join(" "),
             model,
@@ -539,7 +549,12 @@ fn join_optional_args(args: &[String]) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-fn parse_direct_slash_cli_action(rest: &[String]) -> Result<CliAction, String> {
+fn parse_direct_slash_cli_action(
+    rest: &[String],
+    model: String,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode: PermissionMode,
+) -> Result<CliAction, String> {
     let raw = rest.join(" ");
     match SlashCommand::parse(&raw) {
         Ok(Some(SlashCommand::Help)) => Ok(CliAction::Help),
@@ -553,6 +568,12 @@ fn parse_direct_slash_cli_action(rest: &[String]) -> Result<CliAction, String> {
             },
         }),
         Ok(Some(SlashCommand::Skills { args })) => Ok(CliAction::Skills { args }),
+        Ok(Some(SlashCommand::Review { scope })) => Ok(CliAction::CodeReview {
+            scope,
+            model,
+            allowed_tools,
+            permission_mode,
+        }),
         Ok(Some(SlashCommand::Unknown(name))) => Err(format_unknown_direct_slash_command(&name)),
         Ok(Some(command)) => Err({
             let _ = command;
@@ -672,14 +693,10 @@ fn levenshtein_distance(left: &str, right: &str) -> usize {
     previous[right_chars.len()]
 }
 
-fn resolve_model_alias(model: &str) -> &str {
-    match model {
-        "opus" => "claude-opus-4-6",
-        "sonnet" => "claude-sonnet-4-6",
-        "haiku" => "claude-haiku-4-5-20251213",
-        _ => model,
-    }
+fn resolve_model_alias(model: &str) -> String {
+    api::resolve_model_alias(model)
 }
+
 
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
     if values.is_empty() {
@@ -875,59 +892,14 @@ fn default_oauth_config() -> OAuthConfig {
 }
 
 fn run_login() -> Result<(), Box<dyn std::error::Error>> {
-    let cwd = env::current_dir()?;
-    let config = ConfigLoader::default_for(&cwd).load()?;
-    let default_oauth = default_oauth_config();
-    let oauth = config.oauth().unwrap_or(&default_oauth);
-    let callback_port = oauth.callback_port.unwrap_or(DEFAULT_OAUTH_CALLBACK_PORT);
-    let redirect_uri = runtime::loopback_redirect_uri(callback_port);
-    let pkce = generate_pkce_pair()?;
-    let state = generate_state()?;
-    let authorize_url =
-        OAuthAuthorizationRequest::from_config(oauth, redirect_uri.clone(), state.clone(), &pkce)
-            .build_url();
-
-    println!("Starting Claude OAuth login...");
-    println!("Listening for callback on {redirect_uri}");
-    if let Err(error) = open_browser(&authorize_url) {
-        eprintln!("warning: failed to open browser automatically: {error}");
-        println!("Open this URL manually:\n{authorize_url}");
-    }
-
-    let callback = wait_for_oauth_callback(callback_port)?;
-    if let Some(error) = callback.error {
-        let description =
-            callback.error_description.unwrap_or_else(|| "authorization failed".to_string());
-        return Err(io::Error::other(format!("{error}: {description}")).into());
-    }
-    let code = callback.code.ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "callback did not include code")
-    })?;
-    let returned_state = callback.state.ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "callback did not include state")
-    })?;
-    if returned_state != state {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "oauth state mismatch").into());
-    }
-
-    let client = AnthropicClient::from_auth(AuthSource::None).with_base_url(api::read_base_url());
-    let exchange_request =
-        OAuthTokenExchangeRequest::from_config(oauth, code, state, pkce.verifier, redirect_uri);
-    let runtime = tokio::runtime::Runtime::new()?;
-    let token_set = runtime.block_on(client.exchange_oauth_code(oauth, &exchange_request))?;
-    save_oauth_credentials(&runtime::OAuthTokenSet {
-        access_token: token_set.access_token,
-        refresh_token: token_set.refresh_token,
-        expires_at: token_set.expires_at,
-        scopes: token_set.scopes,
-    })?;
-    println!("Claude OAuth login complete.");
+    println!("OAuth login is not supported with the current provider setup.");
+    println!("Set DEEPSEEK_API_KEY, MIMO_API_KEY, or OPENAI_API_KEY env vars to authenticate.");
     Ok(())
 }
 
 fn run_logout() -> Result<(), Box<dyn std::error::Error>> {
     clear_oauth_credentials()?;
-    println!("Claude OAuth credentials cleared.");
+    println!("OAuth credentials cleared.");
     Ok(())
 }
 
@@ -1130,11 +1102,33 @@ fn format_unknown_slash_command_message(name: &str) -> String {
 }
 
 fn format_model_report(model: &str, message_count: usize, turns: u32) -> String {
+    let models = [
+        ("deepseek-chat", "DeepSeek Chat (主力国产)"),
+        ("deepseek-v4-pro", "DeepSeek V4 Pro"),
+        ("mimo-v2.5-pro", "MiMo V2.5 Pro (月之暗面)"),
+        ("gpt-4.1", "GPT-4.1 (ChatGPT)"),
+    ];
+
+    let current_label = "\u{25cf} current";
+    let available_label = "\u{25cb} available";
+
+    let model_list = models
+        .iter()
+        .map(|(name, desc)| {
+            let marker = if model == *name { current_label } else { available_label };
+            format!("  {name:<20} {marker:<12} {desc}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
     format!(
         "Model
   Current model    {model}
   Session messages {message_count}
   Session turns    {turns}
+
+Available models
+{model_list}
 
 Usage
   Inspect current model with /model
@@ -1653,7 +1647,7 @@ struct RuntimeMcpState {
 }
 
 struct BuiltRuntime {
-    runtime: Option<ConversationRuntime<AnthropicRuntimeClient, CliToolExecutor>>,
+    runtime: Option<ConversationRuntime<SegoRuntimeClient, CliToolExecutor>>,
     plugin_registry: PluginRegistry,
     plugins_active: bool,
     mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
@@ -1662,7 +1656,7 @@ struct BuiltRuntime {
 
 impl BuiltRuntime {
     fn new(
-        runtime: ConversationRuntime<AnthropicRuntimeClient, CliToolExecutor>,
+        runtime: ConversationRuntime<SegoRuntimeClient, CliToolExecutor>,
         plugin_registry: PluginRegistry,
         mcp_state: Option<Arc<Mutex<RuntimeMcpState>>>,
     ) -> Self {
@@ -1702,7 +1696,7 @@ impl BuiltRuntime {
 }
 
 impl Deref for BuiltRuntime {
-    type Target = ConversationRuntime<AnthropicRuntimeClient, CliToolExecutor>;
+    type Target = ConversationRuntime<SegoRuntimeClient, CliToolExecutor>;
 
     fn deref(&self) -> &Self::Target {
         self.runtime.as_ref().expect("runtime should exist while built runtime is alive")
@@ -2416,7 +2410,6 @@ impl LiveCli {
             | SlashCommand::Keybindings
             | SlashCommand::PrivacySettings
             | SlashCommand::Plan { .. }
-            | SlashCommand::Review { .. }
             | SlashCommand::Tasks { .. }
             | SlashCommand::Theme { .. }
             | SlashCommand::Voice { .. }
@@ -2435,6 +2428,10 @@ impl LiveCli {
             | SlashCommand::AddDir { .. } => {
                 eprintln!("Command registered but not yet implemented.");
                 false
+            }
+            SlashCommand::Review { scope } => {
+                self.run_review(scope.as_deref())?;
+                true
             }
             SlashCommand::Unknown(name) => {
                 eprintln!("{}", format_unknown_slash_command(&name));
@@ -2566,6 +2563,7 @@ impl LiveCli {
         println!("{}", format_model_switch_report(&previous, &model, message_count));
         Ok(true)
     }
+
 
     fn set_permissions(
         &mut self,
@@ -2952,6 +2950,28 @@ impl LiveCli {
     fn run_issue(&self, context: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
         println!("{}", format_issue_report(context));
         Ok(())
+    }
+
+    fn run_review(&mut self, scope: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+        let review_scope = ReviewScope::parse(scope)?;
+        let target = collect_review_target(&env::current_dir()?, review_scope)?;
+        if target.is_empty() {
+            print_clean_review_scope(&target);
+            return Ok(());
+        }
+
+        self.run_review_target(target)
+    }
+
+    fn run_review_target(
+        &mut self,
+        target: ReviewTarget,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let prompt = build_review_prompt(
+            &ReviewContext::new(target),
+            ReviewPromptOptions::default(),
+        );
+        self.run_turn(&prompt)
     }
 }
 
@@ -3827,6 +3847,61 @@ fn render_diff_report_for(cwd: &Path) -> Result<String, Box<dyn std::error::Erro
     Ok(format!("Diff\n\n{}", sections.join("\n\n")))
 }
 
+fn collect_review_target(
+    cwd: &Path,
+    scope: ReviewScope,
+) -> Result<ReviewTarget, Box<dyn std::error::Error>> {
+    let git_status = run_git_diff_command_in(cwd, &["status", "--short", "--branch"])?;
+    let (staged_diff, unstaged_diff) = match &scope {
+        ReviewScope::Workspace => (
+            run_git_diff_command_in(cwd, &["diff", "--cached"])?,
+            run_git_diff_command_in(cwd, &["diff"])?,
+        ),
+        ReviewScope::Staged => (
+            run_git_diff_command_in(cwd, &["diff", "--cached"])?,
+            String::new(),
+        ),
+        ReviewScope::Unstaged => (String::new(), run_git_diff_command_in(cwd, &["diff"])?),
+        ReviewScope::Path(path) => {
+            let path = path.to_string_lossy();
+            (
+                run_git_diff_command_in(cwd, &["diff", "--cached", "--", path.as_ref()])?,
+                run_git_diff_command_in(cwd, &["diff", "--", path.as_ref()])?,
+            )
+        }
+    };
+
+    Ok(ReviewTarget {
+        scope,
+        git_status,
+        staged_diff,
+        unstaged_diff,
+    })
+}
+
+fn run_code_review_cli(
+    model: String,
+    allowed_tools: Option<AllowedToolSet>,
+    permission_mode: PermissionMode,
+    scope: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let review_scope = ReviewScope::parse(scope)?;
+    let target = collect_review_target(&env::current_dir()?, review_scope)?;
+    if target.is_empty() {
+        print_clean_review_scope(&target);
+        return Ok(());
+    }
+
+    LiveCli::new(model, true, allowed_tools, permission_mode)?.run_review_target(target)
+}
+
+fn print_clean_review_scope(target: &ReviewTarget) {
+    println!(
+        "Review\n  Result           clean review scope\n  Scope            {}\n  Detail           no current changes",
+        target.scope.label()
+    );
+}
+
 fn run_git_diff_command_in(
     cwd: &Path,
     args: &[&str],
@@ -4562,7 +4637,7 @@ fn build_runtime_with_plugin_state(
         .map_err(std::io::Error::other)?;
     let mut runtime = ConversationRuntime::new_with_features(
         session,
-        AnthropicRuntimeClient::new(
+        SegoRuntimeClient::new(
             session_id,
             model,
             enable_tools,
@@ -4656,9 +4731,9 @@ impl runtime::PermissionPrompter for CliPermissionPrompter {
     }
 }
 
-struct AnthropicRuntimeClient {
+struct SegoRuntimeClient {
     runtime: tokio::runtime::Runtime,
-    client: AnthropicClient,
+    client: ProviderClient,
     model: String,
     enable_tools: bool,
     emit_output: bool,
@@ -4667,7 +4742,7 @@ struct AnthropicRuntimeClient {
     progress_reporter: Option<InternalPromptProgressReporter>,
 }
 
-impl AnthropicRuntimeClient {
+impl SegoRuntimeClient {
     fn new(
         session_id: &str,
         model: String,
@@ -4677,11 +4752,11 @@ impl AnthropicRuntimeClient {
         tool_registry: GlobalToolRegistry,
         progress_reporter: Option<InternalPromptProgressReporter>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = ProviderClient::from_model(&model)
+            .map_err(|e| Box::<dyn std::error::Error>::from(e.to_string()))?;
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
-            client: AnthropicClient::from_auth(resolve_cli_auth_source()?)
-                .with_base_url(api::read_base_url())
-                .with_prompt_cache(PromptCache::new(session_id)),
+            client: client.with_prompt_cache(api::PromptCache::new(session_id)),
             model,
             enable_tools,
             emit_output,
@@ -4692,17 +4767,7 @@ impl AnthropicRuntimeClient {
     }
 }
 
-fn resolve_cli_auth_source() -> Result<AuthSource, Box<dyn std::error::Error>> {
-    Ok(resolve_startup_auth_source(|| {
-        let cwd = env::current_dir().map_err(api::ApiError::from)?;
-        let config = ConfigLoader::default_for(&cwd).load().map_err(|error| {
-            api::ApiError::Auth(format!("failed to load runtime OAuth config: {error}"))
-        })?;
-        Ok(config.oauth().cloned())
-    })?)
-}
-
-impl ApiClient for AnthropicRuntimeClient {
+impl ApiClient for SegoRuntimeClient {
     #[allow(clippy::too_many_lines)]
     fn stream(&mut self, request: ApiRequest) -> Result<Vec<AssistantEvent>, RuntimeError> {
         if let Some(progress_reporter) = &self.progress_reporter {
@@ -4752,6 +4817,8 @@ impl ApiClient for AnthropicRuntimeClient {
             let mut markdown_stream = MarkdownStreamState::default();
             let mut events = Vec::new();
             let mut pending_tool: Option<(String, String, String)> = None;
+            let mut pending_thinking = String::new();
+            let mut pending_thinking_signature: Option<String> = None;
             let mut saw_stop = false;
 
             while let Some(event) =
@@ -4791,8 +4858,12 @@ impl ApiClient for AnthropicRuntimeClient {
                                 input.push_str(&partial_json);
                             }
                         }
-                        ContentBlockDelta::ThinkingDelta { .. }
-                        | ContentBlockDelta::SignatureDelta { .. } => {}
+                        ContentBlockDelta::ThinkingDelta { thinking } => {
+                            pending_thinking.push_str(&thinking);
+                        }
+                        ContentBlockDelta::SignatureDelta { signature } => {
+                            pending_thinking_signature = Some(signature);
+                        }
                     },
                     ApiStreamEvent::ContentBlockStop(_) => {
                         if let Some(rendered) = markdown_stream.flush(&renderer) {
@@ -4821,12 +4892,25 @@ impl ApiClient for AnthropicRuntimeClient {
                                 .and_then(|()| out.flush())
                                 .map_err(|error| RuntimeError::new(error.to_string()))?;
                         }
+                        if !pending_thinking.is_empty() {
+                            events.push(AssistantEvent::Thinking {
+                                thinking: std::mem::take(&mut pending_thinking),
+                                signature: pending_thinking_signature.take(),
+                            });
+                        }
                         events.push(AssistantEvent::MessageStop);
                     }
                 }
             }
 
             push_prompt_cache_record(&self.client, &mut events);
+
+            if !pending_thinking.is_empty() {
+                events.push(AssistantEvent::Thinking {
+                    thinking: std::mem::take(&mut pending_thinking),
+                    signature: pending_thinking_signature.take(),
+                });
+            }
 
             if !saw_stop
                 && events.iter().any(|event| {
@@ -5422,7 +5506,7 @@ fn response_to_events(
     Ok(events)
 }
 
-fn push_prompt_cache_record(client: &AnthropicClient, events: &mut Vec<AssistantEvent>) {
+fn push_prompt_cache_record(client: &ProviderClient, events: &mut Vec<AssistantEvent>) {
     if let Some(record) = client.take_last_prompt_cache_record() {
         if let Some(event) = prompt_cache_record_to_runtime_event(record) {
             events.push(AssistantEvent::PromptCache(event));
@@ -6054,10 +6138,12 @@ mod tests {
 
     #[test]
     fn resolves_known_model_aliases() {
-        assert_eq!(resolve_model_alias("opus"), "claude-opus-4-6");
-        assert_eq!(resolve_model_alias("sonnet"), "claude-sonnet-4-6");
-        assert_eq!(resolve_model_alias("haiku"), "claude-haiku-4-5-20251213");
-        assert_eq!(resolve_model_alias("claude-opus"), "claude-opus");
+        assert_eq!(resolve_model_alias("deepseek"), "deepseek-chat");
+        assert_eq!(resolve_model_alias("ds"), "deepseek-chat");
+        assert_eq!(resolve_model_alias("deepseek-pro"), "deepseek-v4-pro");
+        assert_eq!(resolve_model_alias("mimo"), "mimo-v2.5-pro");
+        assert_eq!(resolve_model_alias("gpt"), "gpt-4.1");
+        assert_eq!(resolve_model_alias("unknown-model"), "unknown-model");
     }
 
     #[test]
@@ -6175,11 +6261,12 @@ mod tests {
             CliAction::Status {
                 model: default_model(),
                 permission_mode: PermissionMode::DangerFullAccess,
+                output_format: CliOutputFormat::Text,
             }
         );
         assert_eq!(
             parse_args(&["sandbox".to_string()]).expect("sandbox should parse"),
-            CliAction::Sandbox
+            CliAction::Sandbox { output_format: CliOutputFormat::Text }
         );
     }
 
@@ -6236,10 +6323,28 @@ mod tests {
             .expect("/skills install should parse"),
             CliAction::Skills { args: Some("install ./fixtures/help-skill".to_string()) }
         );
+        assert_eq!(
+            parse_args(&["/review".to_string(), "staged".to_string()])
+                .expect("/review staged should parse"),
+            CliAction::CodeReview {
+                scope: Some("staged".to_string()),
+                model: default_model(),
+                allowed_tools: None,
+                permission_mode: PermissionMode::DangerFullAccess,
+            }
+        );
         let error = parse_args(&["/status".to_string()])
             .expect_err("/status should remain REPL-only when invoked directly");
         assert!(error.contains("interactive-only"));
         assert!(error.contains("claw --resume SESSION.jsonl /status"));
+    }
+
+    #[test]
+    fn keeps_bare_review_as_workflow_review() {
+        assert_eq!(
+            parse_args(&["review".to_string()]).expect("review should parse"),
+            CliAction::Review { last_n: None, output_format: CliOutputFormat::Text }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds the first real code-review milestone for Sego and updates the README to reflect the product direction toward an Engineering Trust Runtime for AI coding.

Sego is positioned as the trust layer between AI code generation and delivery:
- author code with Claude Code, Codex, Cursor, OpenHands, or another coding tool
- use Sego to review diffs, preserve evidence, and prepare changes for verification and shipping

## Changes

- Add runtime::code_review with review scope parsing, review target/context types, prompt contract, severity/finding/report types
- Wire /review into the CLI and REPL dispatch path
- Support direct CLI usage: sego /review, sego /review staged, sego /review unstaged, sego /review path/to/file
- Keep sego review as workflow/session review so it does not conflict with code review semantics
- Return a clean-scope result without initializing a model client when there are no changes
- Preserve DeepSeek reasoning_content across request translation, streaming deltas, and response normalization
- Update README from a pure self-learning-agent story toward the Review -> Verify -> Memory -> Ship trust-runtime roadmap

## Validation

- cargo build -p runtime: passed
- cargo build -p rusty-claude-cli: passed
- cargo test -p api --lib -- reasoning_content: 3 passed
- cargo test -p rusty-claude-cli --bins -- parses_direct/keeps_bare: 2 passed
- git diff --check: clean

## Out of Scope

- /verify
- .sego artifacts
- Memory Kernel
- Data Flow Impact Review
- /ship
- Qwen/provider registry cleanup
- IDE or GitHub App integration