### PR TITLE
chore: bump workspace version to 0.1.3

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "api",
  "commands",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.0"
+version = "0.1.3"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/api/tests/client_integration.rs
+++ b/rust/crates/api/tests/client_integration.rs
@@ -65,7 +65,11 @@ async fn send_message_posts_json_and_parses_response() {
         Some("Bearer proxy-token")
     );
     assert_eq!(request.headers.get("anthropic-version").map(String::as_str), Some("2023-06-01"));
-    assert_eq!(request.headers.get("user-agent").map(String::as_str), Some("claude-code/0.1.0"));
+    let expected_user_agent = format!("claude-code/{}", env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        request.headers.get("user-agent").map(String::as_str),
+        Some(expected_user_agent.as_str())
+    );
     assert_eq!(
         request.headers.get("anthropic-beta").map(String::as_str),
         Some("claude-code-20250219,prompt-caching-scope-2026-01-05")


### PR DESCRIPTION
## Summary
- bump Rust workspace package version to 0.1.3
- update Cargo.lock workspace crate versions only
- keep registry dependency versions unchanged

## Why
- v0.1.2 release assets are functional, but sego --version still reports 0.1.0
- this aligns CLI version metadata with the next public release

## Tests
- cargo build -p rusty-claude-cli
- rust/target/debug/sego.exe --version -> Version 0.1.3
- git diff --check