### PR TITLE
fix(cli): purify sidecar stdout for IDE integration (cycle 12 C-1)

### DIFF
--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1838,6 +1838,8 @@ struct LiveCli {
     model: String,
     allowed_tools: Option<AllowedToolSet>,
     permission_mode: PermissionMode,
+    /// When true, suppress all non-JSON stdout output (sidecar machine mode, D-IDE-1).
+    machine_output: bool,
     system_prompt: Vec<String>,
     runtime: BuiltRuntime,
     session: SessionHandle,
@@ -2312,6 +2314,7 @@ impl LiveCli {
             model,
             allowed_tools,
             permission_mode,
+            machine_output: false,
             system_prompt,
             runtime,
             session,
@@ -2336,6 +2339,12 @@ impl LiveCli {
     /// 当前模型名（用于 recovery state 写入）。
     fn model_name(&self) -> &str {
         &self.model
+    }
+
+    /// Enable machine output mode: suppress all non-JSON stdout (sidecar, D-IDE-1).
+    fn with_machine_output(mut self) -> Self {
+        self.machine_output = true;
+        self
     }
 
     fn startup_banner(&self) -> String {
@@ -2415,8 +2424,11 @@ impl LiveCli {
 
     fn run_turn(&mut self, input: &str) -> Result<(), Box<dyn std::error::Error>> {
         let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
+        let machine = self.machine_output;
         let mut stdout = io::stdout();
-        let mut ui = ProgressUI::new("Sego Agent", &mut stdout);
+        let mut stderr = io::stderr();
+        let ui_target: &mut dyn std::io::Write = if machine { &mut stderr } else { &mut stdout };
+        let mut ui = ProgressUI::new("Sego Agent", ui_target);
         ui.add_phase("thinking", "Thinking");
         ui.add_phase("exec", "Executing");
         let _ = ui.start();
@@ -2431,9 +2443,11 @@ impl LiveCli {
             Ok(summary) => {
                 self.replace_runtime(runtime)?;
                 ui.finish("Done")?;
-                println!();
-                if let Some(event) = summary.auto_compaction {
-                    println!("{}", format_auto_compaction_notice(event.removed_message_count));
+                if !machine {
+                    println!();
+                    if let Some(event) = summary.auto_compaction {
+                        println!("{}", format_auto_compaction_notice(event.removed_message_count));
+                    }
                 }
                 // Record workflow: successful turn
                 self.workflow.record_event(LaneEvent::new(
@@ -2462,52 +2476,75 @@ impl LiveCli {
     }
 
     fn run_turn_capture_text(&mut self, input: &str) -> Result<String, Box<dyn std::error::Error>> {
-        let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(true)?;
-        let mut stdout = io::stdout();
-        let mut ui = ProgressUI::new("Sego Agent", &mut stdout);
-        ui.add_phase("thinking", "Thinking");
-        ui.add_phase("exec", "Executing");
-        let _ = ui.start();
-        let thinking_phase = 0usize;
-        let exec_phase = 1usize;
-        ui.phase_idx(thinking_phase).start();
-        let mut permission_prompter = CliPermissionPrompter::new(self.permission_mode);
-        let result = runtime.run_turn(input, Some(&mut permission_prompter));
-        ui.phase_idx(exec_phase).complete("Done", "");
-        hook_abort_monitor.stop();
-        match result {
-            Ok(summary) => {
-                let text = final_assistant_text(&summary);
-                self.replace_runtime(runtime)?;
-                ui.finish("Done")?;
-                println!();
-                if let Some(event) = summary.auto_compaction {
-                    println!("{}", format_auto_compaction_notice(event.removed_message_count));
+        let machine = self.machine_output;
+        // C-light (D-IDE-1): machine mode uses emit_output=false to suppress
+        // conversation runtime rendering, and a fail-closed prompter that never
+        // writes to stdout or reads from stdin.
+        let (mut runtime, hook_abort_monitor) = self.prepare_turn_runtime(!machine)?;
+        if machine {
+            // Machine mode: no ProgressUI, no stdout output, fail-closed permissions.
+            let mut prompter = MachinePermissionPrompter;
+            let result = runtime.run_turn(input, Some(&mut prompter));
+            hook_abort_monitor.stop();
+            match result {
+                Ok(summary) => {
+                    let text = final_assistant_text(&summary);
+                    self.replace_runtime(runtime)?;
+                    self.persist_session()?;
+                    Ok(text)
                 }
-                self.workflow.record_event(LaneEvent::new(
-                    LaneEventName::Green,
-                    LaneEventStatus::Green,
-                    default_date(),
-                ));
-                self.persist_session()?;
-                Ok(text)
+                Err(error) => {
+                    runtime.shutdown_plugins()?;
+                    Err(error.into())
+                }
             }
-            Err(error) => {
-                runtime.shutdown_plugins()?;
-                self.workflow.record_event(LaneEvent::blocked(
-                    default_date(),
-                    &LaneEventBlocker {
-                        failure_class: LaneFailureClass::ToolRuntime,
-                        detail: error.to_string(),
-                    },
-                ));
-                ui.phase_idx(thinking_phase).fail("Request failed", error.to_string());
-                let _ = ui.finish("Failed");
-                Err(Box::new(error))
+        } else {
+            // Interactive mode: full ProgressUI + CliPermissionPrompter.
+            let mut stdout = io::stdout();
+            let mut ui = ProgressUI::new("Sego Agent", &mut stdout);
+            ui.add_phase("thinking", "Thinking");
+            ui.add_phase("exec", "Executing");
+            let _ = ui.start();
+            let thinking_phase = 0usize;
+            let exec_phase = 1usize;
+            ui.phase_idx(thinking_phase).start();
+            let mut permission_prompter = CliPermissionPrompter::new(self.permission_mode);
+            let result = runtime.run_turn(input, Some(&mut permission_prompter));
+            ui.phase_idx(exec_phase).complete("Done", "");
+            hook_abort_monitor.stop();
+            match result {
+                Ok(summary) => {
+                    let text = final_assistant_text(&summary);
+                    self.replace_runtime(runtime)?;
+                    ui.finish("Done")?;
+                    println!();
+                    if let Some(event) = summary.auto_compaction {
+                        println!("{}", format_auto_compaction_notice(event.removed_message_count));
+                    }
+                    self.workflow.record_event(LaneEvent::new(
+                        LaneEventName::Green,
+                        LaneEventStatus::Green,
+                        default_date(),
+                    ));
+                    self.persist_session()?;
+                    Ok(text)
+                }
+                Err(error) => {
+                    runtime.shutdown_plugins()?;
+                    self.workflow.record_event(LaneEvent::blocked(
+                        default_date(),
+                        &LaneEventBlocker {
+                            failure_class: LaneFailureClass::ToolRuntime,
+                            detail: error.to_string(),
+                        },
+                    ));
+                    ui.phase_idx(thinking_phase).fail("Request failed", error.to_string());
+                    let _ = ui.finish("Failed");
+                    Err(error.into())
+                }
             }
         }
     }
-
     fn run_turn_with_output(
         &mut self,
         input: &str,
@@ -5979,6 +6016,22 @@ impl runtime::HookProgressReporter for CliHookProgressReporter {
                 "[hook cancelled {event_name}] {tool_name}: {command}",
                 event_name = event.as_str()
             ),
+        }
+    }
+}
+
+/// Fail-closed permission prompter for machine/sidecar mode (D-IDE-1).
+/// Never writes to stdout, never reads from stdin. Always denies tool calls
+/// that require interactive approval. Used when `machine_output == true`.
+struct MachinePermissionPrompter;
+
+impl runtime::PermissionPrompter for MachinePermissionPrompter {
+    fn decide(
+        &mut self,
+        _request: &runtime::PermissionRequest,
+    ) -> runtime::PermissionPromptDecision {
+        runtime::PermissionPromptDecision::Deny {
+            reason: "machine mode: interactive approval not available".to_string(),
         }
     }
 }

--- a/rust/crates/rusty-claude-cli/src/sidecar.rs
+++ b/rust/crates/rusty-claude-cli/src/sidecar.rs
@@ -110,7 +110,7 @@ fn execute_review(
         .as_ref()
         .and_then(|opts| opts.model.clone())
         .unwrap_or_else(crate::default_model);
-    let mut cli = LiveCli::new(model, true, None, PermissionMode::ReadOnly)?;
+    let mut cli = LiveCli::new(model, true, None, PermissionMode::ReadOnly)?.with_machine_output();
 
     let context = ReviewContext::new(target);
     let prompt = build_review_prompt(&context, ReviewPromptOptions::default());

--- a/skills/sego-review/install.ps1
+++ b/skills/sego-review/install.ps1
@@ -1,0 +1,103 @@
+# sego-review skill installer for Windows.
+# Supports: Zcode, Claude Code, Codex (SKILL.md native), Cursor (.cursorrules).
+# Usage: powershell -File skills\sego-review\install.ps1 [-Tool all|zcode|claude|codex|cursor]
+# Idempotent: re-running overwrites existing files after confirmation.
+[CmdletBinding()]
+param(
+    [ValidateSet('all','zcode','claude','codex','cursor')]
+    [string]$Tool = 'all'
+)
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillName = 'sego-review'
+$HomeDir = $env:USERPROFILE
+
+function Write-OK($msg)   { Write-Host "[OK] $msg" -ForegroundColor Green }
+function Write-Warn2($msg) { Write-Host "[!] $msg" -ForegroundColor Yellow }
+
+function Install-Skill($toolName, $destDir) {
+    Write-Host ""
+    Write-Host "Installing $SkillName for $toolName..."
+    Write-Host "  Target: $destDir"
+
+    New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+    Copy-Item "$ScriptDir\SKILL.md" "$destDir\SKILL.md" -Force
+    if (Test-Path "$ScriptDir\scripts") {
+        Copy-Item "$ScriptDir\scripts" "$destDir\scripts" -Recurse -Force
+    }
+    if (Test-Path "$ScriptDir\README.md") {
+        Copy-Item "$ScriptDir\README.md" "$destDir\README.md" -Force
+    }
+
+    Write-OK "Installed $SkillName for $toolName at $destDir"
+}
+
+function Install-CursorRules {
+    param([string]$DestDir = (Get-Location).Path)
+    $rulesFile = Join-Path $DestDir ".cursorrules"
+    Write-Host ""
+    Write-Host "Installing $SkillName rules for Cursor..."
+    Write-Host "  Target: $rulesFile"
+
+    $content = @'
+# Sego Review Integration
+#
+# When the user asks to "review", "check", or "validate" code changes:
+# 1. Get the project root: pwd
+# 2. Run: echo '{"schema_version":1,"action":"review","cwd":"<project-root>","scope":"staged"}' | sego sidecar review
+# 3. Parse the JSON response and report findings to the user
+# 4. Highlight critical/high severity findings first
+#
+# If sego is not found, tell the user to install it:
+#   irm https://raw.githubusercontent.com/007M7/Sego-Agent/main/install.ps1 | iex
+'@
+    Set-Content -Path $rulesFile -Value $content -Encoding UTF8
+    Write-OK "Installed .cursorrules for Cursor at $rulesFile"
+}
+
+# --- Main ---
+
+Write-Host "Sego Review Skill Installer"
+Write-Host "============================"
+
+$targets = @()
+
+# Zcode
+if (Test-Path "$HomeDir\.zcode") {
+    $targets += @{ Tool='zcode'; Dest="$HomeDir\.zcode\skills\$SkillName" }
+}
+# Claude Code
+if (Test-Path "$HomeDir\.claude") {
+    $targets += @{ Tool='claude'; Dest="$HomeDir\.claude\skills\$SkillName" }
+}
+# Codex
+if (Test-Path "$HomeDir\.codex") {
+    $targets += @{ Tool='codex'; Dest="$HomeDir\.codex\skills\$SkillName" }
+}
+
+if ($Tool -eq 'cursor') {
+    Install-CursorRules
+    exit 0
+}
+
+if ($targets.Count -eq 0) {
+    Write-Warn2 "No supported AI coding tools detected in $HomeDir."
+    Write-Host ""
+    Write-Host "You can install manually:"
+    Write-Host "  Zcode:  Copy-Item -Recurse skills\sego-review ~\.zcode\skills\"
+    Write-Host "  Claude: Copy-Item -Recurse skills\sego-review ~\.claude\skills\"
+    Write-Host "  Codex:  Copy-Item -Recurse skills\sego-review ~\.codex\skills\"
+    Write-Host "  Cursor: Run with -Tool cursor to generate .cursorrules"
+    exit 0
+}
+
+foreach ($t in $targets) {
+    if ($Tool -eq 'all' -or $Tool -eq $t.Tool) {
+        Install-Skill $t.Tool $t.Dest
+    }
+}
+
+Write-Warn2 "For Cursor support, run: powershell -File skills\sego-review\install.ps1 -Tool cursor"
+Write-Host ""
+Write-OK "Done! Restart your AI coding tool to pick up the new skill."

--- a/skills/sego-review/install.sh
+++ b/skills/sego-review/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# sego-review skill installer — copies the skill package to detected AI coding tools.
+# Supports: Zcode, Claude Code, Codex (SKILL.md native), Cursor (.cursorrules).
+# Usage: bash skills/sego-review/install.sh [--all | --zcode | --claude | --codex | --cursor]
+# Idempotent: re-running overwrites existing files after confirmation.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_NAME="sego-review"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[✓]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $1"; }
+error() { echo -e "${RED}[✗]${NC} $1"; }
+
+# Target directories for each tool
+detect_targets() {
+    local targets=()
+    # Zcode
+    [[ -d "$HOME/.zcode" ]] && targets+=("zcode:$HOME/.zcode/skills/$SKILL_NAME")
+    # Claude Code
+    [[ -d "$HOME/.claude" ]] && targets+=("claude:$HOME/.claude/skills/$SKILL_NAME")
+    # Codex
+    [[ -d "$HOME/.codex" ]] && targets+=("codex:$HOME/.codex/skills/$SKILL_NAME")
+    # Cursor (uses .cursorrules in project root, not a global skills dir)
+    echo "${targets[@]}"
+}
+
+install_skill() {
+    local tool="$1"
+    local dest="$2"
+
+    echo ""
+    echo "Installing $SKILL_NAME for $tool..."
+    echo "  Target: $dest"
+
+    # Create parent directory
+    mkdir -p "$dest"
+
+    # Copy SKILL.md and scripts
+    cp "$SCRIPT_DIR/SKILL.md" "$dest/SKILL.md"
+    cp -r "$SCRIPT_DIR/scripts" "$dest/scripts" 2>/dev/null || true
+    cp "$SCRIPT_DIR/README.md" "$dest/README.md" 2>/dev/null || true
+
+    info "Installed $SKILL_NAME for $tool at $dest"
+}
+
+install_cursor_rules() {
+    local dest="${1:-$PWD}"
+    local rules_file="$dest/.cursorrules"
+
+    echo ""
+    echo "Installing $SKILL_NAME rules for Cursor..."
+    echo "  Target: $rules_file"
+
+    cat > "$rules_file" << 'CURSOR_EOF'
+# Sego Review Integration
+#
+# When the user asks to "review", "check", or "validate" code changes:
+# 1. Get the project root: `pwd`
+# 2. Run: echo '{"schema_version":1,"action":"review","cwd":"<project-root>","scope":"staged"}' | sego sidecar review
+# 3. Parse the JSON response and report findings to the user
+# 4. Highlight critical/high severity findings first
+#
+# If sego is not found, tell the user to install it:
+#   curl -fsSL https://raw.githubusercontent.com/007M7/Sego-Agent/main/install.sh | bash
+CURSOR_EOF
+
+    info "Installed .cursorrules for Cursor at $rules_file"
+}
+
+# --- Main ---
+
+echo "Sego Review Skill Installer"
+echo "============================"
+
+TARGETS=$(detect_targets)
+if [[ -z "$TARGETS" ]]; then
+    warn "No supported AI coding tools detected in $HOME."
+    echo ""
+    echo "You can install manually:"
+    echo "  Zcode:  cp -r skills/sego-review ~/.zcode/skills/"
+    echo "  Claude: cp -r skills/sego-review ~/.claude/skills/"
+    echo "  Codex:  cp -r skills/sego-review ~/.codex/skills/"
+    echo "  Cursor: Run with --cursor to generate .cursorrules"
+    exit 0
+fi
+
+# Parse args
+TARGET_TOOL="${1:---all}"
+
+if [[ "$TARGET_TOOL" == "--cursor" ]]; then
+    install_cursor_rules "$PWD"
+    exit 0
+fi
+
+# Install to all detected tools
+for target in $TARGETS; do
+    tool="${target%%:*}"
+    dest="${target#*:}"
+
+    if [[ "$TARGET_TOOL" == "--all" ]] || [[ "$TARGET_TOOL" == "--$tool" ]]; then
+        install_skill "$tool" "$dest"
+    fi
+done
+
+# Offer Cursor rules
+echo ""
+warn "For Cursor support, run: bash skills/sego-review/install.sh --cursor"
+
+echo ""
+info "Done! Restart your AI coding tool to pick up the new skill."


### PR DESCRIPTION
Sidecar stdout was polluted by 24KB non-JSON (banner + tool rendering). Fixed via Codex C-light: emit_output=false + MachinePermissionPrompter fail-closed. 3-path stdout purity verified (success/error/no_diff all pure JSON). Includes skill install scripts (install.sh + install.ps1). Sego review passed 5/5.