### PR TITLE
docs: restore readme utf8 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,91 @@
-<h1>Sego <img src="assets/sego-ui-icon.png" width="34" height="34" alt="Sego 鍥炬爣" align="right"></h1>
+<h1>Sego <img src="assets/sego-ui-icon.png" width="34" height="34" alt="Sego 图标" align="right"></h1>
 
 <p align="center">
-  <strong>AI Coding 鐨勫伐绋嬩俊浠昏繍琛屾椂</strong><br>
-  璁?AI 鐢熸垚鐨勪唬鐮佸彉寰楀彲瀹℃煡銆佸彲楠岃瘉銆佸彲澶嶇洏銆佸彲浜や粯銆?</p>
+  <strong>AI Coding 的工程信任运行时</strong><br>
+  让 AI 生成的代码变得可审查、可验证、可复盘、可交付。
+</p>
 
 <p align="center">
-  <a href="#蹇€熷紑濮?><img src="https://img.shields.io/badge/蹇€熷紑濮?5鍒嗛挓-blue?style=flat-square" alt="蹇€熷紑濮?></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/璁稿彲璇?MIT-green?style=flat-square" alt="MIT 璁稿彲璇?></a>
-  <img src="https://img.shields.io/badge/Rust-鍘熺敓-orange?style=flat-square" alt="Rust 鍘熺敓">
-  <img src="https://img.shields.io/badge/骞冲彴-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="鏀寔骞冲彴">
+  <a href="#快速开始"><img src="https://img.shields.io/badge/快速开始-5分钟-blue?style=flat-square" alt="快速开始"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/许可证-MIT-green?style=flat-square" alt="MIT 许可证"></a>
+  <img src="https://img.shields.io/badge/Rust-原生-orange?style=flat-square" alt="Rust 原生">
+  <img src="https://img.shields.io/badge/平台-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="支持平台">
 </p>
 
 ---
 
-## Sego 鏄粈涔?
-Sego 鏄潰鍚?AI Coding 鏃朵唬鐨勫伐绋嬩俊浠诲伐鍏枫€傚畠涓嶆槸鍐嶅仛涓€涓€滄浛浣犲啓鏇村浠ｇ爜鈥濈殑 Agent锛屼篃涓嶆槸浼犵粺 IDE锛涘畠鏇村儚涓€灞傚紑鍙戝伐浣滄祦鐨勬湰鍦颁俊浠昏繍琛屾椂锛屽府鍔╁紑鍙戣€呭垽鏂?AI 鍐欏嚭鐨勪唬鐮佹槸鍚﹀€煎緱杩涘叆鎻愪氦銆佸悎骞跺拰浜や粯銆?
-浣犲彲浠ョ户缁娇鐢?Claude Code銆丆odex銆丆ursor銆丱penHands 鎴栧叾浠?AI 缂栫爜宸ュ叿鐢熸垚浠ｇ爜銆係ego 璐熻矗鍦ㄤ唬鐮佽繘鍏?Git銆丳R 鎴栦氦浠樹箣鍓嶏紝琛ヤ笂宸ョ▼鍖栫殑瀹℃煡銆侀獙璇併€佽褰曞拰浜ゆ帴璇佹嵁銆?
-涓€鍙ヨ瘽锛?
-```text
-AI 璐熻矗鐢熸垚锛孲ego 璐熻矗璇佹槑瀹冨€煎緱琚悎骞躲€?```
+## Sego 是什么
 
----
+Sego 是面向 AI Coding 时代的工程信任工具。它不是再做一个“替你写更多代码”的 Agent，也不是传统 IDE；它更像一层开发工作流的本地信任运行时，帮助开发者判断 AI 写出的代码是否值得进入提交、合并和交付。
 
-## 涓轰粈涔堥渶瑕?Sego
+你可以继续使用 Claude Code、Codex、Cursor、OpenHands 或其他 AI 编码工具生成代码。Sego 负责在代码进入 Git、PR 或交付之前，补上工程化的审查、验证、记录和交接证据。
 
-AI 缂栫爜宸ュ叿宸茬粡鑳藉揩閫熺敓鎴愪唬鐮侊紝浣嗙湡瀹炲紑鍙戜腑鐨勯闄╁線寰€鍑虹幇鍦ㄥ悗鍗婃锛?
-- 淇畬涓€涓?bug 鍚庯紝鐩稿叧鏁版嵁閾捐矾銆佽皟鐢ㄩ摼銆佹祴璇曞拰鏂囨。娌℃湁鍚屾瀵归綈銆?- AI 鍙叧娉ㄥ綋鍓?diff锛屽鏄撳拷鐣ュ巻鍙蹭笂涓嬫枃銆侀」鐩害鏉熷拰宸叉帴鍙楄鍒欍€?- 浠ｇ爜 review 鍙粰鑷劧璇█寤鸿锛岀己灏戦闄╃瓑绾с€佽瘉鎹€佺姸鎬佸拰鍙拷韪褰曘€?- 娴嬭瘯閫氳繃涓庡惁缂哄皯缁撴瀯鍖栨矇娣€锛屼笅涓€娆′粛鐒朵粠澶村垽鏂€?- 鍗曟瀵硅瘽瓒婃潵瓒婇暱锛岄」鐩粡楠屾棤娉曠ǔ瀹氬鐢紝涔熷緢闅句氦鎺ョ粰鍙︿竴涓?Agent 鎴栧紑鍙戣€呫€?
-Sego 甯屾湜鎶婅繖浜涢棶棰樻敹鏁涙垚涓€涓湰鍦颁紭鍏堛€佸彲瀹¤銆佸彲鎸佺画婕旇繘鐨勫伐绋嬮棴鐜細
+一句话：
 
 ```text
-鐢熸垚浠ｇ爜 -> 瀹℃煡鏀瑰姩 -> 楠岃瘉璇佹嵁 -> 娌夋穩涓婁笅鏂?-> 杈呭姪浜や粯
+AI 负责生成，Sego 负责证明它值得被合并。
 ```
 
 ---
 
-## 褰撳墠 MVP 鑳藉仛浠€涔?
-褰撳墠寮€婧愮増鏈粛澶勫湪 MVP 杩唬闃舵锛岄噸鐐规槸鎶?review銆乿erify 鍜屾湰鍦板伐绋嬭蹇嗚窇閫氥€傚凡鍏紑鐨勮兘鍔涗富瑕佸洿缁曗€滄彁浜ゅ墠宸ョ▼淇′换闂幆鈥濆睍寮€銆?
-### 鎻愪氦鍓?readiness gate
+## 为什么需要 Sego
+
+AI 编码工具已经能快速生成代码，但真实开发中的风险往往出现在后半段：
+
+- 修完一个 bug 后，相关数据链路、调用链、测试和文档没有同步对齐。
+- AI 只关注当前 diff，容易忽略历史上下文、项目约束和已接受规则。
+- 代码 review 只给自然语言建议，缺少风险等级、证据、状态和可追踪记录。
+- 测试通过与否缺少结构化沉淀，下一次仍然从头判断。
+- 单次对话越来越长，项目经验无法稳定复用，也很难交接给另一个 Agent 或开发者。
+
+Sego 希望把这些问题收敛成一个本地优先、可审计、可持续演进的工程闭环：
+
+```text
+生成代码 -> 审查改动 -> 验证证据 -> 沉淀上下文 -> 辅助交付
+```
+
+---
+
+## 当前 MVP 能做什么
+
+当前开源版本仍处在 MVP 迭代阶段，重点是把 review、verify 和本地工程记忆跑通。已公开的能力主要围绕“提交前工程信任闭环”展开。
+
+### 提交前 readiness gate
 
 ```bash
 sego /review ready
 ```
 
-`/review ready` 浼氱粰鍑?staged 鎻愪氦鍓嶇姸鎬侊細
+`/review ready` 会给出 staged 提交前状态：
 
-- 褰撳墠鏆傚瓨鍖烘枃浠舵暟閲忋€?- staged safety lock 缁撴灉銆?- `/verify fast` 鐨勮鍒掑懡浠ゃ€?- 涓嬩竴姝ュ缓璁細鏄惁闇€瑕佸厛琛?staged銆佷慨澶嶅畨鍏ㄩ闄┿€佹墽琛?review 鎴?verify銆?
-瀹冩槸鍙鎶ュ憡锛屼笉浼氳皟鐢ㄦā鍨嬨€佷笉浼氭墽琛?build/test銆佷笉浼氬畨瑁呬緷璧栥€佷笉浼氫慨鏀规枃浠躲€?
-### staged 瀹夊叏閿?
+- 当前暂存区文件数量。
+- staged safety lock 结果。
+- `/verify fast` 的计划命令。
+- 下一步建议：是否需要先补 staged、修复安全风险、执行 review 或 verify。
+
+它是只读报告，不会调用模型、不会执行 build/test、不会安装依赖、不会修改文件。
+
+### staged 安全锁
+
 ```bash
 sego /review safety staged
 ```
 
-鍙壂鎻?Git 鏆傚瓨鍖烘枃浠讹紝鐢ㄤ簬鎻愪氦鍓嶅彂鐜版槑鏄剧殑鍒濈骇瀹夊叏椋庨櫓锛屼緥濡傜枒浼煎瘑閽ユ枃浠躲€佺‖缂栫爜瀵嗛挜銆佸嵄闄?shell 鍛戒护銆佹湰鏈虹粷瀵硅矾寰勭瓑銆?
-瀹冮€傚悎浣滀负 vibe coding 鏂版墜鐨勭涓€灞傚畨鍏ㄩ攣锛屼絾杩欏彧鏄?Sego 鐨勪竴涓簲鐢ㄥ満鏅紝涓嶆槸 Sego 鐨勫畬鏁翠骇鍝佽竟鐣屻€?
-### 浠ｇ爜瀹℃煡
+只扫描 Git 暂存区文件，用于提交前发现明显的初级安全风险，例如疑似密钥文件、硬编码密钥、危险 shell 命令、本机绝对路径等。
+
+它适合作为 vibe coding 新手的第一层安全锁，但这只是 Sego 的一个应用场景，不是 Sego 的完整产品边界。
+
+### 代码审查
 
 ```bash
 sego /review staged
 sego /review
 ```
 
-Sego 鍙互閽堝 staged diff 鎴栧綋鍓嶅伐浣滃尯鏀瑰姩鍙戣捣鍙浠ｇ爜瀹℃煡锛岃緭鍑虹粨鏋勫寲 findings锛屽苟灏介噺淇濈暀闂浣嶇疆銆佷弗閲嶇▼搴︺€佽瘉鎹€侀闄╄鏄庡拰淇寤鸿銆?
-### 瀹℃煡鍘嗗彶涓庣姸鎬?
+Sego 可以针对 staged diff 或当前工作区改动发起只读代码审查，输出结构化 findings，并尽量保留问题位置、严重程度、证据、风险说明和修复建议。
+
+### 审查历史与状态
+
 ```bash
 sego /review list
 sego /review show <review-id>
@@ -69,25 +93,30 @@ sego /review status <review-id>
 sego /review mark <review-id> <finding-id> <status> [note]
 ```
 
-瀹℃煡缁撴灉浼氭矇娣€涓烘湰鍦拌褰曪紝渚夸簬鍥炵湅銆佹爣璁般€佸鐩樺拰浜ゆ帴銆俧inding 鐘舵€佹敮鎸佸悗缁拷韪紝涓嶅繀鎶婃瘡娆?review 閮藉綋鎴愪竴娆℃€ц亰澶╃粨鏋溿€?
-### 楠岃瘉璁″垝
+审查结果会沉淀为本地记录，便于回看、标记、复盘和交接。finding 状态支持后续追踪，不必把每次 review 都当成一次性聊天结果。
+
+### 验证计划
 
 ```bash
 sego /verify fast
 sego /verify
 ```
 
-Sego 浼氭牴鎹綋鍓嶉」鐩瘑鍒熀纭€楠岃瘉璁″垝锛屼緥濡?Rust 椤圭洰鐨?`cargo build` / `cargo test`锛屾垨 Node 椤圭洰鐨?test/build 鑴氭湰銆俙/review ready` 鍙睍绀洪獙璇佽鍒掞紱鐪熸鎵ц浠嶇敱 `/verify` 鏄庣‘瑙﹀彂銆?
-### 宸ュ叿閾惧缓璁?
+Sego 会根据当前项目识别基础验证计划，例如 Rust 项目的 `cargo build` / `cargo test`，或 Node 项目的 test/build 脚本。`/review ready` 只展示验证计划；真正执行仍由 `/verify` 明确触发。
+
+### 工具链建议
+
 ```bash
 sego /review tools
 ```
 
-鏈湴鍙鎺㈡祴椤圭洰璇█鍜屽伐鍏烽摼锛岀粰鍑哄缓璁墽琛岀殑妫€鏌ュ懡浠ゃ€傚畠涓嶄細瀹夎渚濊禆锛屼篃涓嶄細鑷姩鎵ц澶栭儴宸ュ叿銆?
+本地只读探测项目语言和工具链，给出建议执行的检查命令。它不会安装依赖，也不会自动执行外部工具。
+
 ---
 
-## 鎺ㄨ崘宸ヤ綔娴?
-濡傛灉浣犲凡缁忎娇鐢?AI 宸ュ叿瀹屾垚浜嗕竴杞唬鐮佷慨鏀癸紝鍙互鎸変笅闈㈢殑椤哄簭鎻愪氦鍓嶈嚜鏌ワ細
+## 推荐工作流
+
+如果你已经使用 AI 工具完成了一轮代码修改，可以按下面的顺序提交前自查：
 
 ```bash
 git add <files>
@@ -97,50 +126,61 @@ sego /review staged
 sego /verify fast
 ```
 
-鎺ㄨ崘鐞嗚В鏂瑰紡锛?
-| 姝ラ | 浣滅敤 |
+推荐理解方式：
+
+| 步骤 | 作用 |
 |---|---|
-| `git add <files>` | 鏄庣‘鏈鍑嗗鎻愪氦鐨勮寖鍥?|
-| `/review ready` | 鏌ョ湅鎻愪氦鍓嶇姸鎬佸拰涓嬩竴姝ュ缓璁?|
-| `/review safety staged` | 鍏堢敤鏈湴瀹夊叏閿佹帓闄ゆ槑鏄鹃闄?|
-| `/review staged` | 瀵规殏瀛樺尯 diff 鍋氭ā鍨嬭緟鍔╁鏌?|
-| `/verify fast` | 鏄庣‘鎵ц蹇€熼獙璇侊紝鐢熸垚鍙氦浠樿瘉鎹?|
+| `git add <files>` | 明确本次准备提交的范围 |
+| `/review ready` | 查看提交前状态和下一步建议 |
+| `/review safety staged` | 先用本地安全锁排除明显风险 |
+| `/review staged` | 对暂存区 diff 做模型辅助审查 |
+| `/verify fast` | 明确执行快速验证，生成可交付证据 |
 
 ---
 
-## 浜у搧鏂瑰悜
+## 产品方向
 
-Sego 鐨勭洰鏍囦笉鏄垚涓轰竴涓€滃彧鏈?review 浼樺娍銆佹病鏈夌紪鐮佷紭鍔库€濈殑瀛ょ珛宸ュ叿銆傚畠鐨勪骇鍝佸畾浣嶆槸 AI Coding 宸ヤ綔娴佷腑鐨勫伐绋嬩俊浠诲眰锛?
+Sego 的目标不是成为一个“只有 review 优势、没有编码优势”的孤立工具。它的产品定位是 AI Coding 工作流中的工程信任层：
+
 ```text
-AI 缂栫爜宸ュ叿        ->  璐熻矗鐢熸垚浠ｇ爜
-Sego              ->  璐熻矗瀹℃煡銆侀獙璇併€佽褰曘€佷氦鎺ヨ瘉鎹?Git / CI / 骞冲彴    ->  璐熻矗鍚堝苟銆侀儴缃插拰鐢熶骇浜や粯
+AI 编码工具        ->  负责生成代码
+Sego              ->  负责审查、验证、记录、交接证据
+Git / CI / 平台    ->  负责合并、部署和生产交付
 ```
 
-鏈潵 Sego 浼氬洿缁曞洓涓柟鍚戞紨杩涳細
+未来 Sego 会围绕四个方向演进：
 
-| 鏂瑰悜 | 璇存槑 |
+| 方向 | 说明 |
 |---|---|
-| Review | 璁╀唬鐮佸鏌ユ洿缁撴瀯鍖栵紝杈撳嚭椋庨櫓绛夌骇銆佽瘉鎹€佹枃浠朵綅缃拰寤鸿 |
-| Verify | 灏嗗鏌ョ粨璁轰笌鏋勫缓銆佹祴璇曘€乴int 绛夐獙璇佽瘉鎹繛鎺ヨ捣鏉?|
-| Memory | 娌夋穩椤圭洰涓婁笅鏂囥€佸巻鍙茶鎶ャ€佸凡鎺ュ彈瑙勫垯鍜岄獙璇佽褰?|
-| Ship | 鐢熸垚闈㈠悜 commit銆丳R 鍜屽彂甯冪殑浜や粯鎶ュ憡 |
+| Review | 让代码审查更结构化，输出风险等级、证据、文件位置和建议 |
+| Verify | 将审查结论与构建、测试、lint 等验证证据连接起来 |
+| Memory | 沉淀项目上下文、历史误报、已接受规则和验证记录 |
+| Ship | 生成面向 commit、PR 和发布的交付报告 |
 
 ---
 
-## 閫傚悎璋佷娇鐢?
-### 涓汉寮€鍙戣€?
-濡傛灉浣犲凡缁忓湪浣跨敤 AI 鍐欎唬鐮侊紝Sego 鍙互甯綘鍦ㄦ彁浜ゅ墠澶氫竴灞傚伐绋嬪寲纭锛氱湅娓呮敼鍔ㄣ€佸彂鐜伴闄┿€佽ˉ瓒抽獙璇佽瘉鎹€?
-### vibe coding 鏂版墜
+## 适合谁使用
 
-濡傛灉浣犱笉鐔熸倝浠ｇ爜瑙勮寖銆丟it 鎻愪氦杈圭晫銆佸畨鍏ㄩ闄╁拰楠岃瘉娴佺▼锛孲ego 鍙互浣滀负鎻愪氦鍓嶅畨鍏ㄩ攣锛屾彁閱掍綘涓嶈鎶婃槑鏄惧嵄闄╃殑鍐呭鐩存帴鎻愪氦銆?
-### 寮€婧愰」鐩淮鎶よ€?
-Sego 鍙互浣滀负鏈湴 review 鍜?verify 杈呭姪宸ュ叿锛屽湪 PR 鍓嶆彁鍓嶆毚闇查棶棰橈紝闄嶄綆缁存姢鑰?review 鎴愭湰銆?
-### AI Coding 宸ュ叿閲嶅害鐢ㄦ埛
+### 个人开发者
 
-濡傛灉浣犵粡甯稿湪澶氫釜 AI 宸ュ叿涔嬮棿鍒囨崲锛孲ego 鍙互浣滀负缁熶竴鐨勫伐绋嬩俊浠诲眰锛屽府鍔╀綘鎶婁笉鍚屽伐鍏风敓鎴愮殑鏀瑰姩绾冲叆鍚屼竴濂楀鏌ュ拰楠岃瘉娴佺▼銆?
+如果你已经在使用 AI 写代码，Sego 可以帮你在提交前多一层工程化确认：看清改动、发现风险、补足验证证据。
+
+### vibe coding 新手
+
+如果你不熟悉代码规范、Git 提交边界、安全风险和验证流程，Sego 可以作为提交前安全锁，提醒你不要把明显危险的内容直接提交。
+
+### 开源项目维护者
+
+Sego 可以作为本地 review 和 verify 辅助工具，在 PR 前提前暴露问题，降低维护者 review 成本。
+
+### AI Coding 工具重度用户
+
+如果你经常在多个 AI 工具之间切换，Sego 可以作为统一的工程信任层，帮助你把不同工具生成的改动纳入同一套审查和验证流程。
+
 ---
 
-## 蹇€熷紑濮?
+## 快速开始
+
 ### Windows
 
 ```powershell
@@ -157,7 +197,8 @@ export ANTHROPIC_API_KEY="sk-your-key"
 sego
 ```
 
-### 浠庢簮鐮佹瀯寤?
+### 从源码构建
+
 ```bash
 git clone https://github.com/007M7/Sego-Agent.git
 cd Sego-Agent/rust
@@ -167,68 +208,104 @@ cargo build --release
 
 ---
 
-## 甯哥敤鍛戒护
+## 常用命令
 
 ```bash
 sego
 ```
 
-杩涘叆浜や簰寮?CLI銆?
+进入交互式 CLI。
+
 ```bash
-sego "鎬荤粨褰撳墠椤圭洰缁撴瀯"
+sego "总结当前项目结构"
 ```
 
-鎵ц涓€娆℃€т换鍔°€?
+执行一次性任务。
+
 ```bash
 sego /review ready
 ```
 
-鏌ョ湅鎻愪氦鍓?readiness gate銆?
+查看提交前 readiness gate。
+
 ```bash
 sego /review staged
 ```
 
-瀹℃煡鏆傚瓨鍖烘敼鍔ㄣ€?
+审查暂存区改动。
+
 ```bash
 sego /review list
 ```
 
-鏌ョ湅鏈湴瀹℃煡鍘嗗彶銆?
+查看本地审查历史。
+
 ```bash
 sego /verify fast
 ```
 
-鎵ц蹇€熼獙璇併€?
+执行快速验证。
+
 ```bash
 sego status
 ```
 
-鏌ョ湅褰撳墠宸ヤ綔鍖虹姸鎬併€?
+查看当前工作区状态。
+
 ```bash
 sego --resume latest
 ```
 
-鎭㈠鏈€杩戜竴娆′細璇濄€?
+恢复最近一次会话。
+
 ---
 
-## 褰撳墠鐘舵€?
-Sego 褰撳墠澶勪簬鏃╂湡 MVP 闃舵锛岄噸鐐规槸鎶?review銆乿erify 鍜屾湰鍦板伐绋嬭蹇嗚窇閫氥€傞儴鍒嗚兘鍔涗粛鍦ㄥ揩閫熻凯浠ｄ腑锛屾帴鍙ｅ拰杈撳嚭鏍煎紡鍙兘缁х画璋冩暣銆?
-宸插畬鎴愮殑鍏紑鏂瑰悜锛?
-- CLI 鍩虹鑳藉姏銆?- 鏈湴浼氳瘽鎭㈠銆?- `/review` 鍒濈増銆?- staged code review銆?- 缁撴瀯鍖?review findings銆?- review 鍘嗗彶鏌ョ湅銆?- finding 鐘舵€佹爣璁般€?- staged safety lock銆?- `/review ready` 鎻愪氦鍓?readiness gate銆?- `/verify` 鍒濈増銆?- 鍩虹鏉冮檺杈圭晫銆?- GitHub Actions 鍩虹楠岃瘉銆?
-姝ｅ湪鎺ㄨ繘锛?
-- 鏇寸ǔ瀹氱殑瀹℃煡杈撳嚭缁撴瀯銆?- 瀹℃煡鎶ュ憡涓庨獙璇佽瘉鎹叧鑱斻€?- 鏇存竻鏅扮殑 PR / commit 鎶ュ憡銆?- 闈㈠悜涓汉寮€鍙戣€呯殑瀹屾暣 MVP 浣撻獙銆?- 鍙鐢ㄧ殑宸ョ▼涓婁笅鏂囪蹇嗐€?
+## 当前状态
+
+Sego 当前处于早期 MVP 阶段，重点是把 review、verify 和本地工程记忆跑通。部分能力仍在快速迭代中，接口和输出格式可能继续调整。
+
+已完成的公开方向：
+
+- CLI 基础能力。
+- 本地会话恢复。
+- `/review` 初版。
+- staged code review。
+- 结构化 review findings。
+- review 历史查看。
+- finding 状态标记。
+- staged safety lock。
+- `/review ready` 提交前 readiness gate。
+- `/verify` 初版。
+- 基础权限边界。
+- GitHub Actions 基础验证。
+
+正在推进：
+
+- 更稳定的审查输出结构。
+- 审查报告与验证证据关联。
+- 更清晰的 PR / commit 报告。
+- 面向个人开发者的完整 MVP 体验。
+- 可复用的工程上下文记忆。
+
 ---
 
-## 寮€婧愯竟鐣?
-褰撳墠 README 鍙睍绀?Sego 鐨勫叕寮€浜у搧瀹氫綅鍜?MVP 浣跨敤鏂瑰紡銆傛洿瀹屾暣鐨勫唴閮ㄥ紑鍙戞祦绋嬨€佸伐绋嬭蹇嗗疄鐜般€佸崗浣滃崗璁€佽瘎瀹＄瓥鐣ャ€侀獙璇侀摼璺拰鍟嗕笟鍖栬璁℃殏涓嶅湪寮€婧愭枃妗ｄ腑灞曞紑銆?
-闅忕潃 MVP 绋冲畾锛岄」鐩細閫愭寮€鏀炬洿澶氬彲浠ュ叕寮€鐨勮兘鍔涜鏄庡拰浣跨敤绀轰緥銆?
+## 开源边界
+
+当前 README 只展示 Sego 的公开产品定位和 MVP 使用方式。更完整的内部开发流程、工程记忆实现、协作协议、评审策略、验证链路和商业化设计暂不在开源文档中展开。
+
+随着 MVP 稳定，项目会逐步开放更多可以公开的能力说明和使用示例。
+
 ---
 
-## 璁稿彲璇?
-Sego 浣跨敤 MIT License銆?
+## 许可证
+
+Sego 使用 MIT License。
+
 ---
 
-## 涓€鍙ヨ瘽鎬荤粨
+## 一句话总结
 
 ```text
-Sego 涓嶆槸鏇夸綘鍐欐洿澶氫唬鐮佺殑宸ュ叿銆?Sego 鏄府浣犲垽鏂?AI 鍐欏嚭鐨勪唬鐮佹槸鍚﹀€煎緱鍚堝苟鐨勫伐绋嬩俊浠昏繍琛屾椂銆?```
+Sego 不是替你写更多代码的工具。
+Sego 是帮你判断 AI 写出的代码是否值得合并的工程信任运行时。
+```


### PR DESCRIPTION
## Summary
- restore README.md Chinese content as valid UTF-8
- fix mojibake introduced in the previous README update
- keep the Cycle 6.5 public product story and MVP command documentation unchanged

## Tests
- Get-Content -Encoding UTF8 README.md shows normal Chinese text
- searched for common mojibake markers: 鍥, 鏄, 鐨, 銆, €
- git diff --check

## Notes
- Documentation-only encoding fix.
- Please avoid rewriting README through Windows default-encoding pipelines.