### PR TITLE
feat: add /verify command with runtime verification module (cycle 2)

### DIFF
--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -382,16 +382,12 @@ impl StreamState {
         }
 
         for choice in chunk.choices {
-            if let Some(reasoning_content) = choice
-                .delta
-                .reasoning_content
-                .filter(|value| !value.is_empty())
+            if let Some(reasoning_content) =
+                choice.delta.reasoning_content.filter(|value| !value.is_empty())
             {
                 events.push(StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
                     index: 0,
-                    delta: ContentBlockDelta::ThinkingDelta {
-                        thinking: reasoning_content,
-                    },
+                    delta: ContentBlockDelta::ThinkingDelta { thinking: reasoning_content },
                 }));
             }
 
@@ -809,10 +805,7 @@ fn normalize_response(
     if let Some(reasoning_content) =
         choice.message.reasoning_content.filter(|value| !value.is_empty())
     {
-        content.push(OutputContentBlock::Thinking {
-            thinking: reasoning_content,
-            signature: None,
-        });
+        content.push(OutputContentBlock::Thinking { thinking: reasoning_content, signature: None });
     }
     if let Some(text) = choice.message.content.filter(|value| !value.is_empty()) {
         content.push(OutputContentBlock::Text { text });
@@ -972,8 +965,8 @@ impl StringExt for String {
 mod tests {
     use super::{
         build_chat_completion_request, chat_completions_endpoint, normalize_finish_reason,
-        normalize_response, openai_tool_choice, parse_tool_arguments, ChatChoice, ChatCompletionResponse,
-        ChatMessage, OpenAiCompatClient, OpenAiCompatConfig,
+        normalize_response, openai_tool_choice, parse_tool_arguments, ChatChoice,
+        ChatCompletionResponse, ChatMessage, OpenAiCompatClient, OpenAiCompatConfig,
     };
     use crate::error::ApiError;
     use crate::types::{
@@ -1083,10 +1076,7 @@ mod tests {
 
         assert_eq!(payload["messages"][0]["role"], json!("assistant"));
         assert_eq!(payload["messages"][0]["content"], json!("Final answer"));
-        assert_eq!(
-            payload["messages"][0]["reasoning_content"],
-            json!("internal reasoning")
-        );
+        assert_eq!(payload["messages"][0]["reasoning_content"], json!("internal reasoning"));
     }
 
     #[test]

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -277,6 +277,13 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: false,
     },
     SlashCommandSpec {
+        name: "verify",
+        aliases: &[],
+        summary: "Run local verification evidence commands",
+        argument_hint: Some("[auto|fast|full]"),
+        resume_supported: false,
+    },
+    SlashCommandSpec {
         name: "tasks",
         aliases: &[],
         summary: "List and manage background tasks",
@@ -1094,6 +1101,7 @@ pub enum SlashCommand {
     PrivacySettings,
     Plan { mode: Option<String> },
     Review { scope: Option<String> },
+    Verify { scope: Option<String> },
     Tasks { args: Option<String> },
     Theme { name: Option<String> },
     Voice { mode: Option<String> },
@@ -1313,6 +1321,7 @@ pub fn validate_slash_command_input(
         }
         "plan" => SlashCommand::Plan { mode: remainder },
         "review" => SlashCommand::Review { scope: remainder },
+        "verify" => SlashCommand::Verify { scope: remainder },
         "tasks" => SlashCommand::Tasks { args: remainder },
         "theme" => SlashCommand::Theme { name: remainder },
         "voice" => SlashCommand::Voice { mode: remainder },
@@ -1678,9 +1687,8 @@ fn slash_command_category(name: &str) -> &'static str {
         }
         "agents" | "skills" | "teleport" | "debug-tool-call" | "mcp" | "context" | "tasks"
         | "doctor" | "ide" | "desktop" => "Discovery & debugging",
-        "bughunter" | "ultraplan" | "review" | "security-review" | "advisor" | "insights" => {
-            "Analysis & automation"
-        }
+        "bughunter" | "ultraplan" | "review" | "verify" | "security-review" | "advisor"
+        | "insights" => "Analysis & automation",
         "theme" | "vim" | "voice" | "color" | "effort" | "fast" | "brief" | "output-style"
         | "keybindings" | "stickers" => "Appearance & input",
         "copy" | "share" | "feedback" | "summary" | "tag" | "thinkback" | "plan" | "exit"
@@ -3025,6 +3033,7 @@ pub fn handle_slash_command(
         | SlashCommand::PrivacySettings
         | SlashCommand::Plan { .. }
         | SlashCommand::Review { .. }
+        | SlashCommand::Verify { .. }
         | SlashCommand::Tasks { .. }
         | SlashCommand::Theme { .. }
         | SlashCommand::Voice { .. }
@@ -3404,7 +3413,8 @@ mod tests {
         assert!(help.contains("aliases: /plugins, /marketplace"));
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help]"));
-        assert_eq!(slash_command_specs().len(), 141);
+        assert!(help.contains("/verify [auto|fast|full]"));
+        assert_eq!(slash_command_specs().len(), 142);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/runtime/src/code_review/context.rs
+++ b/rust/crates/runtime/src/code_review/context.rs
@@ -24,10 +24,7 @@ pub struct ReviewContext {
 impl ReviewContext {
     #[must_use]
     pub fn new(target: ReviewTarget) -> Self {
-        Self {
-            target,
-            project_rules: Vec::new(),
-        }
+        Self { target, project_rules: Vec::new() }
     }
 
     #[must_use]
@@ -36,4 +33,3 @@ impl ReviewContext {
         self
     }
 }
-

--- a/rust/crates/runtime/src/code_review/mod.rs
+++ b/rust/crates/runtime/src/code_review/mod.rs
@@ -9,4 +9,3 @@ pub use prompt::{build_review_prompt, ReviewPromptOptions};
 pub use report::{ReviewFinding, ReviewReport};
 pub use scope::{ReviewScope, ReviewScopeParseError};
 pub use severity::ReviewSeverity;
-

--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -11,10 +11,7 @@ pub struct ReviewPromptOptions {
 
 impl Default for ReviewPromptOptions {
     fn default() -> Self {
-        Self {
-            max_diff_chars: DEFAULT_MAX_DIFF_CHARS,
-            max_rule_chars: DEFAULT_MAX_RULE_CHARS,
-        }
+        Self { max_diff_chars: DEFAULT_MAX_DIFF_CHARS, max_rule_chars: DEFAULT_MAX_RULE_CHARS }
     }
 }
 
@@ -38,10 +35,8 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
 
     if !context.project_rules.is_empty() {
         prompt.push("Project rules:".to_string());
-        prompt.push(truncate_for_prompt(
-            &context.project_rules.join("\n\n"),
-            options.max_rule_chars,
-        ));
+        prompt
+            .push(truncate_for_prompt(&context.project_rules.join("\n\n"), options.max_rule_chars));
         prompt.push(String::new());
     }
 
@@ -56,10 +51,7 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
         prompt.push("Diff: no current changes for this review scope.".to_string());
     } else {
         prompt.push("Diff:".to_string());
-        prompt.push(fenced(
-            "diff",
-            &truncate_for_prompt(&diff, options.max_diff_chars),
-        ));
+        prompt.push(fenced("diff", &truncate_for_prompt(&diff, options.max_diff_chars)));
     }
 
     prompt.join("\n")
@@ -70,10 +62,8 @@ fn diff_for_scope(context: &ReviewContext) -> String {
         ReviewScope::Workspace | ReviewScope::Path(_) => {
             let mut sections = Vec::new();
             if !context.target.staged_diff.trim().is_empty() {
-                sections.push(format!(
-                    "Staged changes:\n{}",
-                    context.target.staged_diff.trim_end()
-                ));
+                sections
+                    .push(format!("Staged changes:\n{}", context.target.staged_diff.trim_end()));
             }
             if !context.target.unstaged_diff.trim().is_empty() {
                 sections.push(format!(
@@ -98,9 +88,7 @@ fn truncate_for_prompt(value: &str, max_chars: usize) -> String {
     }
 
     let truncated = value.chars().take(max_chars).collect::<String>();
-    format!(
-        "{truncated}\n\n[truncated: original content exceeded {max_chars} characters]"
-    )
+    format!("{truncated}\n\n[truncated: original content exceeded {max_chars} characters]")
 }
 
 #[cfg(test)]
@@ -152,13 +140,9 @@ mod tests {
 
         let prompt = build_review_prompt(
             &context,
-            ReviewPromptOptions {
-                max_diff_chars: 12,
-                max_rule_chars: 12,
-            },
+            ReviewPromptOptions { max_diff_chars: 12, max_rule_chars: 12 },
         );
 
         assert!(prompt.contains("[truncated: original content exceeded 12 characters]"));
     }
 }
-

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -22,10 +22,6 @@ pub struct ReviewReport {
 impl ReviewReport {
     #[must_use]
     pub fn no_findings(raw_text: impl Into<String>) -> Self {
-        Self {
-            findings: Vec::new(),
-            raw_text: raw_text.into(),
-        }
+        Self { findings: Vec::new(), raw_text: raw_text.into() }
     }
 }
-

--- a/rust/crates/runtime/src/code_review/scope.rs
+++ b/rust/crates/runtime/src/code_review/scope.rs
@@ -19,9 +19,9 @@ impl ReviewScope {
             "workspace" | "all" | "." => Ok(Self::Workspace),
             "staged" | "--staged" | "cached" | "--cached" => Ok(Self::Staged),
             "unstaged" | "--unstaged" | "working" | "worktree" => Ok(Self::Unstaged),
-            value if value.starts_with('-') => Err(ReviewScopeParseError::UnsupportedFlag {
-                value: value.to_string(),
-            }),
+            value if value.starts_with('-') => {
+                Err(ReviewScopeParseError::UnsupportedFlag { value: value.to_string() })
+            }
             value => Ok(Self::Path(PathBuf::from(value))),
         }
     }
@@ -86,10 +86,7 @@ mod tests {
     fn rejects_unknown_flags() {
         assert_eq!(
             ReviewScope::parse(Some("--json")),
-            Err(ReviewScopeParseError::UnsupportedFlag {
-                value: "--json".to_string(),
-            })
+            Err(ReviewScopeParseError::UnsupportedFlag { value: "--json".to_string() })
         );
     }
 }
-

--- a/rust/crates/runtime/src/code_review/severity.rs
+++ b/rust/crates/runtime/src/code_review/severity.rs
@@ -6,4 +6,3 @@ pub enum ReviewSeverity {
     Low,
     Info,
 }
-

--- a/rust/crates/runtime/src/file_ops.rs
+++ b/rust/crates/runtime/src/file_ops.rs
@@ -671,7 +671,7 @@ mod tests {
         let outside = temp_path("symlink-target.txt");
         std::fs::write(&outside, "target content").expect("target should write");
 
-        let _link_path = workspace.join("escape-link.txt");
+        let link_path = workspace.join("escape-link.txt");
         #[cfg(unix)]
         {
             std::os::unix::fs::symlink(&outside, &link_path).expect("symlink should create");

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -45,6 +45,7 @@ pub mod task_registry;
 pub mod team_cron_registry;
 pub mod trust_resolver;
 mod usage;
+pub mod verification;
 pub mod worker_boot;
 pub mod workflow;
 
@@ -160,6 +161,10 @@ pub use task_packet::{validate_packet, TaskPacket, TaskPacketValidationError, Va
 pub use trust_resolver::{TrustConfig, TrustDecision, TrustEvent, TrustPolicy, TrustResolver};
 pub use usage::{
     format_usd, pricing_for_model, ModelPricing, TokenUsage, UsageCostEstimate, UsageTracker,
+};
+pub use verification::{
+    build_verification_plan, VerificationCommand, VerificationPlan, VerificationPlanStatus,
+    VerificationScope, VerificationScopeParseError,
 };
 pub use worker_boot::{
     Worker, WorkerEvent, WorkerEventKind, WorkerEventPayload, WorkerFailure, WorkerFailureKind,

--- a/rust/crates/runtime/src/mcp_stdio.rs
+++ b/rust/crates/runtime/src/mcp_stdio.rs
@@ -1341,7 +1341,10 @@ mod tests {
         )
         .expect("write script");
         let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
-        #[cfg(unix)] { permissions.set_mode(0o755); }
+        #[cfg(unix)]
+        {
+            permissions.set_mode(0o755);
+        }
         fs::set_permissions(&script_path, permissions).expect("chmod");
         script_path
     }
@@ -1387,7 +1390,10 @@ mod tests {
         .join("\n");
         fs::write(&script_path, script).expect("write script");
         let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
-        #[cfg(unix)] { permissions.set_mode(0o755); }
+        #[cfg(unix)]
+        {
+            permissions.set_mode(0o755);
+        }
         fs::set_permissions(&script_path, permissions).expect("chmod");
         script_path
     }
@@ -1521,7 +1527,10 @@ mod tests {
         .join("\n");
         fs::write(&script_path, script).expect("write script");
         let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
-        #[cfg(unix)] { permissions.set_mode(0o755); }
+        #[cfg(unix)]
+        {
+            permissions.set_mode(0o755);
+        }
         fs::set_permissions(&script_path, permissions).expect("chmod");
         script_path
     }
@@ -1646,7 +1655,10 @@ mod tests {
         .join("\n");
         fs::write(&script_path, script).expect("write script");
         let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
-        #[cfg(unix)] { permissions.set_mode(0o755); }
+        #[cfg(unix)]
+        {
+            permissions.set_mode(0o755);
+        }
         fs::set_permissions(&script_path, permissions).expect("chmod");
         script_path
     }

--- a/rust/crates/runtime/src/mcp_tool_bridge.rs
+++ b/rust/crates/runtime/src/mcp_tool_bridge.rs
@@ -419,7 +419,10 @@ mod tests {
         .join("\n");
         fs::write(&script_path, script).expect("write script");
         let mut permissions = fs::metadata(&script_path).expect("metadata").permissions();
-        #[cfg(unix)] { permissions.set_mode(0o755); }
+        #[cfg(unix)]
+        {
+            permissions.set_mode(0o755);
+        }
         fs::set_permissions(&script_path, permissions).expect("chmod");
         script_path
     }

--- a/rust/crates/runtime/src/verification/REVIEW.md
+++ b/rust/crates/runtime/src/verification/REVIEW.md
@@ -1,0 +1,88 @@
+# Sego Code Review — Cycle 2 `/verify` MVP
+
+**Reviewer:** Sego Agent (DeepSeek v4 Pro)
+**Date:** 2026-06-12
+**Commit:** feat(review): slash-verify-trust-phase1 / verify MVP
+
+**Reviewed files:**
+
+1. `rust/crates/runtime/src/verification/mod.rs`
+2. `rust/crates/runtime/src/verification/scope.rs`
+3. `rust/crates/runtime/src/verification/plan.rs`
+4. `rust/crates/runtime/src/lib.rs`
+5. `rust/crates/commands/src/lib.rs`
+6. `rust/crates/rusty-claude-cli/src/main.rs`
+
+**Verification baseline:**
+- `cargo test -p runtime verification` → **8 passed, 0 failed**
+- `cargo test -p rusty-claude-cli parses_direct_agents_mcp_and_skills_slash_commands` → **passed**
+- `cargo test -p commands renders_help_from_shared_specs` → **passed**
+- `cargo build -p rusty-claude-cli` → **passed**
+- `sego /verify fast` (worktree root) → **passed** (1/1 commands, exit 0)
+- `sego /verify auto` (worktree root) → **build passed**, tests failed (known pre-existing api credential test issue — not related to /verify)
+
+---
+
+## Findings（按严重度排序）
+
+### Finding 1 — `run_verification_command` 失败时返回 `Err`，触发误导性 CLI usage 提示
+
+| Field | Value |
+|---|---|
+| **Severity** | 🟡 Medium |
+| **File** | `rust/crates/rusty-claude-cli/src/main.rs` Lines 3959-3960 |
+| **Evidence** | `if failed { return Err("verification failed".into()); }` followed by `main()` 中的 `eprintln!("error: {message}\n\nRun `sego --help` for usage.")` |
+| **Risk** | 当 2+ 个命令执行后首个命令失败时，用户看到后续命令的输出仍在打印，然后突然出现 `error: verification failed` 跟着 `Run sego --help for usage.`——这是误导性的，因为错误**不是** CLI 用法错误。 |
+| **Suggestion** | 失败时不要返回 `Err`，改为 `return Ok(());` 让用户根据打印输出自行判断。当前 `Err` 会触发 `Run sego --help for usage.` 的后缀，与实际情况不符。 |
+| **Confidence** | High |
+| **Verification hint** | 在 worktree root 运行 `sego /verify auto` → 观察 `failed` 结果后的最后一行是否显示 `Run sego --help for usage.` |
+
+### Finding 2 — 输出截断可能丢失错误诊断信息
+
+| Field | Value |
+|---|---|
+| **Severity** | 🟡 Medium |
+| **File** | `rust/crates/rusty-claude-cli/src/main.rs` Lines 4024-4035 (`summarize_command_output`) |
+| **Evidence** | 对去重后的非空行取 `take(6)` 并截断到 `take(500)` 字符。对于 `cargo test` 输出，当有多个 crate 的编译警告在测试失败之前时，前 6 行 stderr 显示的是编译状态，而非测试失败的诊断信息。 |
+| **Risk** | `/verify auto` 失败时 stdout 显示类似 `running 51 tests | test client::tests::... ok | ...`——被截断的 stdout 无法让用户看到具体哪些测试失败。stderr 显示的是编译信息而非测试失败。用户无法判断验证失败的**原因**，必须手动运行 `cargo test`。 |
+| **Suggestion** | 对于 `failed` 结果，增加行数限制（例如 20 行）或显示**最后** N 行而非前 N 行。或者将完整输出打印到临时文件并提示用户：`Full output at .sego/verify-output.txt`。 |
+| **Confidence** | Medium |
+| **Verification hint** | 制造一个测试失败然后观察截断的输出是否省略了实际失败行。 |
+
+### Finding 3 — `ExePath`（`sego.exe` 路径）依赖 `env::current_exe()`
+
+| Field | Value |
+|---|---|
+| **Severity** | 🟢 Low |
+| **File** | `rust/crates/rusty-claude-cli/src/main.rs` Lines 3945-3952（通过 `println!` + `run_verification_command`） |
+| **Evidence** | N/A — 仅为观察记录 |
+| **Risk** | N/A — 无实际问题。`env::current_exe()` 用于诊断输出的路径解析——这是正确的做法。 |
+| **Suggestion** | 无需操作。路径解析完全正确。 |
+| **Confidence** | High |
+| **Verification hint** | N/A |
+
+### Finding 4 — `build_verification_plan` 的 cwd 依赖是隐式的
+
+| Field | Value |
+|---|---|
+| **Severity** | 🟢 Low |
+| **File** | `rust/crates/runtime/src/verification/plan.rs` Lines 79-91 |
+| **Evidence** | `build_verification_plan` 隐式使用 `&Path`（cwd）。如果调用者传入错误的路径，生成的 plan 也会错误。无法通过环境变量覆盖。 |
+| **Risk** | 当前唯一调用者是 `run_code_verify_cli`，它传入 `env::current_dir()`，在当前用例下是正确的。但如果将来有其他调用者（REPL、adapter 等）未传入正确的 cwd 就调用 `build_verification_plan`，可能会生成错误的 plan。 |
+| **Suggestion** | 不阻塞 MVP。后续如有需要可添加 `--cwd` 标志或支持 `SEGO_PROJECT_DIR` 环境变量覆盖。 |
+| **Confidence** | Medium |
+| **Verification hint** | N/A — 取决于未来用例。 |
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| 🔴 High | 0 |
+| 🟡 Medium | 2 |
+| 🟢 Low | 2 |
+
+**总体评价：** 代码质量高。实现干净、范围合理，遵循现有代码库的模式（slash 命令注册、re-exports、模块结构）。测试覆盖了关键路径。两个中等严重度的 findings 是可用性问题（错误消息和输出截断），而非正确性 bug。两者都不是 MVP 合并的阻断项——可以作为后续补丁处理。
+
+**推荐：** ✅ 可以合并。Findings 1 和 2 应在发布给用户之前解决，但不阻塞 PR。

--- a/rust/crates/runtime/src/verification/mod.rs
+++ b/rust/crates/runtime/src/verification/mod.rs
@@ -1,0 +1,7 @@
+mod plan;
+mod scope;
+
+pub use plan::{
+    build_verification_plan, VerificationCommand, VerificationPlan, VerificationPlanStatus,
+};
+pub use scope::{VerificationScope, VerificationScopeParseError};

--- a/rust/crates/runtime/src/verification/plan.rs
+++ b/rust/crates/runtime/src/verification/plan.rs
@@ -18,12 +18,7 @@ impl VerificationCommand {
         program: impl Into<String>,
         args: Vec<String>,
     ) -> Self {
-        Self {
-            label: label.into(),
-            working_dir: working_dir.into(),
-            program: program.into(),
-            args,
-        }
+        Self { label: label.into(), working_dir: working_dir.into(), program: program.into(), args }
     }
 
     #[must_use]
@@ -51,20 +46,14 @@ pub struct VerificationPlan {
 impl VerificationPlan {
     #[must_use]
     pub fn ready(scope: VerificationScope, commands: Vec<VerificationCommand>) -> Self {
-        Self {
-            scope,
-            status: VerificationPlanStatus::Ready,
-            commands,
-        }
+        Self { scope, status: VerificationPlanStatus::Ready, commands }
     }
 
     #[must_use]
     pub fn no_plan(scope: VerificationScope, reason: impl Into<String>) -> Self {
         Self {
             scope,
-            status: VerificationPlanStatus::NoPlan {
-                reason: reason.into(),
-            },
+            status: VerificationPlanStatus::NoPlan { reason: reason.into() },
             commands: Vec::new(),
         }
     }

--- a/rust/crates/runtime/src/verification/plan.rs
+++ b/rust/crates/runtime/src/verification/plan.rs
@@ -1,0 +1,263 @@
+use std::path::Path;
+
+use super::VerificationScope;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationCommand {
+    pub label: String,
+    pub working_dir: String,
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl VerificationCommand {
+    #[must_use]
+    pub fn new(
+        label: impl Into<String>,
+        working_dir: impl Into<String>,
+        program: impl Into<String>,
+        args: Vec<String>,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            working_dir: working_dir.into(),
+            program: program.into(),
+            args,
+        }
+    }
+
+    #[must_use]
+    pub fn display_command(&self) -> String {
+        std::iter::once(self.program.as_str())
+            .chain(self.args.iter().map(String::as_str))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationPlanStatus {
+    Ready,
+    NoPlan { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationPlan {
+    pub scope: VerificationScope,
+    pub status: VerificationPlanStatus,
+    pub commands: Vec<VerificationCommand>,
+}
+
+impl VerificationPlan {
+    #[must_use]
+    pub fn ready(scope: VerificationScope, commands: Vec<VerificationCommand>) -> Self {
+        Self {
+            scope,
+            status: VerificationPlanStatus::Ready,
+            commands,
+        }
+    }
+
+    #[must_use]
+    pub fn no_plan(scope: VerificationScope, reason: impl Into<String>) -> Self {
+        Self {
+            scope,
+            status: VerificationPlanStatus::NoPlan {
+                reason: reason.into(),
+            },
+            commands: Vec::new(),
+        }
+    }
+}
+
+#[must_use]
+pub fn build_verification_plan(cwd: &Path, scope: VerificationScope) -> VerificationPlan {
+    if cwd.join("Cargo.toml").is_file() {
+        return build_rust_plan(scope, ".");
+    }
+
+    if cwd.join("rust").join("Cargo.toml").is_file() {
+        return build_rust_plan(scope, "rust");
+    }
+
+    if cwd.join("package.json").is_file() {
+        return build_node_plan(cwd, scope, ".");
+    }
+
+    VerificationPlan::no_plan(
+        scope,
+        "no supported project manifest found (expected Cargo.toml or package.json)",
+    )
+}
+
+fn build_rust_plan(scope: VerificationScope, working_dir: &str) -> VerificationPlan {
+    let mut commands = Vec::new();
+    match scope {
+        VerificationScope::Fast => {
+            commands.push(VerificationCommand::new(
+                "rust build",
+                working_dir,
+                "cargo",
+                vec!["build".to_string()],
+            ));
+        }
+        VerificationScope::Auto | VerificationScope::Full => {
+            commands.push(VerificationCommand::new(
+                "rust build",
+                working_dir,
+                "cargo",
+                vec!["build".to_string()],
+            ));
+            commands.push(VerificationCommand::new(
+                "rust tests",
+                working_dir,
+                "cargo",
+                vec!["test".to_string()],
+            ));
+        }
+    }
+    VerificationPlan::ready(scope, commands)
+}
+
+fn build_node_plan(cwd: &Path, scope: VerificationScope, working_dir: &str) -> VerificationPlan {
+    let package_json = std::fs::read_to_string(cwd.join("package.json")).unwrap_or_default();
+    let has_test = package_json.contains("\"test\"");
+    let has_build = package_json.contains("\"build\"");
+    let package_manager = if cwd.join("pnpm-lock.yaml").is_file() {
+        "pnpm"
+    } else if cwd.join("yarn.lock").is_file() {
+        "yarn"
+    } else {
+        "npm"
+    };
+
+    let mut commands = Vec::new();
+    if has_test {
+        commands.push(node_command(package_manager, "node tests", working_dir, "test"));
+    }
+    if matches!(scope, VerificationScope::Auto | VerificationScope::Full) && has_build {
+        commands.push(node_command(package_manager, "node build", working_dir, "build"));
+    }
+
+    if commands.is_empty() {
+        return VerificationPlan::no_plan(
+            scope,
+            "package.json found but no test/build scripts were detected",
+        );
+    }
+
+    VerificationPlan::ready(scope, commands)
+}
+
+fn node_command(
+    package_manager: &str,
+    label: &str,
+    working_dir: &str,
+    script: &str,
+) -> VerificationCommand {
+    match package_manager {
+        "pnpm" => VerificationCommand::new(label, working_dir, "pnpm", vec![script.to_string()]),
+        "yarn" => VerificationCommand::new(label, working_dir, "yarn", vec![script.to_string()]),
+        _ => VerificationCommand::new(
+            label,
+            working_dir,
+            "npm",
+            vec!["run".to_string(), script.to_string()],
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_verification_plan, VerificationPlanStatus};
+    use crate::VerificationScope;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn rust_auto_plan_runs_build_and_tests() {
+        let cwd = temp_dir("verify-rust");
+        fs::write(cwd.join("Cargo.toml"), "[package]\nname='demo'\n").expect("write manifest");
+
+        let plan = build_verification_plan(&cwd, VerificationScope::Auto);
+
+        assert_eq!(plan.status, VerificationPlanStatus::Ready);
+        assert_eq!(plan.commands.len(), 2);
+        assert_eq!(plan.commands[0].working_dir, ".");
+        assert_eq!(plan.commands[0].display_command(), "cargo build");
+        assert_eq!(plan.commands[1].display_command(), "cargo test");
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn node_fast_plan_runs_tests_only() {
+        let cwd = temp_dir("verify-node");
+        fs::write(
+            cwd.join("package.json"),
+            r#"{"scripts":{"test":"vitest","build":"vite build"}}"#,
+        )
+        .expect("write package json");
+
+        let plan = build_verification_plan(&cwd, VerificationScope::Fast);
+
+        assert_eq!(plan.status, VerificationPlanStatus::Ready);
+        assert_eq!(plan.commands.len(), 1);
+        assert_eq!(plan.commands[0].display_command(), "npm run test");
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn detects_nested_rust_workspace() {
+        let cwd = temp_dir("verify-rust-root");
+        fs::create_dir_all(cwd.join("rust")).expect("create rust dir");
+        fs::write(cwd.join("rust").join("Cargo.toml"), "[workspace]\n").expect("write manifest");
+
+        let plan = build_verification_plan(&cwd, VerificationScope::Fast);
+
+        assert_eq!(plan.status, VerificationPlanStatus::Ready);
+        assert_eq!(plan.commands[0].working_dir, "rust");
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn rust_fast_plan_runs_build_only() {
+        let cwd = temp_dir("verify-rust-fast");
+        fs::write(cwd.join("Cargo.toml"), "[package]\nname='demo'\n").expect("write manifest");
+
+        let plan = build_verification_plan(&cwd, VerificationScope::Fast);
+
+        assert_eq!(plan.status, VerificationPlanStatus::Ready);
+        assert_eq!(plan.commands.len(), 1);
+        assert_eq!(plan.commands[0].display_command(), "cargo build");
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    #[test]
+    fn no_manifest_returns_no_plan() {
+        let cwd = temp_dir("verify-empty");
+
+        let plan = build_verification_plan(&cwd, VerificationScope::Auto);
+
+        assert!(matches!(plan.status, VerificationPlanStatus::NoPlan { .. }));
+
+        let _ = fs::remove_dir_all(cwd);
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "sego-{name}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock should be after epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+}

--- a/rust/crates/runtime/src/verification/scope.rs
+++ b/rust/crates/runtime/src/verification/scope.rs
@@ -17,12 +17,10 @@ impl VerificationScope {
             "auto" | "default" => Ok(Self::Auto),
             "fast" | "quick" | "targeted" => Ok(Self::Fast),
             "full" | "workspace" | "all" => Ok(Self::Full),
-            value if value.starts_with('-') => Err(VerificationScopeParseError::UnsupportedFlag {
-                value: value.to_string(),
-            }),
-            value => Err(VerificationScopeParseError::UnknownScope {
-                value: value.to_string(),
-            }),
+            value if value.starts_with('-') => {
+                Err(VerificationScopeParseError::UnsupportedFlag { value: value.to_string() })
+            }
+            value => Err(VerificationScopeParseError::UnknownScope { value: value.to_string() }),
         }
     }
 
@@ -49,10 +47,9 @@ impl fmt::Display for VerificationScopeParseError {
                 formatter,
                 "unsupported /verify scope flag `{value}` (expected auto, fast, or full)"
             ),
-            Self::UnknownScope { value } => write!(
-                formatter,
-                "unknown /verify scope `{value}` (expected auto, fast, or full)"
-            ),
+            Self::UnknownScope { value } => {
+                write!(formatter, "unknown /verify scope `{value}` (expected auto, fast, or full)")
+            }
         }
     }
 }
@@ -80,15 +77,11 @@ mod tests {
     fn rejects_unknown_scopes_and_flags() {
         assert_eq!(
             VerificationScope::parse(Some("src/lib.rs")),
-            Err(VerificationScopeParseError::UnknownScope {
-                value: "src/lib.rs".to_string(),
-            })
+            Err(VerificationScopeParseError::UnknownScope { value: "src/lib.rs".to_string() })
         );
         assert_eq!(
             VerificationScope::parse(Some("--json")),
-            Err(VerificationScopeParseError::UnsupportedFlag {
-                value: "--json".to_string(),
-            })
+            Err(VerificationScopeParseError::UnsupportedFlag { value: "--json".to_string() })
         );
     }
 }

--- a/rust/crates/runtime/src/verification/scope.rs
+++ b/rust/crates/runtime/src/verification/scope.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerificationScope {
+    Auto,
+    Fast,
+    Full,
+}
+
+impl VerificationScope {
+    pub fn parse(input: Option<&str>) -> Result<Self, VerificationScopeParseError> {
+        let Some(raw) = input.map(str::trim).filter(|value| !value.is_empty()) else {
+            return Ok(Self::Auto);
+        };
+
+        match raw {
+            "auto" | "default" => Ok(Self::Auto),
+            "fast" | "quick" | "targeted" => Ok(Self::Fast),
+            "full" | "workspace" | "all" => Ok(Self::Full),
+            value if value.starts_with('-') => Err(VerificationScopeParseError::UnsupportedFlag {
+                value: value.to_string(),
+            }),
+            value => Err(VerificationScopeParseError::UnknownScope {
+                value: value.to_string(),
+            }),
+        }
+    }
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Fast => "fast",
+            Self::Full => "full",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerificationScopeParseError {
+    UnsupportedFlag { value: String },
+    UnknownScope { value: String },
+}
+
+impl fmt::Display for VerificationScopeParseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedFlag { value } => write!(
+                formatter,
+                "unsupported /verify scope flag `{value}` (expected auto, fast, or full)"
+            ),
+            Self::UnknownScope { value } => write!(
+                formatter,
+                "unknown /verify scope `{value}` (expected auto, fast, or full)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for VerificationScopeParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{VerificationScope, VerificationScopeParseError};
+
+    #[test]
+    fn parses_empty_scope_as_auto() {
+        assert_eq!(VerificationScope::parse(None), Ok(VerificationScope::Auto));
+        assert_eq!(VerificationScope::parse(Some("  ")), Ok(VerificationScope::Auto));
+    }
+
+    #[test]
+    fn parses_named_scopes() {
+        assert_eq!(VerificationScope::parse(Some("auto")), Ok(VerificationScope::Auto));
+        assert_eq!(VerificationScope::parse(Some("quick")), Ok(VerificationScope::Fast));
+        assert_eq!(VerificationScope::parse(Some("workspace")), Ok(VerificationScope::Full));
+    }
+
+    #[test]
+    fn rejects_unknown_scopes_and_flags() {
+        assert_eq!(
+            VerificationScope::parse(Some("src/lib.rs")),
+            Err(VerificationScopeParseError::UnknownScope {
+                value: "src/lib.rs".to_string(),
+            })
+        );
+        assert_eq!(
+            VerificationScope::parse(Some("--json")),
+            Err(VerificationScopeParseError::UnsupportedFlag {
+                value: "--json".to_string(),
+            })
+        );
+    }
+}

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -55,6 +55,7 @@ use runtime::{
     OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, Phase, PhaseLogEntry, PhaseStatus,
     ProgressUI, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, ReviewStatus,
     RuntimeError, Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
+    VerificationCommand, VerificationPlanStatus, VerificationScope, build_verification_plan,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -168,7 +169,7 @@ type AllowedToolSet = BTreeSet<String>;
 fn main() {
     if let Err(error) = run() {
         let message = error.to_string();
-        if message.contains("`sego --help`") {
+        if message.contains("`sego --help`") || message == "verification failed" {
             eprintln!("error: {message}");
         } else {
             eprintln!(
@@ -205,6 +206,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::CodeReview { scope, model, allowed_tools, permission_mode } => {
             run_code_review_cli(model, allowed_tools, permission_mode, scope.as_deref())?
         }
+        CliAction::CodeVerify { scope } => run_code_verify_cli(scope.as_deref())?,
         CliAction::Login => run_login()?,
         CliAction::Logout => run_logout()?,
         CliAction::Init => run_init()?,
@@ -266,6 +268,9 @@ enum CliAction {
         model: String,
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
+    },
+    CodeVerify {
+        scope: Option<String>,
     },
     Login,
     Logout,
@@ -574,6 +579,7 @@ fn parse_direct_slash_cli_action(
             allowed_tools,
             permission_mode,
         }),
+        Ok(Some(SlashCommand::Verify { scope })) => Ok(CliAction::CodeVerify { scope }),
         Ok(Some(SlashCommand::Unknown(name))) => Err(format_unknown_direct_slash_command(&name)),
         Ok(Some(command)) => Err({
             let _ = command;
@@ -1545,6 +1551,7 @@ fn run_resume_command(
         | SlashCommand::PrivacySettings
         | SlashCommand::Plan { .. }
         | SlashCommand::Review { .. }
+        | SlashCommand::Verify { .. }
         | SlashCommand::Tasks { .. }
         | SlashCommand::Theme { .. }
         | SlashCommand::Voice { .. }
@@ -2443,6 +2450,10 @@ impl LiveCli {
             }
             SlashCommand::Review { scope } => {
                 self.run_review(scope.as_deref())?;
+                true
+            }
+            SlashCommand::Verify { scope } => {
+                run_code_verify_cli(scope.as_deref())?;
                 true
             }
             SlashCommand::Unknown(name) => {
@@ -3911,6 +3922,148 @@ fn print_clean_review_scope(target: &ReviewTarget) {
         "Review\n  Result           clean review scope\n  Scope            {}\n  Detail           no current changes",
         target.scope.label()
     );
+}
+
+fn run_code_verify_cli(scope: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let scope = VerificationScope::parse(scope)?;
+    let cwd = env::current_dir()?;
+    let plan = build_verification_plan(&cwd, scope);
+
+    println!("Verify");
+    println!("  Scope            {}", scope.label());
+    match &plan.status {
+        VerificationPlanStatus::NoPlan { reason } => {
+            println!("  Result           no verification plan");
+            println!("  Reason           {reason}");
+            return Ok(());
+        }
+        VerificationPlanStatus::Ready => {
+            println!("  Plan             {} command(s)", plan.commands.len());
+        }
+    }
+
+    let mut failed = false;
+    for command in &plan.commands {
+        let result = run_verification_command(&cwd, command)?;
+        if !result.success {
+            failed = true;
+        }
+        print_verification_result(&result);
+    }
+
+    println!(
+        "  Result           {}",
+        if failed { "failed" } else { "passed" }
+    );
+
+    if failed {
+        return Err("verification failed".into());
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct VerificationCommandResult {
+    label: String,
+    command: String,
+    working_dir: String,
+    exit_code: Option<i32>,
+    success: bool,
+    duration: Duration,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_verification_command(
+    cwd: &Path,
+    command: &VerificationCommand,
+) -> Result<VerificationCommandResult, Box<dyn std::error::Error>> {
+    let started_at = Instant::now();
+    let working_dir = if command.working_dir == "." {
+        cwd.to_path_buf()
+    } else {
+        cwd.join(&command.working_dir)
+    };
+    let output = std::process::Command::new(&command.program)
+        .args(&command.args)
+        .current_dir(&working_dir)
+        .output()?;
+
+    Ok(VerificationCommandResult {
+        label: command.label.clone(),
+        command: command.display_command(),
+        working_dir: command.working_dir.clone(),
+        exit_code: output.status.code(),
+        success: output.status.success(),
+        duration: started_at.elapsed(),
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+    })
+}
+
+fn print_verification_result(result: &VerificationCommandResult) {
+    println!();
+    println!("  Command          {}", result.label);
+    println!("  Run              {}", result.command);
+    println!("  Working dir      {}", result.working_dir);
+    println!("  Exit             {}", result.exit_code.map_or_else(|| "signal".to_string(), |code| code.to_string()));
+    println!("  Duration         {}ms", result.duration.as_millis());
+    println!(
+        "  Status           {}",
+        if result.success { "passed" } else { "failed" }
+    );
+    let stdout = summarize_command_output(&result.stdout, result.success);
+    if !stdout.is_empty() {
+        println!("  Stdout           {stdout}");
+    }
+    let stderr = summarize_command_output(&result.stderr, result.success);
+    if !stderr.is_empty() {
+        println!("  Stderr           {stderr}");
+    }
+}
+
+fn summarize_command_output(value: &str, success: bool) -> String {
+    let lines = value
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+
+    let compact = if success {
+        lines.iter().take(6).copied().collect::<Vec<_>>().join(" | ")
+    } else {
+        let mut selected = Vec::new();
+        for line in lines.iter().filter(|line| is_diagnostic_output_line(line)).take(12) {
+            selected.push(*line);
+        }
+        let tail_start = lines.len().saturating_sub(12);
+        for line in &lines[tail_start..] {
+            if !selected.contains(line) {
+                selected.push(*line);
+            }
+        }
+        selected.join(" | ")
+    };
+
+    let max_chars = if success { 500 } else { 1_200 };
+    if compact.chars().count() <= max_chars {
+        compact
+    } else {
+        format!("{}...", compact.chars().take(max_chars).collect::<String>())
+    }
+}
+
+fn is_diagnostic_output_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("failures:")
+        || lower.contains("failed")
+        || lower.contains("panicked")
+        || lower.contains("assertion failed")
+        || lower.contains("error:")
+        || lower.contains("test result: failed")
+        || lower.starts_with("---- ")
+        || lower.starts_with("thread '")
 }
 
 fn run_git_diff_command_in(
@@ -6385,6 +6538,13 @@ mod tests {
                 model: default_model(),
                 allowed_tools: None,
                 permission_mode: PermissionMode::DangerFullAccess,
+            }
+        );
+        assert_eq!(
+            parse_args(&["/verify".to_string(), "fast".to_string()])
+                .expect("/verify fast should parse"),
+            CliAction::CodeVerify {
+                scope: Some("fast".to_string()),
             }
         );
         let error = parse_args(&["/status".to_string()])

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -24,9 +24,8 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, UNIX_EPOCH};
 
 use api::{
-    detect_provider_kind, ProviderClient, ProviderKind,
-    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OutputContentBlock,
+    detect_provider_kind, ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, ProviderClient, ProviderKind,
     StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
@@ -40,7 +39,7 @@ use init::initialize_repo;
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    clear_oauth_credentials,
+    build_review_prompt, build_verification_plan, clear_oauth_credentials,
     community_learning::CommunityLearning,
     evaluate, format_usd, generate_pkce_pair, generate_state,
     green_contract::GreenLevel,
@@ -48,14 +47,14 @@ use runtime::{
     resolve_sandbox_status, save_oauth_credentials,
     workflow::{SessionReport, WorkflowSnapshot, WorkflowStore},
     ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
-    build_review_prompt, ContentBlock, ConversationMessage, ConversationRuntime, DiffScope,
-    LaneBlocker, LaneContext, LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus,
-    LaneFailureClass, ReviewContext, ReviewPromptOptions, ReviewScope, ReviewTarget,
+    ContentBlock, ConversationMessage, ConversationRuntime, DiffScope, LaneBlocker, LaneContext,
+    LaneEvent, LaneEventBlocker, LaneEventName, LaneEventStatus, LaneFailureClass,
     McpServerManager, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest, OAuthConfig,
     OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, Phase, PhaseLogEntry, PhaseStatus,
-    ProgressUI, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, ReviewStatus,
-    RuntimeError, Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
-    VerificationCommand, VerificationPlanStatus, VerificationScope, build_verification_plan,
+    ProgressUI, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, ReviewContext,
+    ReviewPromptOptions, ReviewScope, ReviewStatus, ReviewTarget, RuntimeError, Session,
+    TokenUsage, ToolError, ToolExecutor, UsageTracker, VerificationCommand, VerificationPlanStatus,
+    VerificationScope,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -573,12 +572,9 @@ fn parse_direct_slash_cli_action(
             },
         }),
         Ok(Some(SlashCommand::Skills { args })) => Ok(CliAction::Skills { args }),
-        Ok(Some(SlashCommand::Review { scope })) => Ok(CliAction::CodeReview {
-            scope,
-            model,
-            allowed_tools,
-            permission_mode,
-        }),
+        Ok(Some(SlashCommand::Review { scope })) => {
+            Ok(CliAction::CodeReview { scope, model, allowed_tools, permission_mode })
+        }
         Ok(Some(SlashCommand::Verify { scope })) => Ok(CliAction::CodeVerify { scope }),
         Ok(Some(SlashCommand::Unknown(name))) => Err(format_unknown_direct_slash_command(&name)),
         Ok(Some(command)) => Err({
@@ -702,7 +698,6 @@ fn levenshtein_distance(left: &str, right: &str) -> usize {
 fn resolve_model_alias(model: &str) -> String {
     api::resolve_model_alias(model)
 }
-
 
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
     if values.is_empty() {
@@ -2587,7 +2582,6 @@ impl LiveCli {
         Ok(true)
     }
 
-
     fn set_permissions(
         &mut self,
         mode: Option<String>,
@@ -2990,10 +2984,8 @@ impl LiveCli {
         &mut self,
         target: ReviewTarget,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let prompt = build_review_prompt(
-            &ReviewContext::new(target),
-            ReviewPromptOptions::default(),
-        );
+        let prompt =
+            build_review_prompt(&ReviewContext::new(target), ReviewPromptOptions::default());
         self.run_turn(&prompt)
     }
 }
@@ -3879,10 +3871,9 @@ fn collect_review_target(
             run_git_diff_command_in(cwd, &["diff", "--cached"])?,
             run_git_diff_command_in(cwd, &["diff"])?,
         ),
-        ReviewScope::Staged => (
-            run_git_diff_command_in(cwd, &["diff", "--cached"])?,
-            String::new(),
-        ),
+        ReviewScope::Staged => {
+            (run_git_diff_command_in(cwd, &["diff", "--cached"])?, String::new())
+        }
         ReviewScope::Unstaged => (String::new(), run_git_diff_command_in(cwd, &["diff"])?),
         ReviewScope::Path(path) => {
             let path = path.to_string_lossy();
@@ -3893,12 +3884,7 @@ fn collect_review_target(
         }
     };
 
-    Ok(ReviewTarget {
-        scope,
-        git_status,
-        staged_diff,
-        unstaged_diff,
-    })
+    Ok(ReviewTarget { scope, git_status, staged_diff, unstaged_diff })
 }
 
 fn run_code_review_cli(
@@ -3951,10 +3937,7 @@ fn run_code_verify_cli(scope: Option<&str>) -> Result<(), Box<dyn std::error::Er
         print_verification_result(&result);
     }
 
-    println!(
-        "  Result           {}",
-        if failed { "failed" } else { "passed" }
-    );
+    println!("  Result           {}", if failed { "failed" } else { "passed" });
 
     if failed {
         return Err("verification failed".into());
@@ -3980,11 +3963,8 @@ fn run_verification_command(
     command: &VerificationCommand,
 ) -> Result<VerificationCommandResult, Box<dyn std::error::Error>> {
     let started_at = Instant::now();
-    let working_dir = if command.working_dir == "." {
-        cwd.to_path_buf()
-    } else {
-        cwd.join(&command.working_dir)
-    };
+    let working_dir =
+        if command.working_dir == "." { cwd.to_path_buf() } else { cwd.join(&command.working_dir) };
     let output = std::process::Command::new(&command.program)
         .args(&command.args)
         .current_dir(&working_dir)
@@ -4007,12 +3987,12 @@ fn print_verification_result(result: &VerificationCommandResult) {
     println!("  Command          {}", result.label);
     println!("  Run              {}", result.command);
     println!("  Working dir      {}", result.working_dir);
-    println!("  Exit             {}", result.exit_code.map_or_else(|| "signal".to_string(), |code| code.to_string()));
-    println!("  Duration         {}ms", result.duration.as_millis());
     println!(
-        "  Status           {}",
-        if result.success { "passed" } else { "failed" }
+        "  Exit             {}",
+        result.exit_code.map_or_else(|| "signal".to_string(), |code| code.to_string())
     );
+    println!("  Duration         {}ms", result.duration.as_millis());
+    println!("  Status           {}", if result.success { "passed" } else { "failed" });
     let stdout = summarize_command_output(&result.stdout, result.success);
     if !stdout.is_empty() {
         println!("  Stdout           {stdout}");
@@ -4024,11 +4004,7 @@ fn print_verification_result(result: &VerificationCommandResult) {
 }
 
 fn summarize_command_output(value: &str, success: bool) -> String {
-    let lines = value
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>();
+    let lines = value.lines().map(str::trim).filter(|line| !line.is_empty()).collect::<Vec<_>>();
 
     let compact = if success {
         lines.iter().take(6).copied().collect::<Vec<_>>().join(" | ")
@@ -6543,9 +6519,7 @@ mod tests {
         assert_eq!(
             parse_args(&["/verify".to_string(), "fast".to_string()])
                 .expect("/verify fast should parse"),
-            CliAction::CodeVerify {
-                scope: Some("fast".to_string()),
-            }
+            CliAction::CodeVerify { scope: Some("fast".to_string()) }
         );
         let error = parse_args(&["/status".to_string()])
             .expect_err("/status should remain REPL-only when invoked directly");

--- a/rust/crates/rusty-claude-cli/tests/mock_parity_harness.rs
+++ b/rust/crates/rusty-claude-cli/tests/mock_parity_harness.rs
@@ -1,7 +1,8 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-#[cfg(unix)] use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -386,7 +387,10 @@ fn prepare_plugin_fixture(workspace: &HarnessWorkspace) {
     )
     .expect("plugin script should write");
     let mut permissions = fs::metadata(&script_path).expect("plugin script metadata").permissions();
-    #[cfg(unix)] { permissions.set_mode(0o755); }
+    #[cfg(unix)]
+    {
+        permissions.set_mode(0o755);
+    }
     fs::set_permissions(&script_path, permissions).expect("plugin script should be executable");
 
     fs::write(

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -5345,7 +5345,8 @@ mod tests {
         let mut events = Vec::new();
         let mut pending_tools = BTreeMap::new();
 
-        let mut pending_thinking: std::collections::BTreeMap<u32, (String, Option<String>)> = std::collections::BTreeMap::new();
+        let mut pending_thinking: std::collections::BTreeMap<u32, (String, Option<String>)> =
+            std::collections::BTreeMap::new();
         push_output_block(
             OutputContentBlock::ToolUse {
                 id: "tool-1".to_string(),


### PR DESCRIPTION
## Summary

Adds a new \/verify\ slash command and \untime::verification\ module for structured local code verification (build + test checks).

## Changes

### New \untime::verification\ module
- \mod.rs\: Re-exports public types
- \scope.rs\: \VerificationScope\ enum (Auto/Fast/Full) with parser + 3 tests
- \plan.rs\: \uild_verification_plan()\ detecting Rust/Node projects, scope-based command generation + 5 tests

### \commands\ crate
- \/verify [auto|fast|full]\ slash command registration
- \Verify\ variant in \SlashCommand\ enum
- Command classification routing

### \usty-claude-cli\
- \un_code_verify_cli()\ entry point
- \CliAction::CodeVerify\ variant
- Direct slash and REPL dispatch
- Formatted output with stdout/stderr summarization

## Validation
- \cargo check\: **passed** (0 errors, 0 warnings)
- \cargo test -p commands\: **26 passed, 0 failed**
- \cargo test -p runtime -- verification::\: **8 passed, 0 failed**
- \cargo test -p rusty-claude-cli\: 14 pre-existing failures (identical before/after, zero regression)