### PR TITLE
fix: route DeepSeek models through native provider config

### DIFF
--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -11,6 +11,7 @@ pub enum ProviderClient {
     Anthropic(AnthropicClient),
     Xai(OpenAiCompatClient),
     OpenAi(OpenAiCompatClient),
+    DeepSeek(OpenAiCompatClient),
 }
 
 impl ProviderClient {
@@ -34,6 +35,9 @@ impl ProviderClient {
             ProviderKind::OpenAi => {
                 Ok(Self::OpenAi(OpenAiCompatClient::from_env(OpenAiCompatConfig::openai())?))
             }
+            ProviderKind::DeepSeek => {
+                Ok(Self::DeepSeek(OpenAiCompatClient::from_env(OpenAiCompatConfig::deepseek())?))
+            }
         }
     }
 
@@ -43,6 +47,7 @@ impl ProviderClient {
             Self::Anthropic(_) => ProviderKind::Anthropic,
             Self::Xai(_) => ProviderKind::Xai,
             Self::OpenAi(_) => ProviderKind::OpenAi,
+            Self::DeepSeek(_) => ProviderKind::DeepSeek,
         }
     }
 
@@ -58,7 +63,7 @@ impl ProviderClient {
     pub fn prompt_cache_stats(&self) -> Option<PromptCacheStats> {
         match self {
             Self::Anthropic(client) => client.prompt_cache_stats(),
-            Self::Xai(_) | Self::OpenAi(_) => None,
+            Self::Xai(_) | Self::OpenAi(_) | Self::DeepSeek(_) => None,
         }
     }
 
@@ -66,7 +71,7 @@ impl ProviderClient {
     pub fn take_last_prompt_cache_record(&self) -> Option<PromptCacheRecord> {
         match self {
             Self::Anthropic(client) => client.take_last_prompt_cache_record(),
-            Self::Xai(_) | Self::OpenAi(_) => None,
+            Self::Xai(_) | Self::OpenAi(_) | Self::DeepSeek(_) => None,
         }
     }
 
@@ -76,7 +81,9 @@ impl ProviderClient {
     ) -> Result<MessageResponse, ApiError> {
         match self {
             Self::Anthropic(client) => client.send_message(request).await,
-            Self::Xai(client) | Self::OpenAi(client) => client.send_message(request).await,
+            Self::Xai(client) | Self::OpenAi(client) | Self::DeepSeek(client) => {
+                client.send_message(request).await
+            }
         }
     }
 
@@ -88,7 +95,7 @@ impl ProviderClient {
             Self::Anthropic(client) => {
                 client.stream_message(request).await.map(MessageStream::Anthropic)
             }
-            Self::Xai(client) | Self::OpenAi(client) => {
+            Self::Xai(client) | Self::OpenAi(client) | Self::DeepSeek(client) => {
                 client.stream_message(request).await.map(MessageStream::OpenAiCompat)
             }
         }
@@ -131,6 +138,11 @@ pub fn read_xai_base_url() -> String {
     openai_compat::read_base_url(OpenAiCompatConfig::xai())
 }
 
+#[must_use]
+pub fn read_deepseek_base_url() -> String {
+    openai_compat::read_base_url(OpenAiCompatConfig::deepseek())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::providers::{detect_provider_kind, resolve_model_alias, ProviderKind};
@@ -146,5 +158,6 @@ mod tests {
     fn provider_detection_prefers_model_family() {
         assert_eq!(detect_provider_kind("grok-3"), ProviderKind::Xai);
         assert_eq!(detect_provider_kind("claude-sonnet-4-6"), ProviderKind::Anthropic);
+        assert_eq!(detect_provider_kind("deepseek-v4-flash"), ProviderKind::DeepSeek);
     }
 }

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -6,8 +6,9 @@ mod sse;
 mod types;
 
 pub use client::{
-    oauth_token_is_expired, read_base_url, read_xai_base_url, resolve_saved_oauth_token,
-    resolve_startup_auth_source, MessageStream, OAuthTokenSet, ProviderClient,
+    oauth_token_is_expired, read_base_url, read_deepseek_base_url, read_xai_base_url,
+    resolve_saved_oauth_token, resolve_startup_auth_source, MessageStream, OAuthTokenSet,
+    ProviderClient,
 };
 pub use error::ApiError;
 pub use prompt_cache::{

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -30,6 +30,7 @@ pub enum ProviderKind {
     Anthropic,
     Xai,
     OpenAi,
+    DeepSeek,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -141,7 +142,7 @@ pub fn resolve_model_alias(model: &str) -> String {
                     "grok-2" => "grok-2",
                     _ => trimmed,
                 },
-                ProviderKind::OpenAi => trimmed,
+                ProviderKind::OpenAi | ProviderKind::DeepSeek => trimmed,
             })
         })
         .map_or_else(|| trimmed.to_string(), ToOwned::to_owned)
@@ -166,6 +167,14 @@ pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
             default_base_url: openai_compat::DEFAULT_XAI_BASE_URL,
         });
     }
+    if canonical.starts_with("deepseek") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::DeepSeek,
+            auth_env: "DEEPSEEK_API_KEY",
+            base_url_env: "DEEPSEEK_BASE_URL",
+            default_base_url: openai_compat::DEFAULT_DEEPSEEK_BASE_URL,
+        });
+    }
     None
 }
 
@@ -179,6 +188,9 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     }
     if openai_compat::has_api_key("OPENAI_API_KEY") {
         return ProviderKind::OpenAi;
+    }
+    if openai_compat::has_api_key("DEEPSEEK_API_KEY") {
+        return ProviderKind::DeepSeek;
     }
     if openai_compat::has_api_key("XAI_API_KEY") {
         return ProviderKind::Xai;
@@ -211,6 +223,8 @@ mod tests {
     fn detects_provider_from_model_name_first() {
         assert_eq!(detect_provider_kind("grok"), ProviderKind::Xai);
         assert_eq!(detect_provider_kind("claude-sonnet-4-6"), ProviderKind::Anthropic);
+        assert_eq!(detect_provider_kind("deepseek-v4-flash"), ProviderKind::DeepSeek);
+        assert_eq!(detect_provider_kind("deepseek-v4-pro"), ProviderKind::DeepSeek);
     }
 
     #[test]

--- a/rust/crates/api/tests/openai_compat_integration.rs
+++ b/rust/crates/api/tests/openai_compat_integration.rs
@@ -279,6 +279,51 @@ async fn provider_client_dispatches_xai_requests_from_env() {
     );
 }
 
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn provider_client_dispatches_deepseek_requests_from_env() {
+    let _lock = env_lock();
+    let _api_key = ScopedEnvVar::set("DEEPSEEK_API_KEY", "deepseek-test-key");
+
+    let state = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
+    let server = spawn_server(
+        state.clone(),
+        vec![http_response(
+            "200 OK",
+            "application/json",
+            "{\"id\":\"chatcmpl_deepseek_provider\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"message\":{\"role\":\"assistant\",\"reasoning_content\":\"internal reasoning\",\"content\":\"Through DeepSeek provider\",\"tool_calls\":[]},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":4}}",
+        )],
+    )
+    .await;
+    let _base_url = ScopedEnvVar::set("DEEPSEEK_BASE_URL", server.base_url());
+
+    let client = ProviderClient::from_model("deepseek-v4-pro")
+        .expect("DeepSeek provider client should be constructed");
+    assert!(matches!(client, ProviderClient::DeepSeek(_)));
+
+    let response = client
+        .send_message(&sample_request(false))
+        .await
+        .expect("provider-dispatched DeepSeek request should succeed");
+
+    assert_eq!(response.total_tokens(), 13);
+    assert_eq!(
+        response.content[0],
+        OutputContentBlock::Thinking {
+            thinking: "internal reasoning".to_string(),
+            signature: None,
+        }
+    );
+
+    let captured = state.lock().await;
+    let request = captured.first().expect("captured request");
+    assert_eq!(request.path, "/chat/completions");
+    assert_eq!(
+        request.headers.get("authorization").map(String::as_str),
+        Some("Bearer deepseek-test-key")
+    );
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CapturedRequest {
     path: String,

--- a/rust/crates/api/tests/provider_client_integration.rs
+++ b/rust/crates/api/tests/provider_client_integration.rs
@@ -1,7 +1,9 @@
 use std::ffi::OsString;
 use std::sync::{Mutex, OnceLock};
 
-use api::{read_xai_base_url, ApiError, AuthSource, ProviderClient, ProviderKind};
+use api::{
+    read_deepseek_base_url, read_xai_base_url, ApiError, AuthSource, ProviderClient, ProviderKind,
+};
 
 #[test]
 fn provider_client_routes_grok_aliases_through_xai() {
@@ -31,6 +33,40 @@ fn provider_client_reports_missing_xai_credentials_for_grok_models() {
 }
 
 #[test]
+fn provider_client_routes_deepseek_models_through_deepseek_config() {
+    let _lock = env_lock();
+    let _deepseek_api_key = EnvVarGuard::set("DEEPSEEK_API_KEY", Some("deepseek-test-key"));
+    let _openai_api_key = EnvVarGuard::set("OPENAI_API_KEY", Some("openai-test-key"));
+    let _anthropic_api_key = EnvVarGuard::set("ANTHROPIC_API_KEY", None);
+    let _anthropic_auth_token = EnvVarGuard::set("ANTHROPIC_AUTH_TOKEN", None);
+
+    let client =
+        ProviderClient::from_model("deepseek-v4-flash").expect("DeepSeek model should resolve");
+
+    assert_eq!(client.provider_kind(), ProviderKind::DeepSeek);
+}
+
+#[test]
+fn provider_client_reports_missing_deepseek_credentials_for_deepseek_models() {
+    let _lock = env_lock();
+    let _deepseek_api_key = EnvVarGuard::set("DEEPSEEK_API_KEY", None);
+    let _openai_api_key = EnvVarGuard::set("OPENAI_API_KEY", Some("openai-test-key"));
+    let _anthropic_api_key = EnvVarGuard::set("ANTHROPIC_API_KEY", None);
+    let _anthropic_auth_token = EnvVarGuard::set("ANTHROPIC_AUTH_TOKEN", None);
+
+    let error = ProviderClient::from_model("deepseek-v4-pro")
+        .expect_err("DeepSeek requests without DEEPSEEK_API_KEY should fail fast");
+
+    match error {
+        ApiError::MissingCredentials { provider, env_vars } => {
+            assert_eq!(provider, "DeepSeek");
+            assert_eq!(env_vars, &["DEEPSEEK_API_KEY"]);
+        }
+        other => panic!("expected missing DeepSeek credentials, got {other:?}"),
+    }
+}
+
+#[test]
 fn provider_client_uses_explicit_anthropic_auth_without_env_lookup() {
     let _lock = env_lock();
     let _anthropic_api_key = EnvVarGuard::set("ANTHROPIC_API_KEY", None);
@@ -51,6 +87,15 @@ fn read_xai_base_url_prefers_env_override() {
     let _xai_base_url = EnvVarGuard::set("XAI_BASE_URL", Some("https://example.xai.test/v1"));
 
     assert_eq!(read_xai_base_url(), "https://example.xai.test/v1");
+}
+
+#[test]
+fn read_deepseek_base_url_prefers_env_override() {
+    let _lock = env_lock();
+    let _deepseek_base_url =
+        EnvVarGuard::set("DEEPSEEK_BASE_URL", Some("https://example.deepseek.test/v1"));
+
+    assert_eq!(read_deepseek_base_url(), "https://example.deepseek.test/v1");
 }
 
 fn env_lock() -> std::sync::MutexGuard<'static, ()> {

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -8978,7 +8978,7 @@ UU conflicted.rs",
         let config_home = temp_dir();
         // Inject a dummy API key so runtime construction succeeds without real credentials.
         // This test only exercises plugin lifecycle (init/shutdown), never calls the API.
-        std::env::set_var("ANTHROPIC_API_KEY", "test-dummy-key-for-plugin-lifecycle");
+        std::env::set_var("DEEPSEEK_API_KEY", "test-dummy-key-for-plugin-lifecycle");
         let workspace = temp_dir();
         let source_root = temp_dir();
         fs::create_dir_all(&config_home).expect("config home");
@@ -9022,7 +9022,7 @@ UU conflicted.rs",
         let _ = fs::remove_dir_all(config_home);
         let _ = fs::remove_dir_all(workspace);
         let _ = fs::remove_dir_all(source_root);
-        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("DEEPSEEK_API_KEY");
     }
 }
 


### PR DESCRIPTION
## Summary
- add native DeepSeek provider routing for deepseek-* models
- keep DeepSeek models on DEEPSEEK_API_KEY / DEEPSEEK_BASE_URL even when OPENAI_API_KEY exists
- preserve reasoning_content through the existing DeepSeek-compatible thinking block parser
- update provider integration tests and CLI test env defaults

## Tests
- cargo fmt --all --check
- cargo test -p api deepseek
- cargo test -p api provider_client
- cargo test -p api
- cargo test -p rusty-claude-cli --bin sego
- cargo build -p rusty-claude-cli
- git diff --check
- cargo clippy -p api --lib
- cargo clippy -p rusty-claude-cli --bin sego