### PR TITLE
feat: scope review safety to staged files

### DIFF
--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -148,8 +148,8 @@ pub use remote::{
     DEFAULT_SESSION_TOKEN_PATH, DEFAULT_SYSTEM_CA_BUNDLE, NO_PROXY_HOSTS, UPSTREAM_PROXY_ENV_KEYS,
 };
 pub use safety_lock::{
-    build_safety_lock_report, SafetyCategory, SafetyFinding, SafetyLockError, SafetyLockReport,
-    SafetySeverity,
+    build_safety_lock_report, build_safety_lock_report_for_paths, SafetyCategory, SafetyFinding,
+    SafetyLockError, SafetyLockReport, SafetyScanMode, SafetySeverity,
 };
 pub use sandbox::{
     build_linux_sandbox_command, detect_container_environment, detect_container_environment_from,

--- a/rust/crates/runtime/src/safety_lock.rs
+++ b/rust/crates/runtime/src/safety_lock.rs
@@ -48,6 +48,23 @@ impl SafetyCategory {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SafetyScanMode {
+    Workspace,
+    Staged,
+}
+
+impl SafetyScanMode {
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Staged => "staged",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SafetyFinding {
     pub severity: SafetySeverity,
@@ -63,6 +80,7 @@ pub struct SafetyFinding {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SafetyLockReport {
     pub root: String,
+    pub mode: SafetyScanMode,
     pub findings: Vec<SafetyFinding>,
     pub warnings: Vec<String>,
 }
@@ -135,7 +153,56 @@ pub fn build_safety_lock_report(root: &Path) -> Result<SafetyLockReport, SafetyL
 
     findings.sort_by_key(|finding| severity_rank(finding.severity));
     let warnings = build_warnings(&state);
-    Ok(SafetyLockReport { root: root.display().to_string(), findings, warnings })
+    Ok(SafetyLockReport {
+        root: root.display().to_string(),
+        mode: SafetyScanMode::Workspace,
+        findings,
+        warnings,
+    })
+}
+
+pub fn build_safety_lock_report_for_paths<I, P>(
+    root: &Path,
+    relative_paths: I,
+    mode: SafetyScanMode,
+) -> Result<SafetyLockReport, SafetyLockError>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
+{
+    if !root.is_dir() {
+        return Err(SafetyLockError::NotDirectory(root.to_path_buf()));
+    }
+
+    let mut findings = Vec::new();
+    let mut state = ScanState::default();
+    for relative_path in relative_paths {
+        if state.scanned_entries >= MAX_SCAN_ENTRIES {
+            state.truncated_entries = true;
+            break;
+        }
+
+        let relative_path = relative_path.as_ref();
+        if !is_safe_relative_path(relative_path) {
+            continue;
+        }
+
+        let path = root.join(relative_path);
+        if !path.is_file() {
+            continue;
+        }
+
+        state.scanned_entries += 1;
+        scan_existing_file(root, &path, &mut findings, &mut state)?;
+        if findings.len() >= MAX_FINDINGS {
+            state.truncated_findings = true;
+            break;
+        }
+    }
+
+    findings.sort_by_key(|finding| severity_rank(finding.severity));
+    let warnings = build_warnings(&state);
+    Ok(SafetyLockReport { root: root.display().to_string(), mode, findings, warnings })
 }
 
 fn scan_file(
@@ -145,10 +212,19 @@ fn scan_file(
     state: &mut ScanState,
 ) -> Result<(), SafetyLockError> {
     let path = entry.path();
+    scan_existing_file(root, path, findings, state)
+}
+
+fn scan_existing_file(
+    root: &Path,
+    path: &Path,
+    findings: &mut Vec<SafetyFinding>,
+    state: &mut ScanState,
+) -> Result<(), SafetyLockError> {
     let relative = relative_path(root, path);
     add_path_findings(&relative, findings);
 
-    let metadata = entry.metadata()?;
+    let metadata = fs::metadata(path)?;
     if metadata.len() > MAX_FILE_BYTES {
         state.skipped_large_files += 1;
         return Ok(());
@@ -174,6 +250,14 @@ fn scan_file(
         }
     }
     Ok(())
+}
+
+fn is_safe_relative_path(path: &Path) -> bool {
+    !path.is_absolute()
+        && path.components().any(|component| matches!(component, std::path::Component::Normal(_)))
+        && path.components().all(|component| {
+            matches!(component, std::path::Component::Normal(_) | std::path::Component::CurDir)
+        })
 }
 
 fn add_path_findings(relative: &str, findings: &mut Vec<SafetyFinding>) {
@@ -411,7 +495,7 @@ fn should_scan_dangerous_commands(relative: &str) -> bool {
 
 fn should_scan_file_content(relative: &str) -> bool {
     let normalized = relative.replace('\\', "/").to_ascii_lowercase();
-    !(normalized == "crates/runtime/src/safety_lock.rs"
+    !(normalized.ends_with("crates/runtime/src/safety_lock.rs")
         || normalized.contains("/tests/")
         || normalized.ends_with("_test.rs")
         || normalized.ends_with("_tests.rs")
@@ -534,7 +618,10 @@ fn relative_path(root: &Path, path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_safety_lock_report, SafetyCategory, SafetySeverity, MAX_FILE_BYTES};
+    use super::{
+        build_safety_lock_report, build_safety_lock_report_for_paths, SafetyCategory,
+        SafetyScanMode, SafetySeverity, MAX_FILE_BYTES,
+    };
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -650,6 +737,49 @@ mod tests {
         assert!(report.findings.is_empty());
         assert!(report.warnings.is_empty());
 
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn path_scoped_scan_ignores_unlisted_files() {
+        let root = temp_dir("scoped");
+        let key = ["API", "_KEY"].concat();
+        let value = ["sk", "-live-value-that-looks-real"].concat();
+        write(&root.join(".env"), &format!("{key}={value}\n"));
+        write(&root.join("src/main.rs"), "fn main() { println!(\"hello\"); }\n");
+
+        let report = build_safety_lock_report_for_paths(
+            &root,
+            [PathBuf::from("src/main.rs")],
+            SafetyScanMode::Staged,
+        )
+        .expect("safety report");
+
+        assert_eq!(report.mode, SafetyScanMode::Staged);
+        assert!(report.findings.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn path_scoped_scan_ignores_unsafe_relative_paths() {
+        let root = temp_dir("unsafe-relative");
+        let outside = root.parent().expect("temp root parent").join("secret.env");
+        let key = ["API", "_KEY"].concat();
+        let value = ["sk", "-live-value-that-looks-real"].concat();
+        write(&outside, &format!("{key}={value}\n"));
+        write(&root.join("safe.rs"), "fn main() {}\n");
+
+        let report = build_safety_lock_report_for_paths(
+            &root,
+            [PathBuf::from("../secret.env"), PathBuf::from("safe.rs")],
+            SafetyScanMode::Staged,
+        )
+        .expect("safety report");
+
+        assert!(report.findings.is_empty());
+
+        let _ = fs::remove_file(outside);
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -213,7 +213,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             mark_code_review_finding(&id, &finding_id, status, note)?;
         }
         CliAction::CodeReviewTools => print_code_review_tools()?,
-        CliAction::CodeReviewSafety => print_code_review_safety()?,
+        CliAction::CodeReviewSafety { scope } => print_code_review_safety(scope)?,
         CliAction::CodeVerify { scope } => run_code_verify_cli(scope.as_deref())?,
         CliAction::Login => run_login()?,
         CliAction::Logout => run_logout()?,
@@ -291,7 +291,9 @@ enum CliAction {
         note: Option<String>,
     },
     CodeReviewTools,
-    CodeReviewSafety,
+    CodeReviewSafety {
+        scope: SafetyReviewScope,
+    },
     CodeVerify {
         scope: Option<String>,
     },
@@ -319,6 +321,12 @@ enum CliAction {
         action: Option<String>,
         output_format: CliOutputFormat,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SafetyReviewScope {
+    Workspace,
+    Staged,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -4008,6 +4016,12 @@ fn collect_review_target(
     Ok(ReviewTarget { scope, git_status, staged_diff, unstaged_diff })
 }
 
+fn collect_staged_review_paths(cwd: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let output =
+        run_git_diff_command_in(cwd, &["diff", "--cached", "--name-only", "--diff-filter=ACMR"])?;
+    Ok(output.lines().map(str::trim).filter(|line| !line.is_empty()).map(PathBuf::from).collect())
+}
+
 fn run_code_review_cli(
     model: String,
     allowed_tools: Option<AllowedToolSet>,
@@ -4031,7 +4045,7 @@ enum ReviewHistoryCommand {
     Status { id: String },
     Mark { id: String, finding_id: String, status: ReviewFindingStatus, note: Option<String> },
     Tools,
-    Safety,
+    Safety { scope: SafetyReviewScope },
 }
 
 fn parse_review_history_command(
@@ -4046,7 +4060,12 @@ fn parse_review_history_command(
         ["list"] => Ok(Some(ReviewHistoryCommand::List)),
         ["tools"] => Ok(Some(ReviewHistoryCommand::Tools)),
         ["tools", ..] => Err("unexpected arguments for /review tools".into()),
-        ["safety"] => Ok(Some(ReviewHistoryCommand::Safety)),
+        ["safety"] => {
+            Ok(Some(ReviewHistoryCommand::Safety { scope: SafetyReviewScope::Workspace }))
+        }
+        ["safety", "staged"] => {
+            Ok(Some(ReviewHistoryCommand::Safety { scope: SafetyReviewScope::Staged }))
+        }
         ["safety", ..] => Err("unexpected arguments for /review safety".into()),
         ["show"] => Err("missing review id for /review show <id>".into()),
         ["show", id] => Ok(Some(ReviewHistoryCommand::Show { id: (*id).to_string() })),
@@ -4084,7 +4103,7 @@ fn review_history_command_to_cli_action(command: ReviewHistoryCommand) -> CliAct
             CliAction::CodeReviewMark { id, finding_id, status, note }
         }
         ReviewHistoryCommand::Tools => CliAction::CodeReviewTools,
-        ReviewHistoryCommand::Safety => CliAction::CodeReviewSafety,
+        ReviewHistoryCommand::Safety { scope } => CliAction::CodeReviewSafety { scope },
     }
 }
 
@@ -4099,7 +4118,7 @@ fn run_review_history_command(
             mark_code_review_finding(&id, &finding_id, status, note)
         }
         ReviewHistoryCommand::Tools => print_code_review_tools(),
-        ReviewHistoryCommand::Safety => print_code_review_safety(),
+        ReviewHistoryCommand::Safety { scope } => print_code_review_safety(scope),
     }
 }
 
@@ -4152,13 +4171,34 @@ fn print_code_review_tools() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn print_code_review_safety() -> Result<(), Box<dyn std::error::Error>> {
+fn print_code_review_safety(scope: SafetyReviewScope) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
-    let report = runtime::build_safety_lock_report(&cwd)?;
+    let report = match scope {
+        SafetyReviewScope::Workspace => runtime::build_safety_lock_report(&cwd)?,
+        SafetyReviewScope::Staged => {
+            let paths = collect_staged_review_paths(&cwd)?;
+            if paths.is_empty() {
+                println!("Review Safety");
+                println!("  Root             {}", cwd.display());
+                println!("  Mode             read-only");
+                println!("  Scope            staged");
+                println!("  Safety           no files were modified; no tools were executed");
+                println!("  Result           no staged files to scan");
+                println!("  Next step        stage changes, then rerun /review safety staged");
+                return Ok(());
+            }
+            runtime::build_safety_lock_report_for_paths(
+                &cwd,
+                paths,
+                runtime::SafetyScanMode::Staged,
+            )?
+        }
+    };
 
     println!("Review Safety");
     println!("  Root             {}", report.root);
     println!("  Mode             read-only");
+    println!("  Scope            {}", report.mode.label());
     println!("  Safety           no files were modified; no tools were executed");
 
     if report.findings.is_empty() {
@@ -6524,8 +6564,8 @@ mod tests {
         resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
         write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor, GitWorkspaceSummary,
-        InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SlashCommand,
-        StatusUsage,
+        InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SafetyReviewScope,
+        SlashCommand, StatusUsage,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
     use plugins::{
@@ -7060,7 +7100,12 @@ mod tests {
         assert_eq!(
             parse_args(&["/review".to_string(), "safety".to_string()])
                 .expect("/review safety should parse"),
-            CliAction::CodeReviewSafety
+            CliAction::CodeReviewSafety { scope: SafetyReviewScope::Workspace }
+        );
+        assert_eq!(
+            parse_args(&["/review".to_string(), "safety".to_string(), "staged".to_string()])
+                .expect("/review safety staged should parse"),
+            CliAction::CodeReviewSafety { scope: SafetyReviewScope::Staged }
         );
         assert_eq!(
             parse_args(&["/review".to_string(), "show".to_string(), "review-123".to_string(),])


### PR DESCRIPTION
## Summary
- add staged scope support for /review safety staged
- add path-scoped safety lock reporting with safe relative path filtering
- preserve /review safety as a full workspace scan and show scan scope in CLI output
- avoid safety lock self-scan false positives when the repository path includes a rust/ prefix

## Tests
- cargo fmt --all --check
- cargo test -p runtime safety_lock (8 passed)
- cargo test -p runtime code_review (17 passed)
- cargo test -p rusty-claude-cli --bin sego (106 passed)
- cargo build -p rusty-claude-cli
- git diff --check
- cargo clippy -p runtime --lib (exit 0, 32 pre-existing warnings)
- cargo clippy -p rusty-claude-cli --bin sego (exit 0, 20 pre-existing warnings)
- target/debug/sego.exe /review safety (Scope workspace, 5 findings)
- target/debug/sego.exe /review safety staged (Scope staged, no staged files)

## Notes
- /review safety staged is read-only and does not call models, verification tools, dependency installers, or file writers.
- Clippy exits successfully but the repository still has pre-existing warnings outside this slice.