### PR TITLE
feat: add review history commands

### DIFF
--- a/rust/crates/runtime/src/code_review/mod.rs
+++ b/rust/crates/runtime/src/code_review/mod.rs
@@ -7,8 +7,8 @@ mod severity;
 pub use context::{ReviewContext, ReviewTarget};
 pub use prompt::{build_review_prompt, ReviewPromptOptions};
 pub use report::{
-    persist_review_artifact, review_diff_hash, PersistedReviewArtifact, ReviewFinding,
-    ReviewParseStatus, ReviewReport,
+    load_review_index, persist_review_artifact, review_diff_hash, PersistedReviewArtifact,
+    ReviewFinding, ReviewIndexEntry, ReviewParseStatus, ReviewReport,
 };
 pub use scope::{ReviewScope, ReviewScopeParseError};
 pub use severity::ReviewSeverity;

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 use std::fs;
-use std::io::Write as _;
+use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -121,16 +121,16 @@ struct ReviewArtifact {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct ReviewIndexEntry {
-    id: String,
-    created_at_epoch_seconds: u64,
-    scope: String,
-    diff_hash: String,
-    finding_count: usize,
-    highest_severity: Option<ReviewSeverity>,
-    parse_status: ReviewParseStatus,
-    json_path: String,
-    markdown_path: String,
+pub struct ReviewIndexEntry {
+    pub id: String,
+    pub created_at_epoch_seconds: u64,
+    pub scope: String,
+    pub diff_hash: String,
+    pub finding_count: usize,
+    pub highest_severity: Option<ReviewSeverity>,
+    pub parse_status: ReviewParseStatus,
+    pub json_path: String,
+    pub markdown_path: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -173,6 +173,28 @@ pub fn persist_review_artifact(
     append_review_index(&index_path, &artifact, &json_path, &markdown_path)?;
 
     Ok(PersistedReviewArtifact { id, diff_hash, json_path, markdown_path, index_path })
+}
+
+pub fn load_review_index(workspace_root: &Path) -> io::Result<Vec<ReviewIndexEntry>> {
+    let index_path = workspace_root.join(".sego").join("reviews").join("index.jsonl");
+    if !index_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(index_path)?;
+    contents
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| !line.trim().is_empty())
+        .map(|(line_index, line)| {
+            serde_json::from_str::<ReviewIndexEntry>(line).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid review index entry at line {}: {error}", line_index + 1),
+                )
+            })
+        })
+        .collect()
 }
 
 #[must_use]
@@ -333,7 +355,10 @@ fn short_hash(hash: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{persist_review_artifact, review_diff_hash, ReviewParseStatus, ReviewReport};
+    use super::{
+        load_review_index, persist_review_artifact, review_diff_hash, ReviewParseStatus,
+        ReviewReport,
+    };
     use crate::code_review::{ReviewScope, ReviewSeverity, ReviewTarget};
 
     #[test]
@@ -426,6 +451,38 @@ mod tests {
         let index = std::fs::read_to_string(&artifact.index_path).expect("read index");
         assert!(index.contains("\"finding_count\":1"));
         assert!(index.contains("\"highest_severity\":\"critical\""));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn loads_review_index_entries() {
+        let root = temp_path("review-index-load");
+        let target = target_with_diff("diff --git a/src/lib.rs b/src/lib.rs\n");
+        let report = ReviewReport::from_model_output(
+            r#"{"findings":[{"severity":"medium","file":"src/lib.rs","line":9,"title":"Missing branch coverage","evidence":"new branch has no test","risk":"regression can slip","suggestion":"add a focused test","confidence":0.72,"verification_hint":"cargo test"}]}"#,
+        );
+        let artifact =
+            persist_review_artifact(&root, &target, &report).expect("artifact should persist");
+
+        let entries = load_review_index(&root).expect("index should load");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, artifact.id);
+        assert_eq!(entries[0].finding_count, 1);
+        assert_eq!(entries[0].highest_severity, Some(ReviewSeverity::Medium));
+        assert_eq!(entries[0].parse_status, ReviewParseStatus::Structured);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn missing_review_index_loads_as_empty_history() {
+        let root = temp_path("review-index-missing");
+
+        let entries = load_review_index(&root).expect("missing index should be empty");
+
+        assert!(entries.is_empty());
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -57,9 +57,10 @@ pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use branch_lock::BranchLockRegistry;
 pub use code_review::{
-    build_review_prompt, persist_review_artifact, review_diff_hash, PersistedReviewArtifact,
-    ReviewContext, ReviewFinding, ReviewParseStatus, ReviewPromptOptions, ReviewReport,
-    ReviewScope, ReviewScopeParseError, ReviewSeverity, ReviewTarget,
+    build_review_prompt, load_review_index, persist_review_artifact, review_diff_hash,
+    PersistedReviewArtifact, ReviewContext, ReviewFinding, ReviewIndexEntry, ReviewParseStatus,
+    ReviewPromptOptions, ReviewReport, ReviewScope, ReviewScopeParseError, ReviewSeverity,
+    ReviewTarget,
 };
 pub use compact::{
     compact_session, estimate_session_tokens, format_compact_summary,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -43,8 +43,8 @@ use runtime::{
     community_learning::CommunityLearning,
     evaluate, format_usd, generate_pkce_pair, generate_state,
     green_contract::GreenLevel,
-    load_system_prompt, parse_oauth_callback_request_target, persist_review_artifact,
-    pricing_for_model, resolve_sandbox_status, save_oauth_credentials,
+    load_review_index, load_system_prompt, parse_oauth_callback_request_target,
+    persist_review_artifact, pricing_for_model, resolve_sandbox_status, save_oauth_credentials,
     workflow::{SessionReport, WorkflowSnapshot, WorkflowStore},
     ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource,
     ContentBlock, ConversationMessage, ConversationRuntime, DiffScope, LaneBlocker, LaneContext,
@@ -52,8 +52,8 @@ use runtime::{
     McpServerManager, McpTool, MessageRole, ModelPricing, OAuthAuthorizationRequest, OAuthConfig,
     OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, Phase, PhaseLogEntry, PhaseStatus,
     ProgressUI, ProjectContext, PromptCacheEvent, ResolvedPermissionMode, ReviewContext,
-    ReviewPromptOptions, ReviewReport, ReviewScope, ReviewStatus, ReviewTarget, RuntimeError,
-    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker, VerificationCommand,
+    ReviewIndexEntry, ReviewPromptOptions, ReviewReport, ReviewScope, ReviewStatus, ReviewTarget,
+    RuntimeError, Session, TokenUsage, ToolError, ToolExecutor, UsageTracker, VerificationCommand,
     VerificationPlanStatus, VerificationScope,
 };
 use serde::Deserialize;
@@ -203,8 +203,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 .run_turn_with_output(&prompt, output_format)?;
         }
         CliAction::CodeReview { scope, model, allowed_tools, permission_mode } => {
-            run_code_review_cli(model, allowed_tools, permission_mode, scope.as_deref())?
+            run_code_review_cli(model, allowed_tools, permission_mode, scope.as_deref())?;
         }
+        CliAction::CodeReviewList => print_code_review_history()?,
+        CliAction::CodeReviewShow { id } => print_code_review_report(&id)?,
         CliAction::CodeVerify { scope } => run_code_verify_cli(scope.as_deref())?,
         CliAction::Login => run_login()?,
         CliAction::Logout => run_logout()?,
@@ -267,6 +269,10 @@ enum CliAction {
         model: String,
         allowed_tools: Option<AllowedToolSet>,
         permission_mode: PermissionMode,
+    },
+    CodeReviewList,
+    CodeReviewShow {
+        id: String,
     },
     CodeVerify {
         scope: Option<String>,
@@ -567,12 +573,9 @@ fn parse_direct_slash_cli_action(
             },
         }),
         Ok(Some(SlashCommand::Skills { args })) => Ok(CliAction::Skills { args }),
-        Ok(Some(SlashCommand::Review { scope })) => Ok(CliAction::CodeReview {
-            scope,
-            model,
-            allowed_tools,
-            permission_mode: PermissionMode::ReadOnly,
-        }),
+        Ok(Some(SlashCommand::Review { scope })) => {
+            parse_code_review_slash_action(scope.as_deref(), model, allowed_tools)
+        }
         Ok(Some(SlashCommand::Verify { scope })) => Ok(CliAction::CodeVerify { scope }),
         Ok(Some(SlashCommand::Unknown(name))) => Err(format_unknown_direct_slash_command(&name)),
         Ok(Some(command)) => Err({
@@ -585,6 +588,36 @@ fn parse_direct_slash_cli_action(
         }),
         Ok(None) => Err(format!("unknown subcommand: {}", rest[0])),
         Err(error) => Err(error.to_string()),
+    }
+}
+
+fn parse_code_review_slash_action(
+    scope: Option<&str>,
+    model: String,
+    allowed_tools: Option<AllowedToolSet>,
+) -> Result<CliAction, String> {
+    let Some(scope_value) = scope.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(CliAction::CodeReview {
+            scope: None,
+            model,
+            allowed_tools,
+            permission_mode: PermissionMode::ReadOnly,
+        });
+    };
+
+    let parts = scope_value.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        ["list"] => Ok(CliAction::CodeReviewList),
+        ["show"] => Err("missing review id for /review show <id>".to_string()),
+        ["show", id] => Ok(CliAction::CodeReviewShow { id: (*id).to_string() }),
+        ["show", ..] => Err("unexpected arguments for /review show <id>".to_string()),
+        ["list", ..] => Err("unexpected arguments for /review list".to_string()),
+        _ => Ok(CliAction::CodeReview {
+            scope: Some(scope_value.to_string()),
+            model,
+            allowed_tools,
+            permission_mode: PermissionMode::ReadOnly,
+        }),
     }
 }
 
@@ -2491,7 +2524,7 @@ impl LiveCli {
                 false
             }
             SlashCommand::Review { scope } => {
-                self.run_review(scope.as_deref())?;
+                self.handle_review_command(scope.as_deref())?;
                 true
             }
             SlashCommand::Verify { scope } => {
@@ -3025,6 +3058,17 @@ impl LiveCli {
         }
 
         self.run_review_target(target)
+    }
+
+    fn handle_review_command(
+        &mut self,
+        scope: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match parse_review_history_command(scope)? {
+            Some(ReviewHistoryCommand::List) => print_code_review_history(),
+            Some(ReviewHistoryCommand::Show { id }) => print_code_review_report(&id),
+            None => self.run_review(scope),
+        }
     }
 
     fn run_review_target(
@@ -3965,6 +4009,102 @@ fn run_code_review_cli(
     }
 
     LiveCli::new(model, true, allowed_tools, permission_mode)?.run_review_target(target)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ReviewHistoryCommand {
+    List,
+    Show { id: String },
+}
+
+fn parse_review_history_command(
+    scope: Option<&str>,
+) -> Result<Option<ReviewHistoryCommand>, Box<dyn std::error::Error>> {
+    let Some(scope_value) = scope.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+
+    let parts = scope_value.split_whitespace().collect::<Vec<_>>();
+    match parts.as_slice() {
+        ["list"] => Ok(Some(ReviewHistoryCommand::List)),
+        ["show"] => Err("missing review id for /review show <id>".into()),
+        ["show", id] => Ok(Some(ReviewHistoryCommand::Show { id: (*id).to_string() })),
+        ["show", ..] => Err("unexpected arguments for /review show <id>".into()),
+        ["list", ..] => Err("unexpected arguments for /review list".into()),
+        _ => Ok(None),
+    }
+}
+
+fn print_code_review_history() -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    let mut entries = load_review_index(&cwd)?;
+    entries.sort_by_key(|entry| entry.created_at_epoch_seconds);
+
+    println!("Review History");
+    if entries.is_empty() {
+        println!("  Result           no review reports found");
+        println!(
+            "  Index            {}",
+            cwd.join(".sego").join("reviews").join("index.jsonl").display()
+        );
+        return Ok(());
+    }
+
+    for entry in entries.iter().rev() {
+        print_review_index_entry(entry);
+    }
+
+    Ok(())
+}
+
+fn print_review_index_entry(entry: &ReviewIndexEntry) {
+    let highest_severity = entry.highest_severity.map_or("none", runtime::ReviewSeverity::label);
+    println!(
+        "  {}\n    Scope            {}\n    Findings         {}\n    Highest severity {}\n    Parse status     {}\n    Created          {}\n    Markdown         {}",
+        entry.id,
+        entry.scope,
+        entry.finding_count,
+        highest_severity,
+        entry.parse_status.label(),
+        entry.created_at_epoch_seconds,
+        entry.markdown_path
+    );
+}
+
+fn print_code_review_report(id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    let entries = load_review_index(&cwd)?;
+    let entry = resolve_review_entry(&entries, id)?;
+    let markdown_path = resolve_review_markdown_path(&cwd, entry);
+    let markdown = fs::read_to_string(&markdown_path)?;
+    println!("{markdown}");
+    Ok(())
+}
+
+fn resolve_review_entry<'a>(
+    entries: &'a [ReviewIndexEntry],
+    id: &str,
+) -> Result<&'a ReviewIndexEntry, Box<dyn std::error::Error>> {
+    let matches = entries.iter().filter(|entry| entry.id == id).collect::<Vec<_>>();
+    if let [entry] = matches.as_slice() {
+        return Ok(*entry);
+    }
+
+    let prefix_matches =
+        entries.iter().filter(|entry| entry.id.starts_with(id)).collect::<Vec<_>>();
+    match prefix_matches.as_slice() {
+        [entry] => Ok(*entry),
+        [] => Err(format!("review report not found: {id}").into()),
+        _ => Err(format!("review id prefix is ambiguous: {id}").into()),
+    }
+}
+
+fn resolve_review_markdown_path(workspace_root: &Path, entry: &ReviewIndexEntry) -> PathBuf {
+    let stored = PathBuf::from(entry.markdown_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+    if stored.exists() {
+        return stored;
+    }
+    workspace_root.join(".sego").join("reviews").join(format!("{}.md", entry.id))
 }
 
 fn print_clean_review_scope(target: &ReviewTarget) {
@@ -6644,6 +6784,16 @@ mod tests {
             }
         );
         assert_eq!(
+            parse_args(&["/review".to_string(), "list".to_string()])
+                .expect("/review list should parse"),
+            CliAction::CodeReviewList
+        );
+        assert_eq!(
+            parse_args(&["/review".to_string(), "show".to_string(), "review-123".to_string(),])
+                .expect("/review show should parse"),
+            CliAction::CodeReviewShow { id: "review-123".to_string() }
+        );
+        assert_eq!(
             parse_args(&["/verify".to_string(), "fast".to_string()])
                 .expect("/verify fast should parse"),
             CliAction::CodeVerify { scope: Some("fast".to_string()) }
@@ -6652,6 +6802,18 @@ mod tests {
             .expect_err("/status should remain REPL-only when invoked directly");
         assert!(error.contains("interactive-only"));
         assert!(error.contains("claw --resume SESSION.jsonl /status"));
+    }
+
+    #[test]
+    fn review_history_commands_reject_invalid_shapes() {
+        let missing_id = parse_args(&["/review".to_string(), "show".to_string()])
+            .expect_err("/review show should require an id");
+        assert!(missing_id.contains("missing review id"));
+
+        let extra_list_arg =
+            parse_args(&["/review".to_string(), "list".to_string(), "extra".to_string()])
+                .expect_err("/review list should not accept extra args");
+        assert!(extra_list_arg.contains("unexpected arguments"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add runtime helpers to load persisted review index entries
- add /review list to display saved review reports
- add /review show <id> to render persisted markdown reports by full or unique prefix id
- preserve existing /review scopes and keep bare sego review as workflow/session review

## Tests
- cargo fmt --all --check
- cargo test -p runtime code_review
- cargo test -p rusty-claude-cli --bin sego
- cargo build -p rusty-claude-cli
- git diff --check
- cargo clippy -p runtime --lib
- cargo clippy -p rusty-claude-cli --bin sego

## Notes
- Clippy passes but the repository still has pre-existing warnings outside this slice.