### PR TITLE
feat: persist review reports

### DIFF
--- a/rust/crates/runtime/src/code_review/mod.rs
+++ b/rust/crates/runtime/src/code_review/mod.rs
@@ -6,6 +6,8 @@ mod severity;
 
 pub use context::{ReviewContext, ReviewTarget};
 pub use prompt::{build_review_prompt, ReviewPromptOptions};
-pub use report::{ReviewFinding, ReviewReport};
+pub use report::{
+    persist_review_artifact, review_diff_hash, PersistedReviewArtifact, ReviewFinding, ReviewReport,
+};
 pub use scope::{ReviewScope, ReviewScopeParseError};
 pub use severity::ReviewSeverity;

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -1,6 +1,14 @@
-use super::ReviewSeverity;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-#[derive(Debug, Clone, PartialEq)]
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::{ReviewSeverity, ReviewTarget};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewFinding {
     pub severity: ReviewSeverity,
     pub file: String,
@@ -13,7 +21,7 @@ pub struct ReviewFinding {
     pub verification_hint: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewReport {
     pub findings: Vec<ReviewFinding>,
     pub raw_text: String,
@@ -23,5 +31,156 @@ impl ReviewReport {
     #[must_use]
     pub fn no_findings(raw_text: impl Into<String>) -> Self {
         Self { findings: Vec::new(), raw_text: raw_text.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedReviewArtifact {
+    pub id: String,
+    pub diff_hash: String,
+    pub json_path: PathBuf,
+    pub markdown_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct ReviewArtifact {
+    schema_version: u32,
+    id: String,
+    created_at_epoch_seconds: u64,
+    scope: String,
+    diff_hash: String,
+    finding_count: usize,
+    git_status: String,
+    raw_text: String,
+}
+
+pub fn persist_review_artifact(
+    workspace_root: &Path,
+    target: &ReviewTarget,
+    report: &ReviewReport,
+) -> std::io::Result<PersistedReviewArtifact> {
+    let reviews_dir = workspace_root.join(".sego").join("reviews");
+    fs::create_dir_all(&reviews_dir)?;
+
+    let diff_hash = review_diff_hash(target);
+    let created_at_epoch_seconds = current_epoch_seconds();
+    let id = format!("review-{created_at_epoch_seconds}-{}", short_hash(&diff_hash));
+
+    let artifact = ReviewArtifact {
+        schema_version: 1,
+        id: id.clone(),
+        created_at_epoch_seconds,
+        scope: target.scope.label().clone(),
+        diff_hash: diff_hash.clone(),
+        finding_count: report.findings.len(),
+        git_status: target.git_status.clone(),
+        raw_text: report.raw_text.clone(),
+    };
+
+    let json_path = reviews_dir.join(format!("{id}.json"));
+    let markdown_path = reviews_dir.join(format!("{id}.md"));
+
+    fs::write(&json_path, serde_json::to_string_pretty(&artifact)? + "\n")?;
+    fs::write(&markdown_path, render_review_markdown(&artifact, report))?;
+
+    Ok(PersistedReviewArtifact { id, diff_hash, json_path, markdown_path })
+}
+
+#[must_use]
+pub fn review_diff_hash(target: &ReviewTarget) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(target.scope.label().as_bytes());
+    hasher.update(b"\n---staged---\n");
+    hasher.update(target.staged_diff.as_bytes());
+    hasher.update(b"\n---unstaged---\n");
+    hasher.update(target.unstaged_diff.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn render_review_markdown(artifact: &ReviewArtifact, report: &ReviewReport) -> String {
+    let mut output = String::new();
+    output.push_str("# Sego Review Report\n\n");
+    let _ = writeln!(output, "- ID: `{}`", artifact.id);
+    let _ = writeln!(output, "- Scope: `{}`", artifact.scope);
+    let _ = writeln!(output, "- Diff hash: `{}`", artifact.diff_hash);
+    let _ = writeln!(output, "- Findings: `{}`", artifact.finding_count);
+    let _ =
+        writeln!(output, "- Created at epoch seconds: `{}`\n", artifact.created_at_epoch_seconds);
+
+    if report.raw_text.trim().is_empty() {
+        output.push_str("## Review Output\n\nNo review output captured.\n");
+    } else {
+        output.push_str("## Review Output\n\n");
+        output.push_str(report.raw_text.trim());
+        output.push('\n');
+    }
+
+    if !artifact.git_status.trim().is_empty() {
+        output.push_str("\n## Git Status\n\n```text\n");
+        output.push_str(artifact.git_status.trim());
+        output.push_str("\n```\n");
+    }
+
+    output
+}
+
+fn current_epoch_seconds() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+fn short_hash(hash: &str) -> &str {
+    hash.get(..12).unwrap_or(hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{persist_review_artifact, review_diff_hash, ReviewReport};
+    use crate::code_review::{ReviewScope, ReviewTarget};
+
+    #[test]
+    fn diff_hash_changes_with_diff_content() {
+        let base = target_with_diff("diff --git a/a b/a\n");
+        let changed = target_with_diff("diff --git a/b b/b\n");
+
+        assert_ne!(review_diff_hash(&base), review_diff_hash(&changed));
+        assert_eq!(
+            review_diff_hash(&base),
+            review_diff_hash(&target_with_diff("diff --git a/a b/a\n"))
+        );
+    }
+
+    #[test]
+    fn persists_json_and_markdown_artifacts() {
+        let root = temp_path("review-artifact");
+        let target = target_with_diff("diff --git a/src/lib.rs b/src/lib.rs\n");
+        let report = ReviewReport::no_findings("No findings.");
+
+        let artifact =
+            persist_review_artifact(&root, &target, &report).expect("artifact should persist");
+
+        assert!(artifact.json_path.exists());
+        assert!(artifact.markdown_path.exists());
+        let markdown = std::fs::read_to_string(&artifact.markdown_path).expect("read markdown");
+        assert!(markdown.contains("# Sego Review Report"));
+        assert!(markdown.contains("No findings."));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    fn target_with_diff(diff: &str) -> ReviewTarget {
+        ReviewTarget {
+            scope: ReviewScope::Workspace,
+            git_status: "## main\n M src/lib.rs".to_string(),
+            staged_diff: String::new(),
+            unstaged_diff: diff.to_string(),
+        }
+    }
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("sego-{name}-{unique}"))
     }
 }

--- a/rust/crates/runtime/src/code_review/severity.rs
+++ b/rust/crates/runtime/src/code_review/severity.rs
@@ -1,8 +1,24 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReviewSeverity {
     Critical,
     High,
     Medium,
     Low,
     Info,
+}
+
+impl ReviewSeverity {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::High => "high",
+            Self::Medium => "medium",
+            Self::Low => "low",
+            Self::Info => "info",
+        }
+    }
 }

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -57,8 +57,9 @@ pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::BranchLockRegistry;
 pub use code_review::{
-    build_review_prompt, ReviewContext, ReviewFinding, ReviewPromptOptions, ReviewReport,
-    ReviewScope, ReviewScopeParseError, ReviewSeverity, ReviewTarget,
+    build_review_prompt, persist_review_artifact, review_diff_hash, PersistedReviewArtifact,
+    ReviewContext, ReviewFinding, ReviewPromptOptions, ReviewReport, ReviewScope,
+    ReviewScopeParseError, ReviewSeverity, ReviewTarget,
 };
 pub use compact::{
     compact_session, estimate_session_tokens, format_compact_summary,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -43,8 +43,8 @@ use runtime::{
     community_learning::CommunityLearning,
     evaluate, format_usd, generate_pkce_pair, generate_state,
     green_contract::GreenLevel,
-    load_system_prompt, parse_oauth_callback_request_target, pricing_for_model,
-    resolve_sandbox_status, save_oauth_credentials,
+    load_system_prompt, parse_oauth_callback_request_target, persist_review_artifact,
+    pricing_for_model, resolve_sandbox_status, save_oauth_credentials,
     workflow::{SessionReport, WorkflowSnapshot, WorkflowStore},
     ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
     ContentBlock, ConversationMessage, ConversationRuntime, DiffScope, LaneBlocker, LaneContext,
@@ -52,9 +52,9 @@ use runtime::{
     McpServerManager, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest, OAuthConfig,
     OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, Phase, PhaseLogEntry, PhaseStatus,
     ProgressUI, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, ReviewContext,
-    ReviewPromptOptions, ReviewScope, ReviewStatus, ReviewTarget, RuntimeError, Session,
-    TokenUsage, ToolError, ToolExecutor, UsageTracker, VerificationCommand, VerificationPlanStatus,
-    VerificationScope,
+    ReviewPromptOptions, ReviewReport, ReviewScope, ReviewStatus, ReviewTarget, RuntimeError,
+    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker, VerificationCommand,
+    VerificationPlanStatus, VerificationScope,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -2236,7 +2236,54 @@ impl LiveCli {
                         detail: error.to_string(),
                     },
                 ));
-                ui.phase_idx(thinking_phase).fail("Request failed", &error.to_string());
+                ui.phase_idx(thinking_phase).fail("Request failed", error.to_string());
+                let _ = ui.finish("Failed");
+                Err(Box::new(error))
+            }
+        }
+    }
+
+    fn run_turn_capture_text(&mut self, input: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
+        let mut stdout = io::stdout();
+        let mut ui = ProgressUI::new("Sego Agent", &mut stdout);
+        ui.add_phase("thinking", "Thinking");
+        ui.add_phase("exec", "Executing");
+        let _ = ui.start();
+        let thinking_phase = 0usize;
+        let exec_phase = 1usize;
+        ui.phase_idx(thinking_phase).start();
+        let mut permission_prompter = CliPermissionPrompter::new(self.permission_mode);
+        let result = runtime.run_turn(input, Some(&mut permission_prompter));
+        ui.phase_idx(exec_phase).complete("Done", "");
+        hook_abort_monitor.stop();
+        match result {
+            Ok(summary) => {
+                let text = final_assistant_text(&summary);
+                self.replace_runtime(runtime)?;
+                ui.finish("Done")?;
+                println!();
+                if let Some(event) = summary.auto_compaction {
+                    println!("{}", format_auto_compaction_notice(event.removed_message_count));
+                }
+                self.workflow.record_event(LaneEvent::new(
+                    LaneEventName::Green,
+                    LaneEventStatus::Green,
+                    default_date(),
+                ));
+                self.persist_session()?;
+                Ok(text)
+            }
+            Err(error) => {
+                runtime.shutdown_plugins()?;
+                self.workflow.record_event(LaneEvent::blocked(
+                    default_date(),
+                    &LaneEventBlocker {
+                        failure_class: LaneFailureClass::ToolRuntime,
+                        detail: error.to_string(),
+                    },
+                ));
+                ui.phase_idx(thinking_phase).fail("Request failed", error.to_string());
                 let _ = ui.finish("Failed");
                 Err(Box::new(error))
             }
@@ -2984,9 +3031,20 @@ impl LiveCli {
         &mut self,
         target: ReviewTarget,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let prompt =
-            build_review_prompt(&ReviewContext::new(target), ReviewPromptOptions::default());
-        self.run_turn(&prompt)
+        let context = ReviewContext::new(target);
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+        let review_text = self.run_turn_capture_text(&prompt)?;
+        let report = ReviewReport::no_findings(review_text);
+        let artifact = persist_review_artifact(&env::current_dir()?, &context.target, &report)?;
+
+        println!(
+            "Review Report\n  ID               {}\n  Diff hash        {}\n  Markdown         {}\n  JSON             {}",
+            artifact.id,
+            artifact.diff_hash,
+            artifact.markdown_path.display(),
+            artifact.json_path.display()
+        );
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- add persisted review artifacts under `.sego/reviews`
- serialize review output to JSON and Markdown with stable diff hash metadata
- make `/review` capture final assistant text and print generated report paths

## Changes
| File | Change |
|------|--------|
| `runtime/src/code_review/report.rs` | Add `persist_review_artifact()`, `review_diff_hash()`, `PersistedReviewArtifact`, `ReviewArtifact` |
| `runtime/src/code_review/severity.rs` | Add `Serialize`/`Deserialize` + `label()` method |
| `runtime/src/code_review/mod.rs` | Export new public items |
| `runtime/src/lib.rs` | Re-export new public items |
| `rusty-claude-cli/src/main.rs` | Add `run_turn_capture_text()`; wire report persistence into `/review` |

## Sego Independent Review
| Check | Result |
|-------|--------|
| `/review` read-only semantics | ✅ No user code modifications |
| File write scope (`.sego/reviews/` only) | ✅ |
| `diff_hash` stability (scope + staged + unstaged) | ✅ SHA-256 with delimiters |
| Artifact traceability (schema_version, id, timestamp, hash) | ✅ |
| `run_turn_capture_text` parity with `run_turn` | ✅ Same runtime prep, workflow, session persistence; same error UI fix |
| `.claw/` excluded from commit | ✅ |

## Verification
```
cargo fmt --all --check          ✅
cargo test -p runtime code_review ✅ 9/9
cargo test -p rusty-claude-cli    ✅ 105/105
cargo build -p rusty-claude-cli   ✅
git diff --check                  ✅
cargo clippy -p runtime --lib     ✅ exit 0
cargo clippy -p rusty-claude-cli  ✅ exit 0
```

## Notes
- Clippy exits successfully; pre-existing warnings in other files not addressed here
- `rust/crates/rusty-claude-cli/.claw/` is a local test artifact intentionally excluded
- Next: structured finding parsing, line-number mapping, review gating, report indexing