### PR TITLE
feat(runtime): crash recovery & session resume (cycle 9 A1+A2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ tests/                       # Python port tests
 | Add a new slash command | `rust/crates/commands/src/lib.rs` |
 | Add a new built-in tool | `rust/crates/tools/src/lib.rs` |
 | Change session persistence | `rust/crates/runtime/src/session.rs` |
+| Change crash/session resume recovery state | `rust/crates/runtime/src/recovery.rs` |
 | Add a recovery recipe | `rust/crates/runtime/src/recovery_recipes.rs` |
 | Add a failure class | `rust/crates/runtime/src/lane_events.rs` |
 | Change CLI arg parsing | `rust/crates/rusty-claude-cli/src/main.rs` → `parse_args()` |
@@ -193,6 +194,18 @@ Before pushing any change:
 5. **Partial success is first-class** — MCP servers can fail individually
 6. **Terminal is transport, not truth** — TUI is rendering, state is above it
 7. **Policy is executable** — merge/retry/rebase rules are machine-enforced
+8. **Recovery paths are absolute** — crash/session resume records live under `.sego/recovery/` and must store absolute session paths, even while session JSONL remains under `.claw/sessions/`
+
+### Recovery State Boundary
+
+- `rust/crates/runtime/src/recovery.rs` owns crash/session resume state, including `.sego/recovery/latest-session.json`, `.sego/recovery/exit-state.json`, and `.sego/recovery/recovery-summary.md`.
+- `rust/crates/runtime/src/recovery_recipes.rs` owns automatic remediation recipes after tool/task failures. Do not use it for session crash recovery.
+- Recovery startup detection must only read recovery JSON and check the referenced session file. It must not scan the repo, call a model, auto-resume, or replay old tool calls.
+- `session_path` in recovery JSON must be absolute. This prevents `.claw` / `.sego` dual-directory references from breaking on Windows paths or future storage migration.
+- **A2 CLI integration**: recovery startup notice is triggered only for actions that create/restore a persistent session and may execute model/tools (`Repl` / `Prompt` / `CodeReview` / `ResumeSession`). Pure-query actions (`Version`, `Help`, `Status`, etc.) must not trigger it.
+- **A2 exit-state write timing**: `active` is written only after the session handle is known (`LiveCli::new` for Repl/Prompt/CodeReview; session load for ResumeSession). `graceful` is written only on the normal return path. Error paths (crash, Ctrl+C, `?` propagation) leave `active` in place so the next launch prompts recovery. Do not use a `Drop` guard for `graceful` (fallible IO in `Drop` is unclear and risks writing `graceful` on error paths).
+- **A2 no signal handler (MVP)**: A2 deliberately does not add a signal handler. Interrupted/crashed sessions keep the `active` state and are surfaced as recoverable on next launch. Precise `interrupted` vs `crashed` distinction is deferred to a future `ctrlc` crate evaluation.
+- **A2 `/recovery-export`**: a separate slash command from `/export`. `/export` writes the session transcript (forced `.txt`); `/recovery-export` writes the recovery summary (markdown, default `.sego/recovery/recovery-summary.md`). Both share the `write_recovery_export` helper pattern but must not share path resolution logic.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -73,6 +73,7 @@ Sego-Agent/
 │       │       ├── lib.rs         # Public API surface
 │       │       ├── conversation.rs # Turn-based conversation loop
 │       │       ├── session.rs     # Session state + persistence (JSONL)
+│       │       ├── recovery.rs    # Crash/session resume recovery state
 │       │       ├── permissions.rs # Permission mode enforcement
 │       │       ├── config.rs      # 5-layer config hierarchy
 │       │       ├── prompt.rs      # System prompt builder
@@ -210,6 +211,26 @@ tools
 ├── runtime (for types)
 └── plugins (for plugin tool aggregation)
 ```
+
+### Crash Recovery State
+
+Crash/session resume recovery is owned by `rust/crates/runtime/src/recovery.rs`.
+
+- Recovery records are written under `.sego/recovery/`.
+- Conversation JSONL sessions currently remain under `.claw/sessions/`; this is intentional until a dedicated migration is designed.
+- Every recovery record that references a session must store `session_path` as an absolute path. Do not rely on `.claw` or `.sego` relative prefixes.
+- Startup recovery detection must stay lightweight: read recovery JSON, check whether the referenced session file exists, and render a prompt. It must not scan the repo, call a model, auto-resume, or replay previous tool calls.
+- `recovery_recipes.rs` is a separate automatic remediation subsystem and must not be used as crash/session resume state storage.
+
+### Crash Recovery CLI Integration (A2)
+
+The CLI layer (`rusty-claude-cli`) integrates the runtime recovery module as follows:
+
+- **Startup notice**: `maybe_print_recovery_notice` runs after `parse_args` and only reads recovery JSON (no writes, no scans, no model calls). It triggers only for `Repl` / `Prompt` / `CodeReview` / `ResumeSession` — actions that create or restore a persistent session. Pure-query actions do not trigger it.
+- **Two-layer write timing**: startup notice (read-only) is separate from session-state writes (`active`/`graceful`). `active` is written only after the session handle is known; `graceful` only on the normal return path. Error paths leave `active` in place.
+- **No signal handler (MVP)**: A2 deliberately avoids signal handling. An interrupted/crashed session keeps `active` and is surfaced as recoverable on the next launch. Precise `interrupted` vs `crashed` distinction is deferred to a future `ctrlc` crate evaluation.
+- **`/recovery-export` command**: separate from `/export`. `/export` writes the session transcript (forced `.txt` suffix); `/recovery-export` writes the recovery summary (markdown, supports `.md`, defaults to `.sego/recovery/recovery-summary.md`). Both resume and REPL modes support it via the shared `write_recovery_export` helper.
+- **`sego-resume` script**: `scripts/sego-resume.bat` (Windows) and `scripts/sego-resume.sh` (Unix) wrap `sego --resume latest "$@"`. They auto-detect the sego binary (local cargo build > `CARGO_TARGET_DIR` > `PATH`).
 
 ---
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -212,6 +212,13 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: true,
     },
     SlashCommandSpec {
+        name: "recovery-export",
+        aliases: &[],
+        summary: "Export the crash recovery summary to a file (markdown)",
+        argument_hint: Some("[file]"),
+        resume_supported: true,
+    },
+    SlashCommandSpec {
         name: "session",
         aliases: &[],
         summary: "List, switch, or fork managed local sessions",
@@ -1073,6 +1080,7 @@ pub enum SlashCommand {
     Diff,
     Version,
     Export { path: Option<String> },
+    RecoveryExport { path: Option<String> },
     Session { action: Option<String>, target: Option<String> },
     Plugins { action: Option<String>, target: Option<String> },
     Agents { args: Option<String> },
@@ -1227,6 +1235,7 @@ pub fn validate_slash_command_input(
             SlashCommand::Version
         }
         "export" => SlashCommand::Export { path: remainder },
+        "recovery-export" => SlashCommand::RecoveryExport { path: remainder },
         "session" => parse_session_command(&args)?,
         "plugin" | "plugins" | "marketplace" => parse_plugin_command(&args)?,
         "agents" => SlashCommand::Agents { args: parse_list_or_help_args(command, remainder)? },
@@ -1682,9 +1691,8 @@ fn slash_command_category(name: &str) -> &'static str {
             "Session & visibility"
         }
         "compact" | "clear" | "config" | "memory" | "init" | "diff" | "commit" | "pr" | "issue"
-        | "export" | "plugin" | "branch" | "add-dir" | "files" | "hooks" | "release-notes" => {
-            "Workspace & git"
-        }
+        | "export" | "recovery-export" | "plugin" | "branch" | "add-dir" | "files" | "hooks"
+        | "release-notes" => "Workspace & git",
         "agents" | "skills" | "teleport" | "debug-tool-call" | "mcp" | "context" | "tasks"
         | "doctor" | "ide" | "desktop" => "Discovery & debugging",
         "bughunter" | "ultraplan" | "review" | "verify" | "security-review" | "advisor"
@@ -3005,6 +3013,7 @@ pub fn handle_slash_command(
         | SlashCommand::Diff
         | SlashCommand::Version
         | SlashCommand::Export { .. }
+        | SlashCommand::RecoveryExport { .. }
         | SlashCommand::Session { .. }
         | SlashCommand::Plugins { .. }
         | SlashCommand::Agents { .. }
@@ -3060,8 +3069,9 @@ mod tests {
         handle_plugins_slash_command, handle_slash_command, load_agents_from_roots,
         load_skills_from_roots, render_agents_report, render_plugins_report, render_skills_report,
         render_slash_command_help, render_slash_command_help_detail,
-        resume_supported_slash_commands, slash_command_specs, suggest_slash_commands,
-        validate_slash_command_input, DefinitionSource, SkillOrigin, SkillRoot, SlashCommand,
+        resume_supported_slash_commands, slash_command_category, slash_command_specs,
+        suggest_slash_commands, validate_slash_command_input, DefinitionSource, SkillOrigin,
+        SkillRoot, SlashCommand,
     };
     use plugins::{PluginKind, PluginManager, PluginManagerConfig, PluginMetadata, PluginSummary};
     use runtime::{
@@ -3405,6 +3415,7 @@ mod tests {
         assert!(help.contains("/diff"));
         assert!(help.contains("/version"));
         assert!(help.contains("/export [file]"));
+        assert!(help.contains("/recovery-export [file]"));
         assert!(help.contains("/session [list|switch <session-id>|fork [branch-name]]"));
         assert!(help.contains("/sandbox"));
         assert!(help.contains(
@@ -3414,8 +3425,40 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help]"));
         assert!(help.contains("/verify [auto|fast|full]"));
-        assert_eq!(slash_command_specs().len(), 142);
+        assert_eq!(slash_command_specs().len(), 143);
         assert!(resume_supported_slash_commands().len() >= 39);
+    }
+
+    #[test]
+    fn recovery_export_parses_with_and_without_path() {
+        // 无参数：path 为 None
+        let parsed = SlashCommand::parse("/recovery-export").expect("parse without path");
+        assert!(matches!(parsed, Some(SlashCommand::RecoveryExport { path: None })));
+
+        // 带参数：path 为 Some
+        let parsed_with_path =
+            SlashCommand::parse("/recovery-export summary.md").expect("parse with path");
+        assert!(matches!(
+            parsed_with_path,
+            Some(SlashCommand::RecoveryExport { path: Some(ref p) }) if p == "summary.md"
+        ));
+    }
+
+    #[test]
+    fn recovery_export_is_resume_supported_and_categorized() {
+        // recovery-export 的 spec 必须标记 resume_supported = true
+        let spec = slash_command_specs()
+            .iter()
+            .find(|spec| spec.name == "recovery-export")
+            .expect("recovery-export spec must exist");
+        assert!(spec.resume_supported, "recovery-export must be resume-supported");
+
+        // recovery-export 必须归类到 Workspace & git（和 export 同组）
+        assert_eq!(slash_command_category("recovery-export"), "Workspace & git");
+
+        // recovery-export 必须出现在 help 里
+        let help = render_slash_command_help();
+        assert!(help.contains("/recovery-export"), "recovery-export must appear in help");
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -32,6 +32,7 @@ pub mod plugin_lifecycle;
 mod policy_engine;
 mod progress_ui;
 mod prompt;
+pub mod recovery;
 pub mod recovery_recipes;
 mod remote;
 pub mod safety_lock;
@@ -137,6 +138,15 @@ pub use progress_ui::{Phase, PhaseLogEntry, PhaseStatus, ProgressUI};
 pub use prompt::{
     frontier_model_name, load_system_prompt, prepend_bullets, ContextFile, ProjectContext,
     PromptBuildError, SystemPromptBuilder, SYSTEM_PROMPT_DYNAMIC_BOUNDARY,
+};
+pub use recovery::{
+    assess_recovery_state, exit_state_record_path, latest_session_record_path,
+    persist_recovery_state, read_exit_state, read_latest_session, recovery_dir,
+    recovery_summary_path, render_recovery_summary, write_recovery_summary, ExitStateRecord,
+    LatestSessionRecord, PersistedRecoveryState, RecoveryAssessment, RecoveryAvailability,
+    RecoveryError, RecoveryExitState, RecoverySessionPathKind, RecoveryStateUpdate,
+    EXIT_STATE_FILE, LATEST_SESSION_FILE, RECOVERY_DIR, RECOVERY_SCHEMA_VERSION,
+    RECOVERY_SUMMARY_FILE,
 };
 pub use recovery_recipes::{
     attempt_recovery, recipe_for, EscalationPolicy, FailureScenario, RecoveryContext,

--- a/rust/crates/runtime/src/recovery.rs
+++ b/rust/crates/runtime/src/recovery.rs
@@ -1,0 +1,624 @@
+use std::fmt::{Display, Formatter, Write as _};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+pub const RECOVERY_SCHEMA_VERSION: u32 = 1;
+pub const RECOVERY_DIR: &str = ".sego/recovery";
+pub const LATEST_SESSION_FILE: &str = "latest-session.json";
+pub const EXIT_STATE_FILE: &str = "exit-state.json";
+pub const RECOVERY_SUMMARY_FILE: &str = "recovery-summary.md";
+
+#[derive(Debug)]
+pub enum RecoveryError {
+    Io { path: PathBuf, source: io::Error },
+    Json { path: PathBuf, source: serde_json::Error },
+    InvalidRecord { path: PathBuf, message: String },
+}
+
+impl Display for RecoveryError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, source } => {
+                write!(f, "{}: {source}", path.display())
+            }
+            Self::Json { path, source } => {
+                write!(f, "invalid recovery JSON at {}: {source}", path.display())
+            }
+            Self::InvalidRecord { path, message } => {
+                write!(f, "invalid recovery record at {}: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for RecoveryError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoverySessionPathKind {
+    Absolute,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryExitState {
+    Active,
+    Graceful,
+    Interrupted,
+    Crashed,
+    Unknown,
+}
+
+impl RecoveryExitState {
+    #[must_use]
+    pub const fn is_potentially_recoverable(self) -> bool {
+        !matches!(self, Self::Graceful)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryAvailability {
+    NoState,
+    CleanExit,
+    Recoverable,
+    MissingSession,
+    UnreadableState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LatestSessionRecord {
+    pub schema_version: u32,
+    pub session_id: String,
+    pub session_path: PathBuf,
+    pub session_path_kind: RecoverySessionPathKind,
+    pub cwd: PathBuf,
+    pub model: Option<String>,
+    pub updated_at_epoch_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExitStateRecord {
+    pub schema_version: u32,
+    pub session_id: String,
+    pub state: RecoveryExitState,
+    pub last_seen_at_epoch_seconds: u64,
+    pub last_user_goal: Option<String>,
+    pub last_error: Option<String>,
+    pub session_path: PathBuf,
+    pub session_path_kind: RecoverySessionPathKind,
+    pub cwd: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryStateUpdate {
+    pub session_id: String,
+    pub session_path: PathBuf,
+    pub cwd: PathBuf,
+    pub model: Option<String>,
+    pub state: RecoveryExitState,
+    pub last_user_goal: Option<String>,
+    pub last_error: Option<String>,
+    pub observed_at_epoch_seconds: u64,
+}
+
+impl RecoveryStateUpdate {
+    #[must_use]
+    pub fn new(
+        session_id: impl Into<String>,
+        session_path: impl Into<PathBuf>,
+        cwd: impl Into<PathBuf>,
+        state: RecoveryExitState,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            session_path: session_path.into(),
+            cwd: cwd.into(),
+            model: None,
+            state,
+            last_user_goal: None,
+            last_error: None,
+            observed_at_epoch_seconds: current_epoch_seconds(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_model(mut self, model: impl Into<Option<String>>) -> Self {
+        self.model = normalize_optional_string(model.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_last_user_goal(mut self, goal: impl Into<Option<String>>) -> Self {
+        self.last_user_goal = normalize_optional_string(goal.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_last_error(mut self, error: impl Into<Option<String>>) -> Self {
+        self.last_error = normalize_optional_string(error.into());
+        self
+    }
+
+    #[must_use]
+    pub const fn with_observed_at_epoch_seconds(mut self, observed_at_epoch_seconds: u64) -> Self {
+        self.observed_at_epoch_seconds = observed_at_epoch_seconds;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedRecoveryState {
+    pub latest_session: LatestSessionRecord,
+    pub exit_state: ExitStateRecord,
+    pub latest_session_path: PathBuf,
+    pub exit_state_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryAssessment {
+    pub availability: RecoveryAvailability,
+    pub latest_session: Option<LatestSessionRecord>,
+    pub exit_state: Option<ExitStateRecord>,
+    pub message: String,
+}
+
+#[must_use]
+pub fn recovery_dir(workspace_root: &Path) -> PathBuf {
+    workspace_root.join(RECOVERY_DIR)
+}
+
+#[must_use]
+pub fn latest_session_record_path(workspace_root: &Path) -> PathBuf {
+    recovery_dir(workspace_root).join(LATEST_SESSION_FILE)
+}
+
+#[must_use]
+pub fn exit_state_record_path(workspace_root: &Path) -> PathBuf {
+    recovery_dir(workspace_root).join(EXIT_STATE_FILE)
+}
+
+#[must_use]
+pub fn recovery_summary_path(workspace_root: &Path) -> PathBuf {
+    recovery_dir(workspace_root).join(RECOVERY_SUMMARY_FILE)
+}
+
+pub fn persist_recovery_state(
+    workspace_root: &Path,
+    update: RecoveryStateUpdate,
+) -> Result<PersistedRecoveryState, RecoveryError> {
+    let session_path = absolute_path(workspace_root, update.session_path);
+    let cwd = absolute_path(workspace_root, update.cwd);
+
+    let latest_session = LatestSessionRecord {
+        schema_version: RECOVERY_SCHEMA_VERSION,
+        session_id: update.session_id.clone(),
+        session_path: session_path.clone(),
+        session_path_kind: RecoverySessionPathKind::Absolute,
+        cwd: cwd.clone(),
+        model: update.model,
+        updated_at_epoch_seconds: update.observed_at_epoch_seconds,
+    };
+    validate_latest_session(&latest_session, &latest_session_record_path(workspace_root))?;
+
+    let exit_state = ExitStateRecord {
+        schema_version: RECOVERY_SCHEMA_VERSION,
+        session_id: update.session_id,
+        state: update.state,
+        last_seen_at_epoch_seconds: update.observed_at_epoch_seconds,
+        last_user_goal: update.last_user_goal,
+        last_error: update.last_error,
+        session_path,
+        session_path_kind: RecoverySessionPathKind::Absolute,
+        cwd,
+    };
+    validate_exit_state(&exit_state, &exit_state_record_path(workspace_root))?;
+
+    let latest_session_path = latest_session_record_path(workspace_root);
+    let exit_state_path = exit_state_record_path(workspace_root);
+    write_json(&latest_session_path, &latest_session)?;
+    write_json(&exit_state_path, &exit_state)?;
+
+    Ok(PersistedRecoveryState { latest_session, exit_state, latest_session_path, exit_state_path })
+}
+
+pub fn read_latest_session(
+    workspace_root: &Path,
+) -> Result<Option<LatestSessionRecord>, RecoveryError> {
+    let path = latest_session_record_path(workspace_root);
+    let Some(record) = read_json::<LatestSessionRecord>(&path)? else {
+        return Ok(None);
+    };
+    validate_latest_session(&record, &path)?;
+    Ok(Some(record))
+}
+
+pub fn read_exit_state(workspace_root: &Path) -> Result<Option<ExitStateRecord>, RecoveryError> {
+    let path = exit_state_record_path(workspace_root);
+    let Some(record) = read_json::<ExitStateRecord>(&path)? else {
+        return Ok(None);
+    };
+    validate_exit_state(&record, &path)?;
+    Ok(Some(record))
+}
+
+#[must_use]
+pub fn assess_recovery_state(workspace_root: &Path) -> RecoveryAssessment {
+    let latest_session = match read_latest_session(workspace_root) {
+        Ok(record) => record,
+        Err(error) => return unreadable_assessment(error.to_string()),
+    };
+
+    let exit_state = match read_exit_state(workspace_root) {
+        Ok(record) => record,
+        Err(error) => return unreadable_assessment(error.to_string()),
+    };
+
+    let Some(exit_state) = exit_state else {
+        return RecoveryAssessment {
+            availability: RecoveryAvailability::NoState,
+            latest_session,
+            exit_state: None,
+            message: "no recovery state found".to_string(),
+        };
+    };
+
+    let availability = if !exit_state.state.is_potentially_recoverable() {
+        RecoveryAvailability::CleanExit
+    } else if exit_state.session_path.exists() {
+        RecoveryAvailability::Recoverable
+    } else {
+        RecoveryAvailability::MissingSession
+    };
+
+    let message = match availability {
+        RecoveryAvailability::CleanExit => "previous session exited cleanly".to_string(),
+        RecoveryAvailability::Recoverable => {
+            "previous session may not have ended normally".to_string()
+        }
+        RecoveryAvailability::MissingSession => {
+            "previous session may be recoverable, but its session file is missing".to_string()
+        }
+        RecoveryAvailability::NoState | RecoveryAvailability::UnreadableState => {
+            "no recovery state found".to_string()
+        }
+    };
+
+    RecoveryAssessment { availability, latest_session, exit_state: Some(exit_state), message }
+}
+
+#[must_use]
+pub fn render_recovery_summary(assessment: &RecoveryAssessment) -> String {
+    let mut summary = String::new();
+    let _ = writeln!(summary, "# Sego Recovery Summary");
+    let _ = writeln!(summary);
+    let _ = writeln!(summary, "- availability: {:?}", assessment.availability);
+    let _ = writeln!(summary, "- message: {}", assessment.message);
+
+    if let Some(exit_state) = &assessment.exit_state {
+        let _ = writeln!(summary, "- session_id: {}", exit_state.session_id);
+        let _ = writeln!(summary, "- state: {:?}", exit_state.state);
+        let _ = writeln!(
+            summary,
+            "- last_seen_at_epoch_seconds: {}",
+            exit_state.last_seen_at_epoch_seconds
+        );
+        let _ = writeln!(summary, "- session_path: {}", exit_state.session_path.display());
+        let _ = writeln!(summary, "- cwd: {}", exit_state.cwd.display());
+        if let Some(goal) = &exit_state.last_user_goal {
+            let _ = writeln!(summary, "- last_user_goal: {goal}");
+        }
+        if let Some(error) = &exit_state.last_error {
+            let _ = writeln!(summary, "- last_error: {error}");
+        }
+    }
+
+    if let Some(latest_session) = &assessment.latest_session {
+        let _ = writeln!(summary, "- model: {}", latest_session.model.as_deref().unwrap_or("n/a"));
+        let _ = writeln!(
+            summary,
+            "- updated_at_epoch_seconds: {}",
+            latest_session.updated_at_epoch_seconds
+        );
+    }
+
+    let _ = writeln!(summary);
+    let _ = writeln!(summary, "## Suggested Commands");
+    let _ = writeln!(summary);
+    let _ = writeln!(summary, "```powershell");
+    let _ = writeln!(summary, "sego --resume latest /status");
+    let _ = writeln!(summary, "sego --resume latest /recovery-export");
+    let _ = writeln!(summary, "```");
+
+    summary
+}
+
+pub fn write_recovery_summary(
+    workspace_root: &Path,
+    assessment: &RecoveryAssessment,
+) -> Result<PathBuf, RecoveryError> {
+    let path = recovery_summary_path(workspace_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|source| RecoveryError::Io { path: parent.to_path_buf(), source })?;
+    }
+    fs::write(&path, render_recovery_summary(assessment))
+        .map_err(|source| RecoveryError::Io { path: path.clone(), source })?;
+    Ok(path)
+}
+
+fn unreadable_assessment(message: String) -> RecoveryAssessment {
+    RecoveryAssessment {
+        availability: RecoveryAvailability::UnreadableState,
+        latest_session: None,
+        exit_state: None,
+        message,
+    }
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), RecoveryError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|source| RecoveryError::Io { path: parent.to_path_buf(), source })?;
+    }
+    let mut body = serde_json::to_string_pretty(value)
+        .map_err(|source| RecoveryError::Json { path: path.to_path_buf(), source })?;
+    body.push('\n');
+    fs::write(path, body).map_err(|source| RecoveryError::Io { path: path.to_path_buf(), source })
+}
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> Result<Option<T>, RecoveryError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let body = fs::read_to_string(path)
+        .map_err(|source| RecoveryError::Io { path: path.to_path_buf(), source })?;
+    let record = serde_json::from_str(&body)
+        .map_err(|source| RecoveryError::Json { path: path.to_path_buf(), source })?;
+    Ok(Some(record))
+}
+
+fn validate_latest_session(record: &LatestSessionRecord, path: &Path) -> Result<(), RecoveryError> {
+    validate_schema_version(record.schema_version, path)?;
+    validate_absolute_path("session_path", &record.session_path, path)?;
+    validate_absolute_path("cwd", &record.cwd, path)?;
+    if record.session_path_kind != RecoverySessionPathKind::Absolute {
+        return Err(invalid_record(path, "session_path_kind must be absolute"));
+    }
+    Ok(())
+}
+
+fn validate_exit_state(record: &ExitStateRecord, path: &Path) -> Result<(), RecoveryError> {
+    validate_schema_version(record.schema_version, path)?;
+    validate_absolute_path("session_path", &record.session_path, path)?;
+    validate_absolute_path("cwd", &record.cwd, path)?;
+    if record.session_path_kind != RecoverySessionPathKind::Absolute {
+        return Err(invalid_record(path, "session_path_kind must be absolute"));
+    }
+    Ok(())
+}
+
+fn validate_schema_version(version: u32, path: &Path) -> Result<(), RecoveryError> {
+    if version != RECOVERY_SCHEMA_VERSION {
+        return Err(invalid_record(
+            path,
+            format!("unsupported schema_version {version}; expected {RECOVERY_SCHEMA_VERSION}"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_absolute_path(
+    field: &'static str,
+    value: &Path,
+    record_path: &Path,
+) -> Result<(), RecoveryError> {
+    if !value.is_absolute() {
+        return Err(invalid_record(
+            record_path,
+            format!("{field} must be an absolute path: {}", value.display()),
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_record(path: &Path, message: impl Into<String>) -> RecoveryError {
+    RecoveryError::InvalidRecord { path: path.to_path_buf(), message: message.into() }
+}
+
+fn absolute_path(base: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn current_epoch_seconds() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_persists_absolute_session_paths() {
+        let root = temp_dir("absolute-paths");
+        let relative_session = PathBuf::from(".claw").join("sessions").join("session.jsonl");
+        let absolute_session = root.join(&relative_session);
+        fs::create_dir_all(absolute_session.parent().expect("session parent"))
+            .expect("create session dir");
+        fs::write(&absolute_session, "{}\n").expect("write session");
+
+        let persisted = persist_recovery_state(
+            &root,
+            RecoveryStateUpdate::new(
+                "session-1",
+                relative_session,
+                root.clone(),
+                RecoveryExitState::Active,
+            )
+            .with_model(Some("deepseek-v4-flash".to_string()))
+            .with_last_user_goal(Some("finish crash recovery".to_string()))
+            .with_observed_at_epoch_seconds(42),
+        )
+        .expect("persist recovery state");
+
+        assert_eq!(persisted.latest_session.session_path, absolute_session);
+        assert_eq!(persisted.exit_state.session_path, absolute_session);
+        assert_eq!(persisted.latest_session.session_path_kind, RecoverySessionPathKind::Absolute);
+        assert_eq!(persisted.exit_state.session_path_kind, RecoverySessionPathKind::Absolute);
+
+        let latest = read_latest_session(&root).expect("read latest").expect("latest exists");
+        let exit = read_exit_state(&root).expect("read exit").expect("exit exists");
+        assert_eq!(latest.session_path, absolute_session);
+        assert_eq!(exit.session_path, absolute_session);
+        assert_eq!(exit.last_user_goal.as_deref(), Some("finish crash recovery"));
+        cleanup_temp_dir(root);
+    }
+
+    #[test]
+    fn recovery_assesses_active_session_as_recoverable() {
+        let root = temp_dir("recoverable");
+        let session_path = root.join(".claw").join("sessions").join("session.jsonl");
+        fs::create_dir_all(session_path.parent().expect("session parent"))
+            .expect("create session dir");
+        fs::write(&session_path, "{}\n").expect("write session");
+
+        persist_recovery_state(
+            &root,
+            RecoveryStateUpdate::new(
+                "session-2",
+                session_path.clone(),
+                root.clone(),
+                RecoveryExitState::Active,
+            ),
+        )
+        .expect("persist recovery state");
+
+        let assessment = assess_recovery_state(&root);
+        assert_eq!(assessment.availability, RecoveryAvailability::Recoverable);
+        assert_eq!(assessment.exit_state.expect("exit state").session_path, session_path);
+        cleanup_temp_dir(root);
+    }
+
+    #[test]
+    fn recovery_assesses_graceful_session_as_clean_exit() {
+        let root = temp_dir("graceful");
+        let session_path = root.join(".claw").join("sessions").join("session.jsonl");
+        fs::create_dir_all(session_path.parent().expect("session parent"))
+            .expect("create session dir");
+        fs::write(&session_path, "{}\n").expect("write session");
+
+        persist_recovery_state(
+            &root,
+            RecoveryStateUpdate::new(
+                "session-3",
+                session_path,
+                root.clone(),
+                RecoveryExitState::Graceful,
+            ),
+        )
+        .expect("persist recovery state");
+
+        let assessment = assess_recovery_state(&root);
+        assert_eq!(assessment.availability, RecoveryAvailability::CleanExit);
+        cleanup_temp_dir(root);
+    }
+
+    #[test]
+    fn recovery_assesses_missing_session_file_without_panicking() {
+        let root = temp_dir("missing-session");
+        let session_path = root.join(".claw").join("sessions").join("missing.jsonl");
+
+        persist_recovery_state(
+            &root,
+            RecoveryStateUpdate::new(
+                "session-4",
+                session_path,
+                root.clone(),
+                RecoveryExitState::Interrupted,
+            ),
+        )
+        .expect("persist recovery state");
+
+        let assessment = assess_recovery_state(&root);
+        assert_eq!(assessment.availability, RecoveryAvailability::MissingSession);
+        cleanup_temp_dir(root);
+    }
+
+    #[test]
+    fn recovery_reports_invalid_json_without_panicking() {
+        let root = temp_dir("invalid-json");
+        let recovery_dir = recovery_dir(&root);
+        fs::create_dir_all(&recovery_dir).expect("create recovery dir");
+        fs::write(exit_state_record_path(&root), "{not-json").expect("write invalid json");
+
+        let assessment = assess_recovery_state(&root);
+        assert_eq!(assessment.availability, RecoveryAvailability::UnreadableState);
+        assert!(assessment.message.contains("invalid recovery JSON"));
+        cleanup_temp_dir(root);
+    }
+
+    #[test]
+    fn recovery_summary_includes_resume_commands_and_absolute_session_path() {
+        let root = temp_dir("summary");
+        let session_path = root.join(".claw").join("sessions").join("session.jsonl");
+        fs::create_dir_all(session_path.parent().expect("session parent"))
+            .expect("create session dir");
+        fs::write(&session_path, "{}\n").expect("write session");
+
+        persist_recovery_state(
+            &root,
+            RecoveryStateUpdate::new(
+                "session-5",
+                session_path.clone(),
+                root.clone(),
+                RecoveryExitState::Crashed,
+            )
+            .with_last_error(Some("window closed".to_string())),
+        )
+        .expect("persist recovery state");
+
+        let assessment = assess_recovery_state(&root);
+        let summary = render_recovery_summary(&assessment);
+        assert!(summary.contains("sego --resume latest /status"));
+        assert!(summary.contains("sego --resume latest /recovery-export"));
+        assert!(summary.contains(&session_path.display().to_string()));
+
+        let summary_path = write_recovery_summary(&root, &assessment).expect("write summary");
+        assert_eq!(summary_path, recovery_summary_path(&root));
+        cleanup_temp_dir(root);
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let unique = SystemTime::now().duration_since(UNIX_EPOCH).expect("system time").as_nanos();
+        let path = std::env::temp_dir().join(format!("sego-recovery-{name}-{unique}"));
+        fs::create_dir_all(&path).expect("create temp dir");
+        path
+    }
+
+    fn cleanup_temp_dir(path: PathBuf) {
+        if let Err(error) = fs::remove_dir_all(&path) {
+            if error.kind() != io::ErrorKind::NotFound {
+                panic!("failed to cleanup {}: {error}", path.display());
+            }
+        }
+    }
+}

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -184,7 +184,20 @@ Run `sego --help` for usage."
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().skip(1).collect();
-    match parse_args(&args)? {
+    let action = parse_args(&args)?;
+
+    // A2 启动提示层：只对会创建/恢复可持久化 session 且可能执行模型/工具的动作触发。
+    // 只读 recovery JSON，不写、不扫描、不调模型（Codex 审查两层架构第 1 层）。
+    let triggers_recovery = matches!(
+        action,
+        CliAction::Repl { .. }
+            | CliAction::Prompt { .. }
+            | CliAction::CodeReview { .. }
+            | CliAction::ResumeSession { .. }
+    );
+    maybe_print_recovery_notice(triggers_recovery);
+
+    match action {
         CliAction::DumpManifests => dump_manifests(),
         CliAction::BootstrapPlan => print_bootstrap_plan(),
         CliAction::Agents { args } => LiveCli::print_agents(args.as_deref())?,
@@ -200,8 +213,24 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         CliAction::Sandbox { output_format } => print_sandbox_status_snapshot(output_format)?,
         CliAction::Prompt { prompt, model, output_format, allowed_tools, permission_mode } => {
-            LiveCli::new(model, true, allowed_tools, permission_mode)?
-                .run_turn_with_output(&prompt, output_format)?;
+            // A2 session 状态写入：active 在 LiveCli 创建后写，graceful 在成功返回后写。
+            // 错误路径（?返回 / 崩溃）不写 graceful，保留 active，下次启动提示可恢复。
+            let mut cli = LiveCli::new(model.clone(), true, allowed_tools, permission_mode)?;
+            persist_recovery_for_cli(
+                runtime::recovery::RecoveryExitState::Active,
+                cli.session_id(),
+                cli.session_path(),
+                Some(cli.model_name()),
+                Some(&prompt),
+            );
+            cli.run_turn_with_output(&prompt, output_format)?;
+            persist_recovery_for_cli(
+                runtime::recovery::RecoveryExitState::Graceful,
+                cli.session_id(),
+                cli.session_path(),
+                Some(cli.model_name()),
+                Some(&prompt),
+            );
         }
         CliAction::CodeReview { scope, model, allowed_tools, permission_mode } => {
             run_code_review_cli(model, allowed_tools, permission_mode, scope.as_deref())?;
@@ -1055,11 +1084,30 @@ fn resume_session(session_path: &Path, commands: &[String]) {
         }
     };
 
+    // A2 session 状态写入：session 加载成功后写 active。
+    // commands 全部成功完成后写 graceful（函数末尾）。
+    // 错误路径（process::exit）不写 graceful，保留 active。
+    persist_recovery_for_cli(
+        runtime::recovery::RecoveryExitState::Active,
+        &session.session_id,
+        &resolved_path,
+        None,
+        None,
+    );
+
     if commands.is_empty() {
         println!(
             "Restored session from {} ({} messages).",
             resolved_path.display(),
             session.messages.len()
+        );
+        // 无命令的纯恢复视为正常退出。
+        persist_recovery_for_cli(
+            runtime::recovery::RecoveryExitState::Graceful,
+            &session.session_id,
+            &resolved_path,
+            None,
+            None,
         );
         return;
     }
@@ -1090,6 +1138,15 @@ fn resume_session(session_path: &Path, commands: &[String]) {
             }
         }
     }
+
+    // 所有 resume 命令成功完成，写 graceful。
+    persist_recovery_for_cli(
+        runtime::recovery::RecoveryExitState::Graceful,
+        &session.session_id,
+        &resolved_path,
+        None,
+        None,
+    );
 }
 
 #[derive(Debug, Clone)]
@@ -1554,6 +1611,16 @@ fn run_resume_command(
                 )),
             })
         }
+        SlashCommand::RecoveryExport { path } => {
+            let export_path = write_recovery_export(path.as_deref())?;
+            Ok(ResumeCommandOutcome {
+                session: session.clone(),
+                message: Some(format!(
+                    "RecoveryExport\n  Result           wrote recovery summary\n  File             {}",
+                    export_path.display(),
+                )),
+            })
+        }
         SlashCommand::Agents { args } => {
             let cwd = env::current_dir()?;
             Ok(ResumeCommandOutcome {
@@ -1635,6 +1702,17 @@ fn run_repl(
         input::LineEditor::new("> ", cli.repl_completion_candidates().unwrap_or_default());
     println!("{}", cli.startup_banner());
 
+    // A2 session 状态写入：进入 REPL 写 active。
+    // 正常退出（/exit、/quit、ReadOutcome::Exit）写 graceful。
+    // 错误路径（?返回 / 崩溃 / Ctrl+C）不写 graceful，保留 active，下次启动提示可恢复。
+    persist_recovery_for_cli(
+        runtime::recovery::RecoveryExitState::Active,
+        cli.session_id(),
+        cli.session_path(),
+        Some(cli.model_name()),
+        None,
+    );
+
     loop {
         editor.set_completions(cli.repl_completion_candidates().unwrap_or_default());
         match editor.read_line()? {
@@ -1645,6 +1723,13 @@ fn run_repl(
                 }
                 if matches!(trimmed.as_str(), "/exit" | "/quit") {
                     cli.persist_session()?;
+                    persist_recovery_for_cli(
+                        runtime::recovery::RecoveryExitState::Graceful,
+                        cli.session_id(),
+                        cli.session_path(),
+                        Some(cli.model_name()),
+                        None,
+                    );
                     break;
                 }
                 match SlashCommand::parse(&trimmed) {
@@ -1666,6 +1751,13 @@ fn run_repl(
             input::ReadOutcome::Cancel => {}
             input::ReadOutcome::Exit => {
                 cli.persist_session()?;
+                persist_recovery_for_cli(
+                    runtime::recovery::RecoveryExitState::Graceful,
+                    cli.session_id(),
+                    cli.session_path(),
+                    Some(cli.model_name()),
+                    None,
+                );
                 break;
             }
         }
@@ -2179,6 +2271,21 @@ impl LiveCli {
         Ok(cli)
     }
 
+    /// 当前 session id（用于 recovery state 写入）。
+    fn session_id(&self) -> &str {
+        &self.session.id
+    }
+
+    /// 当前 session 文件路径（用于 recovery state 写入）。
+    fn session_path(&self) -> &Path {
+        &self.session.path
+    }
+
+    /// 当前模型名（用于 recovery state 写入）。
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
     fn startup_banner(&self) -> String {
         let cwd = env::current_dir()
             .map_or_else(|_| "<unknown>".to_string(), |path| path.display().to_string());
@@ -2488,6 +2595,14 @@ impl LiveCli {
             }
             SlashCommand::Export { path } => {
                 self.export_session(path.as_deref())?;
+                false
+            }
+            SlashCommand::RecoveryExport { path } => {
+                let export_path = write_recovery_export(path.as_deref())?;
+                println!(
+                    "RecoveryExport\n  Result           wrote recovery summary\n  File             {}",
+                    export_path.display(),
+                );
                 false
             }
             SlashCommand::Session { action, target } => {
@@ -3136,6 +3251,96 @@ fn create_managed_session_handle(
     let id = session_id.to_string();
     let path = sessions_dir()?.join(format!("{id}.{PRIMARY_SESSION_EXTENSION}"));
     Ok(SessionHandle { id, path })
+}
+
+// ---------------------------------------------------------------------------
+// Crash recovery CLI 集成（A2）
+//
+// 设计依据：sego-c9-a2-zcode-handoff-2026-06-15.md + Codex 架构审查
+// 两层架构：
+//   1. 启动提示层 maybe_print_recovery_notice —— parse_args 后只读 recovery JSON
+//   2. session 状态写入层 persist_recovery_for_cli —— session handle 已知后写
+// 不在 parse_args 后立即写 active（session id/path 那时不可用，Codex 审查问题③）
+// 不用 Drop guard 写 graceful（fallible IO 不清晰，Codex 审查 §4.3）
+// ---------------------------------------------------------------------------
+
+/// 启动提示层：parse_args 后调用，只读 recovery JSON，不写、不扫描、不调模型。
+///
+/// 仅对会创建/恢复可持久化 session 且可能执行模型/工具的动作触发提示
+/// （Repl / Prompt / CodeReview / ResumeSession）。对 Version/Help 等纯查询动作不触发。
+fn maybe_print_recovery_notice(should_check: bool) {
+    if !should_check {
+        return;
+    }
+    let Ok(workspace_root) = env::current_dir() else {
+        return;
+    };
+    let assessment = runtime::recovery::assess_recovery_state(&workspace_root);
+    if assessment.availability == runtime::recovery::RecoveryAvailability::Recoverable
+        || assessment.availability == runtime::recovery::RecoveryAvailability::MissingSession
+    {
+        println!("{}", assessment.message);
+        println!("hint: run `sego --resume latest` to restore the previous session.");
+    }
+}
+
+/// session 状态写入层：在 session handle 已知后调用，写入完整 recovery record。
+///
+/// 错误路径（进程崩溃 / Ctrl+C / 窗口关闭）不会调用本函数写 graceful，
+/// 因此 exit-state 保留上次的 active，下次启动提示可恢复。
+fn persist_recovery_for_cli(
+    state: runtime::recovery::RecoveryExitState,
+    session_id: &str,
+    session_path: &Path,
+    model: Option<&str>,
+    last_user_goal: Option<&str>,
+) {
+    let Ok(workspace_root) = env::current_dir() else {
+        return;
+    };
+    let Ok(cwd) = env::current_dir() else {
+        return;
+    };
+    let mut update =
+        runtime::recovery::RecoveryStateUpdate::new(session_id, session_path, cwd, state);
+    if let Some(model) = model {
+        update = update.with_model(model.to_string());
+    }
+    if let Some(goal) = last_user_goal {
+        update = update.with_last_user_goal(goal.to_string());
+    }
+    // recovery 写入失败不应影响主流程，只记录到 stderr。
+    if let Err(error) = runtime::recovery::persist_recovery_state(&workspace_root, update) {
+        eprintln!("warning: failed to persist recovery state: {error}");
+    }
+}
+
+/// `/recovery-export` 的共享实现：读取当前 recovery 状态，渲染 summary，写文件。
+///
+/// resume 模式和 REPL 模式共用此 helper（Codex 审查 §2.3 建议），
+/// 避免"registered but not yet implemented"的断裂体验。
+///
+/// 路径语义：
+/// - 用户传 path → 尊重用户路径，不强制 .txt（区别于 /export 的 resolve_export_path）
+/// - 用户不传 path → 默认写到 .sego/recovery/recovery-summary.md
+fn write_recovery_export(
+    requested_path: Option<&str>,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let workspace_root = env::current_dir()?;
+    let assessment = runtime::recovery::assess_recovery_state(&workspace_root);
+    let summary = runtime::recovery::render_recovery_summary(&assessment);
+
+    let final_path = match requested_path {
+        Some(path) if !path.trim().is_empty() => PathBuf::from(path),
+        _ => runtime::recovery::recovery_summary_path(&workspace_root),
+    };
+    if let Some(parent) = final_path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    fs::write(&final_path, summary)?;
+    Ok(final_path)
 }
 
 fn resolve_session_reference(reference: &str) -> Result<SessionHandle, Box<dyn std::error::Error>> {
@@ -4039,7 +4244,24 @@ fn run_code_review_cli(
         return Ok(());
     }
 
-    LiveCli::new(model, true, allowed_tools, permission_mode)?.run_review_target(target)
+    // A2 session 状态写入：active 在 LiveCli 创建后写，graceful 在成功返回后写。
+    let mut cli = LiveCli::new(model, true, allowed_tools, permission_mode)?;
+    persist_recovery_for_cli(
+        runtime::recovery::RecoveryExitState::Active,
+        cli.session_id(),
+        cli.session_path(),
+        Some(cli.model_name()),
+        Some(scope.unwrap_or("code-review")),
+    );
+    cli.run_review_target(target)?;
+    persist_recovery_for_cli(
+        runtime::recovery::RecoveryExitState::Graceful,
+        cli.session_id(),
+        cli.session_path(),
+        Some(cli.model_name()),
+        Some(scope.unwrap_or("code-review")),
+    );
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/scripts/sego-resume.bat
+++ b/scripts/sego-resume.bat
@@ -1,0 +1,38 @@
+@echo off
+REM sego-resume.bat - Resume the latest Sego session after a crash or interruption.
+REM
+REM Usage:
+REM   sego-resume                  Restore latest session, enter REPL
+REM   sego-resume /status          Show status of restored session
+REM   sego-resume /recovery-export Export recovery summary to .sego/recovery/recovery-summary.md
+REM   sego-resume latest /status   Equivalent (explicit "latest" alias)
+REM
+REM Any extra args are forwarded to the resumed session.
+
+setlocal enabledelayedexpansion
+
+REM Locate the sego binary: prefer a local cargo build, then PATH.
+set "SEGO_BIN="
+
+if exist "%~dp0..\rust\target\debug\sego.exe" (
+    set "SEGO_BIN=%~dp0..\rust\target\debug\sego.exe"
+) else if defined CARGO_TARGET_DIR (
+    if exist "%CARGO_TARGET_DIR%\debug\sego.exe" (
+        set "SEGO_BIN=%CARGO_TARGET_DIR%\debug\sego.exe"
+    )
+)
+
+if not defined SEGO_BIN (
+    where sego >nul 2>nul
+    if !errorlevel! equ 0 (
+        set "SEGO_BIN=sego"
+    ) else (
+        echo sego-resume: sego binary not found.
+        echo Build it first with:  cargo build -p rusty-claude-cli
+        echo Or ensure 'sego' is on your PATH.
+        exit /b 1
+    )
+)
+
+"%SEGO_BIN%" --resume latest %*
+endlocal

--- a/scripts/sego-resume.sh
+++ b/scripts/sego-resume.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# sego-resume.sh - Resume the latest Sego session after a crash or interruption.
+#
+# Usage:
+#   sego-resume                  Restore latest session, enter REPL
+#   sego-resume /status          Show status of restored session
+#   sego-resume /recovery-export Export recovery summary to .sego/recovery/recovery-summary.md
+#   sego-resume latest /status   Equivalent (explicit "latest" alias)
+#
+# Any extra args are forwarded to the resumed session.
+set -euo pipefail
+
+# Locate the sego binary: prefer a local cargo build, then PATH.
+SEGO_BIN=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -x "${SCRIPT_DIR}/../rust/target/debug/sego" ]]; then
+    SEGO_BIN="${SCRIPT_DIR}/../rust/target/debug/sego"
+elif [[ -n "${CARGO_TARGET_DIR:-}" && -x "${CARGO_TARGET_DIR}/debug/sego" ]]; then
+    SEGO_BIN="${CARGO_TARGET_DIR}/debug/sego"
+elif command -v sego >/dev/null 2>&1; then
+    SEGO_BIN="sego"
+else
+    echo "sego-resume: sego binary not found." >&2
+    echo "Build it first with:  cargo build -p rusty-claude-cli" >&2
+    echo "Or ensure 'sego' is on your PATH." >&2
+    exit 1
+fi
+
+exec "${SEGO_BIN}" --resume latest "$@"


### PR DESCRIPTION
feat(runtime): crash recovery & session resume (cycle 9 A1+A2)

## 摘要

为 Sego 新增 crash recovery / session resume 能力。进程异常中断后，下次启动检测到未正常结束的会话，提示用户恢复。支持 `sego --resume latest` 恢复、`/status` 查看状态、`/recovery-export` 导出恢复摘要。

---

## 变更内容

### A1：runtime recovery 模块（runtime/src/recovery.rs）

- 新增 `RecoveryState` / `RecoveryExitState` / `RecoveryAssessment` 数据结构
- `assess_recovery_state`：只读 `.sego/recovery/*.json`，不扫描、不调模型
- `persist_recovery_state`：原子写入 exit-state（active/graceful）
- `render_recovery_summary`：纯规则生成恢复摘要（不调模型）
- session_path 绝对路径存储（预防 .claw/.sego 双目录迁移问题）
- 68 个单元测试（recovery 22 + session 31 + recovery_recipes 15）

### A2：CLI 集成（main.rs + commands + scripts）

- 启动检测 `maybe_print_recovery_notice`：只对 Repl/Prompt/CodeReview/ResumeSession 触发，只读不写
- exit-state 两层架构：active 在 session handle 已知后写，graceful 在正常返回后写，错误路径保留 active
- 无 signal handler（MVP 决策，D-A2-2）
- `/recovery-export` 新命令：独立于 `/export`，导出 recovery summary（markdown），不强制 .txt
- `sego-resume.bat` / `sego-resume.sh`：跨平台恢复入口脚本
- LiveCli 新增 session_id/session_path/model_name getter

## 测试

| 套件 | 结果 |
|------|------|
| `cargo test -p runtime recovery` | 22 passed |
| `cargo test -p runtime session` | 31 passed |
| `cargo test -p runtime recovery_recipes` | 15 passed |
| `cargo test -p commands --lib` | 28 passed（含 2 个新增 recovery-export 测试） |
| `cargo test -p rusty-claude-cli` | 119 passed |
| `cargo fmt --all --check` | CLEAN |
| clippy | A1/A2 改动 0 新增 warning（基线 warning 来自 832f0ae） |

## 审查记录

- **A1 Sego review**: PASSED（10/10 checklist）
- **A2 Codex 架构审查**: passed_with_notes（3 处修正已落实）
- **A2 Sego review**: PASSED（8/8 checklist）

## 不变量（AGENTS.md 已记录）

- `recovery.rs` ≠ `recovery_recipes.rs`（不同功能，不混用）
- session_path 必须绝对路径
- 启动检测只对 Repl/Prompt/CodeReview/ResumeSession 4 个 action 触发
- active/graceful 写入在 session handle 已知后
- 无 signal handler（MVP）
- `/recovery-export` 独立于 `/export`
