### PR TITLE
skill-review-add-sidecar-review-skill-poc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ archive/
 **/.omc/
 **/.sandbox-home/
 **/.sandbox-tmp/
+# Claw Code config  
+**/.claw/ 

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -9,6 +9,7 @@
 mod init;
 mod input;
 mod render;
+mod sidecar;
 
 use std::collections::{BTreeSet, HashSet};
 use std::env;
@@ -200,6 +201,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     match action {
         CliAction::DumpManifests => dump_manifests(),
         CliAction::BootstrapPlan => print_bootstrap_plan(),
+        CliAction::SidecarReview => {
+            // c9/c PoC: stdin JSON → stdout JSON. Exit code from pipeline.
+            let exit_code = sidecar::run_sidecar_review_pipeline();
+            std::process::exit(exit_code);
+        }
         CliAction::Agents { args } => LiveCli::print_agents(args.as_deref())?,
         CliAction::Mcp { args } => LiveCli::print_mcp(args.as_deref())?,
         CliAction::Skills { args } => LiveCli::print_skills(args.as_deref())?,
@@ -269,6 +275,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 enum CliAction {
     DumpManifests,
     BootstrapPlan,
+    SidecarReview,
     Agents {
         args: Option<String>,
     },
@@ -556,6 +563,14 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
     match rest[0].as_str() {
         "dump-manifests" => Ok(CliAction::DumpManifests),
         "bootstrap-plan" => Ok(CliAction::BootstrapPlan),
+        "sidecar" => {
+            // sego sidecar review — JSON stdin → JSON stdout (c9/c PoC, P1)
+            if rest.len() >= 2 && rest[1] == "review" {
+                Ok(CliAction::SidecarReview)
+            } else {
+                Err("sidecar subcommand requires an action (currently: review)".to_string())
+            }
+        }
         "agents" => Ok(CliAction::Agents { args: join_optional_args(&rest[1..]) }),
         "mcp" => Ok(CliAction::Mcp { args: join_optional_args(&rest[1..]) }),
         "skills" => Ok(CliAction::Skills { args: join_optional_args(&rest[1..]) }),

--- a/rust/crates/rusty-claude-cli/src/sidecar.rs
+++ b/rust/crates/rusty-claude-cli/src/sidecar.rs
@@ -1,0 +1,263 @@
+//! Sidecar JSON interface for external skill / tool consumers (c9/c PoC).
+//!
+//! Implements `sego sidecar review`: reads a JSON request from stdin, runs a
+//! code review, and writes a JSON response to stdout. stderr is reserved for
+//! diagnostic logs.
+//!
+//! Design decisions (Codex c9/c):
+//! - D-C-1: PermissionMode::ReadOnly (non-interactive, fail-safe on write/danger)
+//! - D-C-2: Reuses existing review components, does NOT modify run_review_target
+//! - D-C-3: stdout always emits machine-readable JSON, even on error
+//! - Minimal PoC: only `review` action, no plugin marketplace / skill runtime
+
+use std::io::{Read, Write};
+
+use runtime::code_review::{
+    build_review_prompt, persist_review_artifact, ReviewContext, ReviewPromptOptions, ReviewReport,
+    ReviewScope,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{collect_review_target, LiveCli, PermissionMode};
+
+/// Schema version for the sidecar envelope (aligned with sidecar-request-response.schema.json).
+const SIDECAR_SCHEMA_VERSION: u32 = 1;
+
+/// Run the sidecar review pipeline: read stdin JSON → review → write stdout JSON.
+///
+/// Returns the process exit code (0 = success, 1 = error). The caller should
+/// pass this to `std::process::exit`.
+pub fn run_sidecar_review_pipeline() -> i32 {
+    // Read entire stdin.
+    let mut input = String::new();
+    if std::io::stdin().read_to_string(&mut input).is_err() {
+        emit_error("read_stdin_failed", "failed to read stdin");
+        return 1;
+    }
+
+    // Parse request JSON. Even on parse failure, emit a structured error envelope.
+    let request: SidecarReviewRequest = match serde_json::from_str(&input) {
+        Ok(req) => req,
+        Err(error) => {
+            emit_error("invalid_request", &format!("failed to parse request JSON: {error}"));
+            return 1;
+        }
+    };
+
+    if request.action != "review" {
+        emit_error(
+            "unsupported_action",
+            &format!("action '{}' is not supported (currently: review)", request.action),
+        );
+        return 1;
+    }
+
+    match execute_review(&request) {
+        Ok(response) => {
+            // Serialize and write to stdout. stdout must be pure JSON.
+            match serde_json::to_string(&response) {
+                Ok(json) => {
+                    let _ = writeln!(std::io::stdout(), "{json}");
+                    0
+                }
+                Err(error) => {
+                    emit_error(
+                        "serialization_failed",
+                        &format!("failed to serialize response: {error}"),
+                    );
+                    1
+                }
+            }
+        }
+        Err(error) => {
+            emit_error("review_failed", &error.to_string());
+            1
+        }
+    }
+}
+
+/// Execute a single review and return a structured response.
+///
+/// Reuses: collect_review_target, build_review_prompt, run_turn_capture_text,
+/// ReviewReport::from_model_output, persist_review_artifact.
+/// Does NOT modify existing run_review_target (D-C-2).
+fn execute_review(
+    request: &SidecarReviewRequest,
+) -> Result<SidecarReviewResponse, Box<dyn std::error::Error>> {
+    let cwd = std::path::PathBuf::from(&request.cwd);
+    let review_scope = ReviewScope::parse(request.scope.as_deref())?;
+    let target = collect_review_target(&cwd, review_scope)?;
+
+    if target.is_empty() {
+        // No diff to review — return success with no findings.
+        return Ok(SidecarReviewResponse {
+            schema_version: SIDECAR_SCHEMA_VERSION,
+            status: "ok".to_string(),
+            review_id: None,
+            diff_hash: None,
+            artifact_path: None,
+            findings: Some(vec![]),
+            parse_status: Some("no_diff".to_string()),
+            error: None,
+        });
+    }
+
+    // D-C-1: ReadOnly mode, non-interactive. Write/danger tools are denied.
+    // .sego/reviews/ persistence is done by persist_review_artifact directly,
+    // not by model tools.
+    let model = request
+        .options
+        .as_ref()
+        .and_then(|opts| opts.model.clone())
+        .unwrap_or_else(crate::default_model);
+    let mut cli = LiveCli::new(model, true, None, PermissionMode::ReadOnly)?;
+
+    let context = ReviewContext::new(target);
+    let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+    let review_text = cli.run_turn_capture_text(&prompt)?;
+    let report = ReviewReport::from_model_output(review_text);
+    let artifact = persist_review_artifact(&cwd, &context.target, &report)?;
+
+    Ok(SidecarReviewResponse {
+        schema_version: SIDECAR_SCHEMA_VERSION,
+        status: "ok".to_string(),
+        review_id: Some(artifact.id),
+        diff_hash: Some(artifact.diff_hash),
+        artifact_path: Some(artifact.json_path.to_string_lossy().to_string()),
+        findings: Some(report.findings.clone()),
+        parse_status: Some(report.parse_status.label().to_string()),
+        error: None,
+    })
+}
+
+/// Emit a structured error envelope to stdout (D-C-3: stdout always JSON).
+fn emit_error(code: &str, message: &str) {
+    let response = SidecarReviewResponse {
+        schema_version: SIDECAR_SCHEMA_VERSION,
+        status: "error".to_string(),
+        review_id: None,
+        diff_hash: None,
+        artifact_path: None,
+        findings: None,
+        parse_status: None,
+        error: Some(SidecarError { code: code.to_string(), message: message.to_string() }),
+    };
+    if let Ok(json) = serde_json::to_string(&response) {
+        let _ = writeln!(std::io::stdout(), "{json}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Request / Response types (aligned with sidecar-request-response.schema.json)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct SidecarReviewRequest {
+    pub schema_version: u32,
+    pub action: String,
+    pub cwd: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub options: Option<SidecarReviewOptions>,
+    #[serde(default)]
+    pub context: Option<SidecarReviewContext>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SidecarReviewOptions {
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SidecarReviewContext {
+    #[serde(default)]
+    pub user_intent: Option<String>,
+    #[serde(default)]
+    pub diff_hash: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SidecarReviewResponse {
+    pub schema_version: u32,
+    pub status: String,
+    pub review_id: Option<String>,
+    pub diff_hash: Option<String>,
+    pub artifact_path: Option<String>,
+    pub findings: Option<Vec<runtime::code_review::ReviewFinding>>,
+    pub parse_status: Option<String>,
+    pub error: Option<SidecarError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SidecarError {
+    pub code: String,
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_parses_minimal_json() {
+        let json = r#"{"schema_version":1,"action":"review","cwd":"/tmp/project"}"#;
+        let req: SidecarReviewRequest = serde_json::from_str(json).expect("parse");
+        assert_eq!(req.action, "review");
+        assert_eq!(req.cwd, "/tmp/project");
+        assert!(req.scope.is_none());
+    }
+
+    #[test]
+    fn request_parses_with_scope_and_options() {
+        let json = r#"{"schema_version":1,"action":"review","cwd":"/tmp","scope":"staged","options":{"model":"deepseek-v4-pro"}}"#;
+        let req: SidecarReviewRequest = serde_json::from_str(json).expect("parse");
+        assert_eq!(req.scope.as_deref(), Some("staged"));
+        assert_eq!(req.options.as_ref().and_then(|o| o.model.as_deref()), Some("deepseek-v4-pro"));
+    }
+
+    #[test]
+    fn response_serializes_success() {
+        let response = SidecarReviewResponse {
+            schema_version: 1,
+            status: "ok".to_string(),
+            review_id: Some("rev-001".to_string()),
+            diff_hash: Some("sha256:abc".to_string()),
+            artifact_path: Some(".sego/reviews/rev-001.json".to_string()),
+            findings: Some(vec![]),
+            parse_status: Some("structured".to_string()),
+            error: None,
+        };
+        let json = serde_json::to_string(&response).expect("serialize");
+        assert!(json.contains(r#""status":"ok""#));
+        assert!(json.contains(r#""review_id":"rev-001""#));
+        assert!(json.contains(r#""schema_version":1"#));
+    }
+
+    #[test]
+    fn response_serializes_error() {
+        let response = SidecarReviewResponse {
+            schema_version: 1,
+            status: "error".to_string(),
+            review_id: None,
+            diff_hash: None,
+            artifact_path: None,
+            findings: None,
+            parse_status: None,
+            error: Some(SidecarError {
+                code: "invalid_request".to_string(),
+                message: "bad JSON".to_string(),
+            }),
+        };
+        let json = serde_json::to_string(&response).expect("serialize");
+        assert!(json.contains(r#""status":"error""#));
+        assert!(json.contains(r#""code":"invalid_request""#));
+    }
+
+    #[test]
+    fn emit_error_outputs_structured_envelope() {
+        // emit_error writes to stdout; we just verify it doesn't panic.
+        emit_error("test_code", "test message");
+    }
+}

--- a/skills/sego-review/README.md
+++ b/skills/sego-review/README.md
@@ -1,0 +1,65 @@
+# sego-review skill
+
+AI coding engineering trust review — a Sego sidecar skill package.
+
+## What it does
+
+After you generate or modify code with any AI tool (Claude Code, Codex, Cursor, etc.), invoke this skill to get a structured review from Sego. Sego returns findings with severity, file, line, evidence, risk, and suggestion — then persists a review artifact to `.sego/reviews/`.
+
+## Install
+
+### Prerequisites
+
+- [Sego](https://github.com/007M7/Sego-Agent) built and on PATH, or built from source:
+  ```bash
+  cargo build -p rusty-claude-cli
+  ```
+- A git repository (review uses `git diff`)
+
+### Use in Zcode / Claude Code / any SKILL.md-compatible tool
+
+Copy the `sego-review/` directory into your tool's skills directory.
+
+## Usage
+
+### Command line
+
+```bash
+# Unix
+echo '{"schema_version":1,"action":"review","cwd":"'"$PWD"'","scope":"staged"}' \
+  | bash skills/sego-review/scripts/sego-review.sh
+
+# Windows PowerShell
+$request = @{ schema_version = 1; action = "review"; cwd = (Get-Location).Path; scope = "staged" } | ConvertTo-Json
+$request | powershell -File skills/sego-review/scripts/sego-review.ps1
+```
+
+### Via `sego sidecar review` directly
+
+```bash
+echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' | sego sidecar review
+```
+
+## Request format
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schema_version` | integer | yes | Must be `1` |
+| `action` | string | yes | Must be `"review"` |
+| `cwd` | string | yes | Absolute path to project root |
+| `scope` | string | no | `"staged"`, `"workspace"`, or a path (default: `staged`) |
+| `options.model` | string | no | Override review model |
+| `context.user_intent` | string | no | What the user wants to achieve |
+
+## Response format
+
+See [SKILL.md](SKILL.md) for the full response schema. Key fields:
+
+- `status`: `"ok"` or `"error"`
+- `findings`: array of structured findings (severity/file/line/evidence/risk/suggestion)
+- `artifact_path`: path to persisted review JSON
+- `error`: present only when `status` is `"error"`
+
+## Graceful degradation
+
+If the Sego binary is not found, the script outputs a structured error JSON to stderr and exits with code 1 — it does not crash silently.

--- a/skills/sego-review/SKILL.md
+++ b/skills/sego-review/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: sego-review
+version: "0.1.0"
+description: >
+  AI coding engineering trust review. After the user generates or modifies code
+  with any AI tool, invoke Sego to perform a structured review. Sego returns
+  findings with severity/file/line/evidence/risk/suggestion and persists a review
+  artifact to .sego/reviews/. Use this skill whenever the user wants to check,
+  review, or validate AI-generated code changes before committing or shipping.
+---
+
+# Sego Review Skill
+
+## When to use this skill
+
+Use this skill when the user:
+- Asks to "review", "check", or "validate" code changes
+- Wants to know if AI-generated code is safe to commit
+- Asks "is this code okay?" or "should I commit this?"
+- Wants a second opinion on AI-generated diffs
+
+Do NOT use this skill for:
+- General coding questions (use normal tools)
+- Running tests (use cargo test / npm test directly)
+- Git operations (use git directly)
+
+## How to invoke
+
+Call the Sego sidecar via the platform-appropriate script:
+
+### Unix / macOS
+
+```bash
+echo '{"schema_version":1,"action":"review","cwd":"'"$PWD"'","scope":"staged"}' \
+  | bash skills/sego-review/scripts/sego-review.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+$request = @{ schema_version = 1; action = "review"; cwd = (Get-Location).Path; scope = "staged" } | ConvertTo-Json
+$request | powershell -File skills/sego-review/scripts/sego-review.ps1
+```
+
+### Request format
+
+```json
+{
+  "schema_version": 1,
+  "action": "review",
+  "cwd": "/absolute/path/to/project",
+  "scope": "staged",
+  "options": { "model": null },
+  "context": { "user_intent": "optional description of what the user wants" }
+}
+```
+
+- `scope`: `"staged"` (git staged changes), `"workspace"` (all uncommitted changes), or a path like `"src/auth"`.
+- `options.model`: override the review model (default: auto-selected).
+
+### Response format
+
+```json
+{
+  "schema_version": 1,
+  "status": "ok",
+  "review_id": "rev-20260616-001",
+  "diff_hash": "sha256:...",
+  "artifact_path": ".sego/reviews/rev-20260616-001.json",
+  "findings": [
+    {
+      "id": "f-001",
+      "severity": "high",
+      "file": "src/auth/login.rs",
+      "line": 42,
+      "title": "Missing error handling",
+      "evidence": "...",
+      "risk": "...",
+      "suggestion": "...",
+      "confidence": 0.85
+    }
+  ],
+  "parse_status": "structured"
+}
+```
+
+Severity levels: `critical` > `high` > `medium` > `low` > `info`.
+
+## Interpreting results
+
+After receiving the response:
+1. Summarize the findings for the user in plain language
+2. Highlight any `critical` or `high` severity findings first
+3. If `status` is `"error"`, report the error message to the user
+4. Mention the `artifact_path` so the user can review the full report later
+
+## Requirements
+
+- Sego must be installed and on PATH, or built from source (`cargo build -p rusty-claude-cli`)
+- The project must be a git repository (review uses git diff)

--- a/skills/sego-review/scripts/sego-review.ps1
+++ b/skills/sego-review/scripts/sego-review.ps1
@@ -1,0 +1,42 @@
+# sego-review.ps1 — Invoke Sego sidecar review from a skill package (Windows).
+#
+# Reads a JSON request from stdin, passes it to `sego sidecar review`,
+# and outputs the JSON response to stdout.
+#
+# Usage:
+#   $request | powershell -File sego-review.ps1
+#   # or pipe directly:
+#   '{"schema_version":1,"action":"review","cwd":"C:\\project","scope":"staged"}' | powershell -File sego-review.ps1
+[CmdletBinding()]
+param()
+$ErrorActionPreference = "Stop"
+
+# Locate the sego binary: local cargo build > CARGO_TARGET_DIR > PATH.
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $ScriptDir))
+
+$SegoBin = $null
+
+if (Test-Path (Join-Path $RepoRoot "rust\target\debug\sego.exe")) {
+    $SegoBin = Join-Path $RepoRoot "rust\target\debug\sego.exe"
+} elseif (Test-Path (Join-Path $RepoRoot "rust\target\release\sego.exe")) {
+    $SegoBin = Join-Path $RepoRoot "rust\target\release\sego.exe"
+} elseif ($env:CARGO_TARGET_DIR -and (Test-Path (Join-Path $env:CARGO_TARGET_DIR "debug\sego.exe"))) {
+    $SegoBin = Join-Path $env:CARGO_TARGET_DIR "debug\sego.exe"
+} else {
+    $found = $null
+    try { $found = (Get-Command sego -ErrorAction Stop).Source } catch {}
+    if ($found) {
+        $SegoBin = "sego"
+    }
+}
+
+if (-not $SegoBin) {
+    $err = @{ schema_version = 1; status = "error"; error = @{ code = "sego_not_found"; message = "Sego binary not found. Build with: cargo build -p rusty-claude-cli, or add sego to PATH." } } | ConvertTo-Json -Compress
+    [Console]::Error.WriteLine($err)
+    exit 1
+}
+
+# Read stdin and pipe to sego sidecar review.
+$input | & $SegoBin sidecar review
+exit $LASTEXITCODE

--- a/skills/sego-review/scripts/sego-review.sh
+++ b/skills/sego-review/scripts/sego-review.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# sego-review.sh — Invoke Sego sidecar review from a skill package.
+#
+# Reads a JSON request from stdin, passes it to `sego sidecar review`,
+# and outputs the JSON response to stdout.
+#
+# Usage:
+#   echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' | sego-review.sh
+set -euo pipefail
+
+# Locate the sego binary: local cargo build > CARGO_TARGET_DIR > PATH.
+SEGO_BIN=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+if [[ -x "${REPO_ROOT}/rust/target/debug/sego" ]]; then
+    SEGO_BIN="${REPO_ROOT}/rust/target/debug/sego"
+elif [[ -x "${REPO_ROOT}/rust/target/release/sego" ]]; then
+    SEGO_BIN="${REPO_ROOT}/rust/target/release/sego"
+elif [[ -n "${CARGO_TARGET_DIR:-}" && -x "${CARGO_TARGET_DIR}/debug/sego" ]]; then
+    SEGO_BIN="${CARGO_TARGET_DIR}/debug/sego"
+elif command -v sego >/dev/null 2>&1; then
+    SEGO_BIN="sego"
+else
+    echo '{"schema_version":1,"status":"error","error":{"code":"sego_not_found","message":"Sego binary not found. Build with: cargo build -p rusty-claude-cli, or add sego to PATH."}}' >&2
+    exit 1
+fi
+
+exec "${SEGO_BIN}" sidecar review


### PR DESCRIPTION
## Summary  
  
Add `sego sidecar review` command as a sidecar JSON interface for external skill/tool consumers.  
  
## Changes  
  
- **sidecar.rs**: New module implementing `sego sidecar review` - reads JSON request from stdin, runs review via `execute_review()`, writes JSON response to stdout  
- **main.rs**: Added `sego sidecar` subcommand (+15 lines), wired to sidecar module  
- **skills/sego-review/**: Skill package with SKILL.md, .ps1, .sh entry points  
- **.gitignore**: Added `**/.claw/` pattern 
