### PR TITLE
feat(schema): formalize .sego artifact schemas (cycle 9 B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,3 +313,22 @@ fn git(args, cwd) { /* runs git command, asserts success */ }
 - Do not overwrite existing `AGENTS.md` content automatically; update it intentionally when repo workflows change
 - Always run `cargo test --workspace` before pushing
 - When in doubt, read `DEVELOPMENT.md` first
+
+## .sego Schema (c9/b)
+
+JSON Schema files in `schema/` are the **public contract** between the Rust
+engine and future TS sidecar / Python consumers. They are version-controlled
+and safe for GitHub.
+
+- `schema/review-artifact.schema.json` — aligned with `ReviewArtifact` (the
+  real on-disk structure in `.sego/reviews/{id}.json`, NOT `PersistedReviewArtifact`
+  which is just a path handle). Contains `schema_version`, `findings`, etc.
+- `schema/review-index-entry.schema.json` — aligned with `ReviewIndexEntry`
+  and `ReviewFindingStatusEntry`. Append-only index, no `schema_version`.
+- `schema/sidecar-request-response.schema.json` — minimal envelope for
+  sidecar <-> engine stdin/stdout JSON. Refined in Cycle 9 C.
+
+When changing any struct that has a schema file, **update the schema file too**.
+The golden fixture tests in `code_review/report.rs` verify serde round-trip
+consistency but do not validate against the JSON Schema file automatically.
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -642,3 +642,20 @@ git push                                    # Push to GitHub
 cd Sego-Agent
 python -m pytest tests/ -v
 ```
+
+### .sego Schema Formalization (c9/b)
+
+The `schema/` directory contains hand-written JSON Schema files that serve as
+the public contract for `.sego` artifacts. Aligned with Codex decision D-B-1~4:
+
+- Schemas are hand-written (no `schemars`/`jsonschema` runtime dependency).
+- Rust production path uses `serde` deserialization + golden fixture round-trip
+  tests; full JSON Schema validation is a future dev-dependency if needed.
+- `review-artifact.schema.json` aligns with `ReviewArtifact` (the real on-disk
+  struct), which already has `schema_version: u32` (currently hardcoded to 1).
+- `review-index-entry.schema.json` has no `schema_version` (append-only, stable).
+- `sidecar-request-response.schema.json` defines a minimal stable envelope;
+  Cycle 9 C refines action-specific fields during PoC.
+- When modifying a struct with a schema, update the schema file and the golden
+  fixture test together.
+

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -469,8 +469,9 @@ fn short_hash(hash: &str) -> &str {
 mod tests {
     use super::{
         latest_review_finding_statuses, load_review_finding_statuses, load_review_index,
-        persist_review_artifact, record_review_finding_status, review_diff_hash,
-        ReviewFindingStatus, ReviewParseStatus, ReviewReport,
+        persist_review_artifact, record_review_finding_status, review_diff_hash, ReviewArtifact,
+        ReviewFinding, ReviewFindingStatus, ReviewFindingStatusEntry, ReviewIndexEntry,
+        ReviewParseStatus, ReviewReport,
     };
     use crate::code_review::{ReviewScope, ReviewSeverity, ReviewTarget};
 
@@ -505,6 +506,137 @@ mod tests {
         assert!(index.contains(&artifact.id));
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn review_artifact_round_trips_through_json() {
+        // Golden fixture: construct a ReviewArtifact with a finding, serialize,
+        // deserialize, and verify every field survives the round-trip.
+        let artifact = ReviewArtifact {
+            schema_version: 1,
+            id: "rev-test-001".to_string(),
+            created_at_epoch_seconds: 1_719_849_600,
+            scope: "staged".to_string(),
+            diff_hash: "sha256:abc123".to_string(),
+            finding_count: 1,
+            highest_severity: Some(ReviewSeverity::High),
+            parse_status: ReviewParseStatus::Structured,
+            git_status: "## main...origin/main".to_string(),
+            findings: vec![ReviewFinding {
+                id: "f-001".to_string(),
+                severity: ReviewSeverity::High,
+                file: "src/lib.rs".to_string(),
+                line: Some(42),
+                title: "Missing error handling".to_string(),
+                evidence: "unwrap on result".to_string(),
+                risk: "panic in production".to_string(),
+                suggestion: "propagate the error".to_string(),
+                confidence: 0.91,
+                verification_hint: Some("cargo test".to_string()),
+            }],
+            raw_text: "raw model output".to_string(),
+        };
+
+        let json = serde_json::to_string(&artifact).expect("serialize artifact");
+        let parsed: ReviewArtifact = serde_json::from_str(&json).expect("deserialize artifact");
+
+        // Field-by-field round-trip verification.
+        assert_eq!(parsed.schema_version, 1);
+        assert_eq!(parsed.id, "rev-test-001");
+        assert_eq!(parsed.scope, "staged");
+        assert_eq!(parsed.diff_hash, "sha256:abc123");
+        assert_eq!(parsed.finding_count, 1);
+        assert_eq!(parsed.highest_severity, Some(ReviewSeverity::High));
+        assert_eq!(parsed.parse_status, ReviewParseStatus::Structured);
+        assert_eq!(parsed.findings.len(), 1);
+        assert_eq!(parsed.findings[0].severity, ReviewSeverity::High);
+        assert_eq!(parsed.findings[0].line, Some(42));
+        assert_eq!(parsed.findings[0].confidence, 0.91);
+        assert_eq!(parsed.raw_text, "raw model output");
+
+        // Enum serialization must be snake_case (aligned with schema).
+        assert!(json.contains(r#""severity":"high""#), "severity must be snake_case: {json}");
+        assert!(
+            json.contains(r#""parse_status":"structured""#),
+            "parse_status must be snake_case: {json}"
+        );
+
+        // schema_version must be present in JSON (schema required field).
+        assert!(json.contains(r#""schema_version":1"#), "schema_version must be in JSON: {json}");
+
+        // finding_count must equal findings length (schema consistency).
+        assert_eq!(parsed.finding_count, parsed.findings.len());
+    }
+
+    #[test]
+    fn review_artifact_with_no_findings_round_trips() {
+        let artifact = ReviewArtifact {
+            schema_version: 1,
+            id: "rev-test-002".to_string(),
+            created_at_epoch_seconds: 1_719_849_600,
+            scope: "workspace".to_string(),
+            diff_hash: "sha256:none".to_string(),
+            finding_count: 0,
+            highest_severity: None,
+            parse_status: ReviewParseStatus::FallbackRawText,
+            git_status: String::new(),
+            findings: vec![],
+            raw_text: "No findings.".to_string(),
+        };
+
+        let json = serde_json::to_string(&artifact).expect("serialize");
+        let parsed: ReviewArtifact = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(parsed.finding_count, 0);
+        assert!(parsed.findings.is_empty());
+        assert_eq!(parsed.highest_severity, None);
+        // null severity must serialize correctly.
+        assert!(json.contains(r#""highest_severity":null"#), "null severity: {json}");
+    }
+
+    #[test]
+    fn review_index_entry_round_trips_through_json() {
+        let entry = ReviewIndexEntry {
+            id: "rev-test-003".to_string(),
+            created_at_epoch_seconds: 1_719_849_600,
+            scope: "staged".to_string(),
+            diff_hash: "sha256:def456".to_string(),
+            finding_count: 2,
+            highest_severity: Some(ReviewSeverity::Critical),
+            parse_status: ReviewParseStatus::Structured,
+            json_path: ".sego/reviews/rev-test-003.json".to_string(),
+            markdown_path: ".sego/reviews/rev-test-003.md".to_string(),
+        };
+
+        let json = serde_json::to_string(&entry).expect("serialize index entry");
+        let parsed: ReviewIndexEntry =
+            serde_json::from_str(&json).expect("deserialize index entry");
+
+        assert_eq!(parsed.id, entry.id);
+        assert_eq!(parsed.highest_severity, Some(ReviewSeverity::Critical));
+        assert_eq!(parsed.finding_count, 2);
+        // Index entries do NOT have schema_version (Codex D-B-2).
+        assert!(!json.contains("schema_version"), "index must not have schema_version: {json}");
+    }
+
+    #[test]
+    fn review_finding_status_entry_round_trips_through_json() {
+        let entry = ReviewFindingStatusEntry {
+            report_id: "rev-test-001".to_string(),
+            finding_id: "f-001".to_string(),
+            status: ReviewFindingStatus::Fixed,
+            note: Some("fixed in commit abc".to_string()),
+            updated_at_epoch_seconds: 1_719_849_700,
+        };
+
+        let json = serde_json::to_string(&entry).expect("serialize status entry");
+        let parsed: ReviewFindingStatusEntry =
+            serde_json::from_str(&json).expect("deserialize status entry");
+
+        assert_eq!(parsed.status, ReviewFindingStatus::Fixed);
+        assert_eq!(parsed.finding_id, "f-001");
+        // status must be snake_case.
+        assert!(json.contains(r#""status":"fixed""#), "status must be snake_case: {json}");
     }
 
     #[test]

--- a/schema/review-artifact.schema.json
+++ b/schema/review-artifact.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/007M7/Sego-Agent/blob/main/schema/review-artifact.schema.json",
+  "title": "Sego Review Artifact",
+  "description": "The persisted review artifact written to .sego/reviews/{id}.json. This is the canonical on-disk representation produced by Sego's code review workflow. Aligned with Rust struct ReviewArtifact in runtime/src/code_review/report.rs.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "id",
+    "created_at_epoch_seconds",
+    "scope",
+    "diff_hash",
+    "finding_count",
+    "parse_status",
+    "git_status",
+    "findings",
+    "raw_text"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "description": "Schema version for forward compatibility. Current version is 1.",
+      "const": 1
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique review artifact identifier, e.g. 'rev-20260615-001'.",
+      "minLength": 1
+    },
+    "created_at_epoch_seconds": {
+      "type": "integer",
+      "description": "Unix timestamp (seconds) when the review was created.",
+      "minimum": 0
+    },
+    "scope": {
+      "type": "string",
+      "description": "Review scope descriptor, e.g. 'staged', 'workspace', 'src/auth'."
+    },
+    "diff_hash": {
+      "type": "string",
+      "description": "Hash of the reviewed diff (binds review/verify/ship to the same code state)."
+    },
+    "finding_count": {
+      "type": "integer",
+      "description": "Number of findings. Must equal findings.length.",
+      "minimum": 0
+    },
+    "highest_severity": {
+      "description": "Highest severity among findings, or null if no findings. Optional in older artifacts.",
+      "oneOf": [
+        { "$ref": "#/$defs/severity" },
+        { "type": "null" }
+      ]
+    },
+    "parse_status": {
+      "$ref": "#/$defs/parse_status"
+    },
+    "git_status": {
+      "type": "string",
+      "description": "Git status snapshot at review time (e.g. '## main...origin/main')."
+    },
+    "findings": {
+      "type": "array",
+      "description": "Structured review findings.",
+      "items": { "$ref": "#/$defs/finding" }
+    },
+    "raw_text": {
+      "type": "string",
+      "description": "Raw model output text before parsing into findings."
+    }
+  },
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "description": "Review finding severity (snake_case, aligned with Rust ReviewSeverity).",
+      "enum": ["critical", "high", "medium", "low", "info"]
+    },
+    "parse_status": {
+      "type": "string",
+      "description": "How the model output was parsed (aligned with Rust ReviewParseStatus).",
+      "enum": ["structured", "fallback_raw_text"]
+    },
+    "finding": {
+      "type": "object",
+      "description": "A single structured review finding (aligned with Rust ReviewFinding).",
+      "required": [
+        "severity",
+        "file",
+        "title",
+        "evidence",
+        "risk",
+        "suggestion",
+        "confidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Finding identifier (e.g. 'f-001'). Has serde default; may be absent in legacy artifacts.",
+          "default": ""
+        },
+        "severity": { "$ref": "#/$defs/severity" },
+        "file": {
+          "type": "string",
+          "description": "File path relative to workspace root."
+        },
+        "line": {
+          "type": ["integer", "null"],
+          "description": "Line number, or null if not applicable.",
+          "minimum": 0
+        },
+        "title": {
+          "type": "string",
+          "description": "Short title summarizing the finding."
+        },
+        "evidence": {
+          "type": "string",
+          "description": "Code snippet or evidence supporting the finding."
+        },
+        "risk": {
+          "type": "string",
+          "description": "Risk description if the finding is not addressed."
+        },
+        "suggestion": {
+          "type": "string",
+          "description": "Suggested fix or mitigation."
+        },
+        "confidence": {
+          "type": "number",
+          "description": "Model confidence score (0.0 to 1.0).",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "verification_hint": {
+          "type": ["string", "null"],
+          "description": "Optional hint for how to verify the finding."
+        }
+      }
+    }
+  }
+}

--- a/schema/review-index-entry.schema.json
+++ b/schema/review-index-entry.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/007M7/Sego-Agent/blob/main/schema/review-index-entry.schema.json",
+  "title": "Sego Review Index Entry",
+  "description": "Append-only index entry for .sego/reviews/index.jsonl. Each line is one ReviewIndexEntry. Aligned with Rust ReviewIndexEntry in runtime/src/code_review/report.rs. No schema_version (Codex D-B-2: index stays simple/stable).",
+  "$ref": "#/$defs/review_index_entry",
+  "$defs": {
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low", "info"]
+    },
+    "parse_status": {
+      "type": "string",
+      "enum": ["structured", "fallback_raw_text"]
+    },
+    "finding_status": {
+      "type": "string",
+      "description": "Lifecycle status of a finding (aligned with Rust ReviewFindingStatus).",
+      "enum": ["open", "acknowledged", "fixed", "ignored"]
+    },
+    "review_index_entry": {
+      "type": "object",
+      "description": "One index entry summarizing a persisted review.",
+      "required": [
+        "id",
+        "created_at_epoch_seconds",
+        "scope",
+        "diff_hash",
+        "finding_count",
+        "parse_status",
+        "json_path",
+        "markdown_path"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at_epoch_seconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "scope": { "type": "string" },
+        "diff_hash": { "type": "string" },
+        "finding_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "highest_severity": {
+          "oneOf": [
+            { "$ref": "#/$defs/severity" },
+            { "type": "null" }
+          ]
+        },
+        "parse_status": { "$ref": "#/$defs/parse_status" },
+        "json_path": {
+          "type": "string",
+          "description": "Path to the full review artifact JSON."
+        },
+        "markdown_path": {
+          "type": "string",
+          "description": "Path to the human-readable review markdown."
+        }
+      }
+    },
+    "finding_status_entry": {
+      "type": "object",
+      "description": "A finding lifecycle status update (aligned with Rust ReviewFindingStatusEntry). Stored separately from the index.",
+      "required": [
+        "report_id",
+        "finding_id",
+        "status",
+        "updated_at_epoch_seconds"
+      ],
+      "properties": {
+        "report_id": { "type": "string" },
+        "finding_id": { "type": "string" },
+        "status": { "$ref": "#/$defs/finding_status" },
+        "note": {
+          "type": ["string", "null"],
+          "description": "Optional note explaining the status change."
+        },
+        "updated_at_epoch_seconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/schema/sidecar-request-response.schema.json
+++ b/schema/sidecar-request-response.schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/007M7/Sego-Agent/blob/main/schema/sidecar-request-response.schema.json",
+  "title": "Sego Sidecar Request / Response",
+  "description": "Minimal stable envelope for sidecar <-> engine communication via stdin/stdout JSON. This is a placeholder for Cycle 9 C (sidecar skill PoC); fields will be refined during PoC. Aligned with Codex D-B-3: define minimal stable envelope now, elaborate later.",
+  "oneOf": [
+    { "$ref": "#/$defs/request" },
+    { "$ref": "#/$defs/success_response" },
+    { "$ref": "#/$defs/error_response" }
+  ],
+  "$defs": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Envelope schema version."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "high", "medium", "low", "info"]
+    },
+    "parse_status": {
+      "type": "string",
+      "enum": ["structured", "fallback_raw_text"]
+    },
+    "finding": {
+      "type": "object",
+      "required": ["severity", "file", "title", "evidence", "risk", "suggestion", "confidence"],
+      "properties": {
+        "id": { "type": "string", "default": "" },
+        "severity": { "$ref": "#/$defs/severity" },
+        "file": { "type": "string" },
+        "line": { "type": ["integer", "null"], "minimum": 0 },
+        "title": { "type": "string" },
+        "evidence": { "type": "string" },
+        "risk": { "type": "string" },
+        "suggestion": { "type": "string" },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "verification_hint": { "type": ["string", "null"] }
+      }
+    },
+    "request": {
+      "type": "object",
+      "description": "Sidecar -> engine request via stdin.",
+      "required": ["schema_version", "action", "cwd"],
+      "properties": {
+        "schema_version": { "$ref": "#/$defs/schema_version" },
+        "action": {
+          "type": "string",
+          "description": "Action to perform. Currently: 'review'. Will expand in C (verify, export, etc.).",
+          "enum": ["review"]
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Absolute path to the project workspace root."
+        },
+        "scope": {
+          "type": ["string", "null"],
+          "description": "Review scope, e.g. 'staged', 'workspace', 'src/auth'. Null defaults to 'staged'."
+        },
+        "options": {
+          "type": ["object", "null"],
+          "description": "Optional review options (include_safety_lock, model, etc.). Refined in C.",
+          "properties": {
+            "include_safety_lock": { "type": "boolean", "default": true },
+            "model": { "type": ["string", "null"] }
+          },
+          "additionalProperties": true
+        },
+        "context": {
+          "type": ["object", "null"],
+          "description": "Optional context (user_intent, diff_hash). Refined in C.",
+          "properties": {
+            "user_intent": { "type": "string" },
+            "diff_hash": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "success_response": {
+      "type": "object",
+      "description": "Engine -> sidecar success response via stdout.",
+      "required": ["schema_version", "status"],
+      "properties": {
+        "schema_version": { "$ref": "#/$defs/schema_version" },
+        "status": {
+          "type": "string",
+          "const": "ok"
+        },
+        "review_id": {
+          "type": "string",
+          "description": "Review artifact identifier."
+        },
+        "diff_hash": {
+          "type": "string",
+          "description": "Hash of the reviewed diff."
+        },
+        "artifact_path": {
+          "type": "string",
+          "description": "Path to the persisted review artifact JSON."
+        },
+        "report": {
+          "type": "object",
+          "description": "Inline review report (findings + raw_text + parse_status).",
+          "properties": {
+            "findings": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/finding" }
+            },
+            "parse_status": { "$ref": "#/$defs/parse_status" }
+          }
+        },
+        "findings": {
+          "type": "array",
+          "description": "Flat findings list (alternative to report).",
+          "items": { "$ref": "#/$defs/finding" }
+        },
+        "invest_judgment": {
+          "type": ["object", "null"],
+          "description": "Investment judgment verdict (future, not required in B). Refined in C.",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": ["proceed", "proceed_with_cautions", "stop"]
+            },
+            "rationale": { "type": "string" }
+          }
+        }
+      }
+    },
+    "error_response": {
+      "type": "object",
+      "description": "Engine -> sidecar error response via stdout.",
+      "required": ["schema_version", "status", "error"],
+      "properties": {
+        "schema_version": { "$ref": "#/$defs/schema_version" },
+        "status": {
+          "type": "string",
+          "const": "error"
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Machine-readable error code."
+            },
+            "message": {
+              "type": "string",
+              "description": "Human-readable error message."
+            }
+          },
+          "required": ["message"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 摘要

将散在 Rust struct 里的 `.sego` artifact schema 用 JSON Schema 正式定义到 `schema/` 目录，作为 Rust 引擎与未来 TS sidecar / Python 消费者的公开契约。这是 Cycle 9 C（sidecar skill 包 PoC）的硬前置。

## 变更内容

### schema/ 目录（新增 3 个 JSON Schema）

| 文件 | 对齐 Rust struct | 说明 |
|---|---|---|
| `review-artifact.schema.json` | `ReviewArtifact`（私有，report.rs:109-122） | 真正落盘的 `.sego/reviews/{id}.json` 结构 |
| `review-index-entry.schema.json` | `ReviewIndexEntry` + `ReviewFindingStatusEntry` | append-only 索引（无 schema_version） |
| `sidecar-request-response.schema.json` | 新定义（C 阶段用） | 最小稳定 envelope（request/success/error） |

**Codex 关键纠偏**：schema 对齐的是 `ReviewArtifact`（有 schema_version + serde），不是 `PersistedReviewArtifact`（只是路径句柄）。B 阶段无需给 PersistedReviewArtifact 补 serde。

### report.rs（+134，仅测试）

4 个 golden fixture round-trip 测试：
1. `review_artifact_round_trips_through_json` — 带 finding 完整 round-trip + 枚举 snake_case + schema_version + finding_count 一致性
2. `review_artifact_with_no_findings_round_trips` — 无 finding + null highest_severity
3. `review_index_entry_round_trips_through_json` — index round-trip + 验证无 schema_version
4. `review_finding_status_entry_round_trips_through_json` — status round-trip + snake_case

### 文档

AGENTS.md + DEVELOPMENT.md 新增 schema 纪律说明（改 struct 时同步更新 schema 文件）。

## 决策记录（Codex D-B-1~4）

| ID | 决策 | 结论 |
|---|---|---|
| D-B-1 | JSON Schema 校验方式 | 手写 schema + serde round-trip 测试，不引入 jsonschema/schemars 运行时依赖 |
| D-B-2 | schema_version 放置 | artifact + sidecar 有；index 无（append-only 稳定） |
| D-B-3 | sidecar schema 细节 | 最小 envelope，C 阶段细化 |
| D-B-4 | schema/ 进 GitHub | 进（公开契约） |

## 测试

| 命令 | 结果 |
|---|---|
| `cargo fmt --all --check` | ✅ CLEAN |
| `cargo test -p runtime --lib code_review` | ✅ 21 passed（17 原有 + 4 新） |
| `cargo test -p runtime --lib` | ✅ 457 passed（0 回归） |
| `cargo test -p rusty-claude-cli` | ✅ 119 passed（0 回归） |
| `cargo build -p rusty-claude-cli` | ✅ 编译通过 |
| `git diff --check` | ✅ CLEAN |

## 审查记录

- **Codex 决策确认**: passed（D-B-1~4，含 ReviewArtifact vs PersistedReviewArtifact 纠偏）
- **Sego review**: passed（5/5 focus areas，0 critical/high/medium/low finding）
- **2 个非阻塞 observation**（C 阶段处理）：
  1. f32 confidence 精度边界（测试用简单小数）
  2. sidecar schema finding.line 缺 minimum:0（C 阶段对齐）

## 未改动

- provider / permissions / bash_command_classifier / recovery（c9/a + c10 刚合并，不动）
- README / USAGE（c10/c 文档单独做）
- review 业务逻辑（只加测试，不改行为）
