### PR TITLE
docs: add IDE integration section to README + USAGE (c12 c2-c3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,31 @@ sego /verify         # 完整验证
 
 根据项目类型识别验证命令（Rust: cargo build/test，Node: npm test/build）。
 
+### 6. 接入 AI 编码工具（Sidecar skill PoC）
+
+Sego 提供一个 sidecar skill 包，让你的 AI 编码工具（Claude Code、Codex、Cursor 等）能自动调用 Sego review。
+
+**一键安装**：
+
+```bash
+# Mac / Linux
+bash skills/sego-review/install.sh
+
+# Windows
+powershell -File skills\sego-review\install.ps1
+```
+
+脚本会自动检测已安装的 AI 工具（Claude Code / Codex / Zcode / Cursor），复制 skill 包到对应目录。安装后重启你的 AI 编码工具即可。
+
+**手动调用**（不依赖 IDE）：
+
+```bash
+echo '{"schema_version":1,"action":"review","cwd":"/your/project","scope":"staged"}' \
+  | sego sidecar review
+```
+
+> **PoC 状态**：sidecar skill 当前仅支持 `review` action。这是早期集成（early integration），不承诺完整 IDE 插件生态。
+
 ---
 
 ## Demo 示例

--- a/USAGE.md
+++ b/USAGE.md
@@ -259,3 +259,98 @@ echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' 
 - Error responses are structured envelopes (`schema_version` / `status` / `error`).
 - The skill package at `skills/sego-review/` can be invoked by SKILL.md-compatible tools (Claude Code, Codex, Cursor, etc.).
 - **PoC status**: only the `review` action is supported. stdout banner mixing is a known limitation to be fixed in a future release.
+# sego-review skill
+
+AI coding engineering trust review — a Sego sidecar skill package.
+
+## What it does
+
+After you generate or modify code with any AI tool (Claude Code, Codex, Cursor, etc.), invoke this skill to get a structured review from Sego. Sego returns findings with severity, file, line, evidence, risk, and suggestion — then persists a review artifact to `.sego/reviews/`.
+
+## Install
+
+### Prerequisites
+
+- [Sego](https://github.com/007M7/Sego-Agent) built and on PATH, or built from source:
+  ```bash
+  cargo build -p rusty-claude-cli
+  ```
+- A git repository (review uses `git diff`)
+
+### Use in Zcode / Claude Code / any SKILL.md-compatible tool
+
+Copy the `sego-review/` directory into your tool's skills directory.
+
+## Usage
+
+### Command line
+
+```bash
+# Unix
+echo '{"schema_version":1,"action":"review","cwd":"'"$PWD"'","scope":"staged"}' \
+  | bash skills/sego-review/scripts/sego-review.sh
+
+# Windows PowerShell
+$request = @{ schema_version = 1; action = "review"; cwd = (Get-Location).Path; scope = "staged" } | ConvertTo-Json
+$request | powershell -File skills/sego-review/scripts/sego-review.ps1
+```
+
+### Via `sego sidecar review` directly
+
+```bash
+echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' | sego sidecar review
+```
+
+## Request format
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `schema_version` | integer | yes | Must be `1` |
+| `action` | string | yes | Must be `"review"` |
+| `cwd` | string | yes | Absolute path to project root |
+| `scope` | string | no | `"staged"`, `"workspace"`, or a path (default: `staged`) |
+| `options.model` | string | no | Override review model |
+| `context.user_intent` | string | no | What the user wants to achieve |
+
+## Response format
+
+See [SKILL.md](SKILL.md) for the full response schema. Key fields:
+
+- `status`: `"ok"` or `"error"`
+- `findings`: array of structured findings (severity/file/line/evidence/risk/suggestion)
+- `artifact_path`: path to persisted review JSON
+- `error`: present only when `status` is `"error"`
+
+## Graceful degradation
+
+If the Sego binary is not found, the script outputs a structured error JSON to stderr and exits with code 1 — it does not crash silently.
+
+## 接入 AI 编码工具（Sidecar skill PoC）
+
+### 一键安装 skill
+
+```bash
+# Mac / Linux
+bash skills/sego-review/install.sh
+
+# Windows
+powershell -File skills\sego-review\install.ps1
+```
+
+自动检测 Claude Code / Codex / Zcode / Cursor 并复制 skill 包。
+
+### 手动 sidecar 调用
+
+```bash
+echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' | sego sidecar review
+```
+
+- stdout 返回纯 JSON（findings + artifact_path）
+- stderr 留给诊断日志
+- exit code：0 成功，1 错误
+
+### 已知限制（PoC）
+
+- 仅支持 `review` action（verify/export 后续扩展）
+- Cursor 通过 `.cursorrules` 适配，不是原生扩展
+- 这是早期集成（early integration），不承诺完整 IDE 插件生态


### PR DESCRIPTION
Sidecar skill PoC: one-click install (install.sh/ps1), manual sidecar call, known limitations. Dogfooding passed 3-path (empty/small/multi-file). Sego review passed 3/3.
