### PR TITLE
docs: add launch site and audit intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/free-sego-audit.yml
+++ b/.github/ISSUE_TEMPLATE/free-sego-audit.yml
@@ -1,0 +1,92 @@
+name: "Free Sego Audit Request"
+description: "Request a free AI code review using Sego"
+title: "[Free Audit] "
+labels: ["free-audit", "pending-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Free Sego Audit Request
+
+        Send us a small AI-generated project and we'll run a free Sego review.
+        You'll get a structured report with security risks, quality issues, and commit readiness.
+
+        **This is a public GitHub issue. Do not submit secrets, production credentials,
+        private customer data, or private source code.**
+
+        If you do not want to publish your email, leave it blank and we will reply in this issue.
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: Your name
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Email (optional, public)
+      placeholder: Leave blank if you prefer GitHub replies
+    validations:
+      required: false
+  - type: input
+    id: repo
+    attributes:
+      label: GitHub repo URL
+      placeholder: https://github.com/you/project
+    validations:
+      required: true
+  - type: dropdown
+    id: public
+    attributes:
+      label: Is the repo public?
+      options:
+        - "Yes"
+        - "No (will share diff privately)"
+    validations:
+      required: true
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: What AI tool did you use?
+      options:
+        - Cursor
+        - Claude Code
+        - Codex
+        - GitHub Copilot
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What are you building?
+      placeholder: A brief description of your project
+    validations:
+      required: true
+  - type: textarea
+    id: focus
+    attributes:
+      label: What do you want Sego to check?
+      placeholder: e.g. security risks, SQL injection, hardcoded secrets, overall quality
+    validations:
+      required: false
+  - type: dropdown
+    id: publish
+    attributes:
+      label: Can we publish an anonymized case study?
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+  - type: dropdown
+    id: paid-later
+    attributes:
+      label: Are you open to a paid private audit later?
+      options:
+        - "Yes"
+        - "No"
+        - "Maybe"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/private-audit.yml
+++ b/.github/ISSUE_TEMPLATE/private-audit.yml
@@ -1,0 +1,86 @@
+name: "Private AI Code Audit"
+description: "Request a private AI code audit (paid, from $19)"
+title: "[Private Audit] "
+labels: ["private-audit", "pending-scope"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Private AI Code Audit Request
+
+        We review your private project or diff with Sego and deliver a structured report.
+        Pricing starts at $19 (overseas) or RMB 99 (China).
+
+        **This is a public GitHub issue. Do not upload sensitive source code, secrets,
+        production credentials, customer data, or private business details before we confirm the workflow.**
+
+        If you do not want to publish your email, leave it blank and we will reply in this issue first.
+  - type: input
+    id: name
+    attributes:
+      label: Name
+      placeholder: Your name
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Email (optional, public)
+      placeholder: Leave blank if you prefer GitHub replies
+    validations:
+      required: false
+  - type: input
+    id: project-type
+    attributes:
+      label: Project type
+      placeholder: e.g. web app, API, CLI tool, library
+    validations:
+      required: true
+  - type: dropdown
+    id: delivery
+    attributes:
+      label: Delivery method
+      options:
+        - Share private GitHub repo access after scope confirmation
+        - Send diff/patch file after scope confirmation
+        - Other (will discuss)
+    validations:
+      required: true
+  - type: input
+    id: deadline
+    attributes:
+      label: Expected deadline
+      placeholder: e.g. within 48 hours
+    validations:
+      required: false
+  - type: dropdown
+    id: budget
+    attributes:
+      label: Budget range
+      options:
+        - "$19 / RMB 99 (basic audit)"
+        - "$99 / RMB 699 (launch check)"
+        - "Custom (will discuss)"
+    validations:
+      required: true
+  - type: dropdown
+    id: payment
+    attributes:
+      label: Preferred payment method
+      options:
+        - PayPal
+        - Wise
+        - WeChat Pay
+        - Alipay
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: nda
+    attributes:
+      label: Need NDA?
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Sego 做独立的第三方审查——不和任何生成工具绑定，输出结
 
 ---
 
+## First Users / 免费代码体检
+
+Sego 正在招募第一批 AI Coding 用户。如果你正在用 Cursor、Claude Code、Codex、Copilot 或其他 AI 编码工具，可以申请一次免费的 Sego 审查。
+
+- [Apply for Free Sego Audit](docs/LAUNCH.md)
+- [Request Private AI Code Audit](docs/LAUNCH.md)
+- [Launch landing page](docs/index.html)
+
+---
+
 ## 快速开始
 
 📘 第一次使用建议先看这份指南：

--- a/docs/CLOUDFLARE-PAGES.md
+++ b/docs/CLOUDFLARE-PAGES.md
@@ -1,0 +1,93 @@
+# Deploy Sego Launch Site to Cloudflare Pages
+
+This guide deploys the Sego launch landing page from `docs/index.html`.
+
+## Recommended setup
+
+- Platform: Cloudflare Pages
+- Source: GitHub repository `007M7/Sego-Agent`
+- Project name: `sego-agent`
+- Production branch: `main`
+- Build command: leave empty
+- Build output directory: `docs`
+
+Cloudflare Pages will serve:
+
+```text
+docs/index.html
+```
+
+as the site homepage.
+
+## Steps
+
+1. Open Cloudflare Pages:
+
+   https://pages.cloudflare.com/
+
+2. Click **Create a project**.
+
+3. Connect the GitHub repository:
+
+   ```text
+   007M7/Sego-Agent
+   ```
+
+4. Use these build settings:
+
+   ```text
+   Framework preset: None
+   Build command: empty
+   Build output directory: docs
+   Root directory: /
+   Production branch: main
+   ```
+
+5. Deploy.
+
+6. After deployment, Cloudflare will give a URL like:
+
+   ```text
+   https://sego-agent.pages.dev
+   ```
+
+7. Open the URL and verify:
+
+   - Download Sego button opens GitHub Releases
+   - Apply for Free Sego Audit opens the free audit GitHub issue template
+   - Request Private Audit opens the private audit GitHub issue template
+   - View GitHub opens the repository
+
+## Temporary form strategy
+
+The launch site currently uses GitHub Issue templates instead of Tally/Fillout.
+
+Reason:
+
+- Tally creation was blocked during Day 1 launch setup
+- GitHub Issues are already available
+- This keeps the launch moving without waiting for a form vendor
+
+When Tally or Fillout is ready, replace only the CTA links in `docs/index.html`.
+
+## Public issue privacy warning
+
+Because GitHub Issues are public, users should not include:
+
+- production credentials
+- API keys
+- private customer data
+- private source code
+- unreleased business details
+
+The issue templates and landing page both include this warning.
+
+## Later upgrade path
+
+After 20+ leads or 3+ paid-intent users:
+
+1. Replace GitHub Issues with Tally/Fillout or a custom form
+2. Add Cloudflare Web Analytics
+3. Add a private audit intake flow
+4. Build a small backend for audit requests
+5. Evaluate GitHub App / PR bot

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -1,0 +1,62 @@
+# Sego Launch
+
+Sego is looking for the first 20 AI coding users.
+
+If you use Cursor, Claude Code, Codex, Copilot, Lovable, or another AI coding tool, you can send us a small AI-generated project. We will run a Sego review and send back a structured report.
+
+## What we review
+
+- Security risks such as SQL injection, hardcoded secrets, unsafe commands, and credential leaks
+- Code quality issues that can block shipping
+- Unexpected changes made by AI coding tools
+- Whether the current diff looks ready to commit or needs another pass
+
+## Free Sego Audit
+
+The free audit is for small public projects or small diffs.
+
+You receive:
+
+- A structured Sego review summary
+- The highest-risk findings
+- Suggested next steps before commit or release
+
+Apply here:
+
+https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=free-audit,pending-review&template=free-sego-audit.yml&title=%5BFree+Audit%5D+
+
+Public issue warning:
+
+Do not include secrets, credentials, private customer data, or private source code in a public GitHub issue.
+
+## Private AI Code Audit
+
+For private projects, paid audits start at:
+
+- $19 / RMB 99 for a basic private audit
+- $99 / RMB 699 for a launch check
+
+Request scope confirmation here:
+
+https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+
+
+Do not upload private code before the workflow is confirmed.
+
+## Why this exists
+
+AI coding tools can write code quickly. The open question is whether the generated code is safe enough to ship.
+
+Sego sits after AI coding tools:
+
+```text
+AI writes code.
+Sego reviews whether it is safe enough to commit.
+```
+
+This launch page is the first step toward a productized Sego workflow:
+
+- Local-first code review
+- Review artifacts
+- First-user audits
+- Case studies
+- Later GitHub PR bot and team dashboard

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sego - The engineering trust layer for AI-generated code</title>
+  <meta name="description" content="Sego reviews AI-generated code after it is written. Cursor, Claude Code and Codex can write code fast. Sego checks whether that code is safe enough to ship.">
+  <style>
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --accent: #1f6f8b;
+      --accent-light: #4ec9f5;
+      --text: #e0e0e0;
+      --text-dim: #8a8f9a;
+      --danger: #f06292;
+      --border: #2a2e3a;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 0 24px;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
+      line-height: 1.7;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 0;
+    }
+
+    nav .logo {
+      color: var(--accent-light);
+      font-size: 1.4rem;
+      font-weight: 700;
+    }
+
+    nav .links a {
+      margin-left: 24px;
+      color: var(--text-dim);
+      font-size: 0.9rem;
+      text-decoration: none;
+    }
+
+    nav .links a:hover {
+      color: var(--text);
+    }
+
+    .hero {
+      padding: 80px 0 60px;
+      text-align: center;
+    }
+
+    .hero h1 {
+      margin-bottom: 16px;
+      font-size: 2.8rem;
+      font-weight: 800;
+      line-height: 1.2;
+    }
+
+    .hero h1 span {
+      color: var(--accent-light);
+    }
+
+    .tagline {
+      max-width: 590px;
+      margin: 0 auto 40px;
+      color: var(--text-dim);
+      font-size: 1.25rem;
+    }
+
+    .tagline-cn {
+      display: block;
+      margin-top: 8px;
+      font-size: 1rem;
+      opacity: 0.75;
+    }
+
+    .cta-group {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 16px;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 14px 32px;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition: opacity 0.15s, transform 0.15s, border-color 0.15s;
+    }
+
+    .btn:hover {
+      transform: translateY(-2px);
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .btn-primary:hover {
+      opacity: 0.9;
+    }
+
+    .btn-secondary {
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+    }
+
+    .btn-secondary:hover {
+      border-color: var(--accent);
+    }
+
+    .btn-ghost {
+      color: var(--text-dim);
+    }
+
+    section {
+      padding: 60px 0;
+    }
+
+    section h2 {
+      margin-bottom: 24px;
+      font-size: 1.8rem;
+      font-weight: 700;
+      text-align: center;
+    }
+
+    section h3 {
+      margin-bottom: 8px;
+      font-size: 1.2rem;
+      font-weight: 600;
+    }
+
+    .problem-list {
+      max-width: 620px;
+      margin: 0 auto;
+    }
+
+    .problem-list li {
+      list-style: none;
+      padding: 12px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 1.05rem;
+    }
+
+    .problem-list li:last-child {
+      border-bottom: 0;
+    }
+
+    .label {
+      display: inline-block;
+      min-width: 82px;
+      color: var(--accent-light);
+      font-weight: 700;
+    }
+
+    .features {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 24px;
+    }
+
+    .feature-card {
+      padding: 24px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      transition: border-color 0.2s;
+    }
+
+    .feature-card:hover {
+      border-color: var(--accent);
+    }
+
+    .feature-card .badge {
+      color: var(--accent-light);
+      font-size: 0.75rem;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
+
+    .feature-card p {
+      margin-top: 8px;
+      color: var(--text-dim);
+      font-size: 0.95rem;
+    }
+
+    .demo-box {
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 32px;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      background: var(--surface);
+      font-family: "Consolas", "Courier New", monospace;
+      font-size: 0.9rem;
+      line-height: 1.6;
+    }
+
+    .demo-box .muted {
+      color: var(--text-dim);
+    }
+
+    .demo-box .critical {
+      color: var(--danger);
+      font-weight: 600;
+    }
+
+    .demo-box .file {
+      color: var(--accent-light);
+    }
+
+    .cta-section {
+      padding: 80px 0;
+      text-align: center;
+    }
+
+    .cta-section h2 {
+      font-size: 2rem;
+    }
+
+    .cta-section p {
+      max-width: 520px;
+      margin: 16px auto 32px;
+      color: var(--text-dim);
+    }
+
+    .note {
+      max-width: 600px;
+      margin: 24px auto 0;
+      color: var(--text-dim);
+      font-size: 0.88rem;
+      text-align: center;
+    }
+
+    footer {
+      padding: 32px 0;
+      border-top: 1px solid var(--border);
+      color: var(--text-dim);
+      font-size: 0.85rem;
+      text-align: center;
+    }
+
+    footer a {
+      margin: 0 12px;
+      color: var(--text-dim);
+      text-decoration: none;
+    }
+
+    footer a:hover {
+      color: var(--text);
+    }
+
+    @media (max-width: 600px) {
+      .hero h1 {
+        font-size: 2rem;
+      }
+
+      .tagline {
+        font-size: 1rem;
+      }
+
+      nav {
+        align-items: flex-start;
+      }
+
+      nav .links {
+        text-align: right;
+      }
+
+      nav .links a {
+        display: inline-block;
+        margin: 0 0 6px 12px;
+        font-size: 0.8rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <div class="logo">Sego</div>
+    <div class="links">
+      <a href="#features">Features</a>
+      <a href="#demo">Demo</a>
+      <a href="#first-users">Get Started</a>
+      <a href="LAUNCH.md">Launch</a>
+      <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero">
+      <h1>The engineering trust layer<br>for <span>AI-generated code</span></h1>
+      <p class="tagline">
+        Cursor, Claude Code and Codex can write code fast.<br>
+        Sego checks whether that code is safe enough to ship.
+        <span class="tagline-cn">AI writes code. Sego checks whether it is safe to ship.</span>
+      </p>
+      <div class="cta-group">
+        <a href="https://github.com/007M7/Sego-Agent/releases/latest" class="btn btn-primary">Download Sego</a>
+        <a href="#first-users" class="btn btn-secondary">Apply for Free Code Audit</a>
+        <a href="LAUNCH.md" class="btn btn-ghost">Read Launch Notes</a>
+      </div>
+    </section>
+
+    <section id="problem">
+      <h2>The gap AI coding does not close</h2>
+      <ul class="problem-list">
+        <li><span class="label">Security</span> Is the code safe? Are there hardcoded secrets?</li>
+        <li><span class="label">Risk</span> Is there SQL injection or dangerous command execution?</li>
+        <li><span class="label">Merge</span> Is this PR ready to merge?</li>
+        <li><span class="label">Diff</span> Did the AI change more than expected?</li>
+      </ul>
+    </section>
+
+    <section id="features">
+      <h2>What Sego does</h2>
+      <div class="features">
+        <div class="feature-card">
+          <div class="badge">Review</div>
+          <h3>Structured code review</h3>
+          <p>Reviews staged changes and outputs severity, file, line, evidence, risk, and suggestion for each finding.</p>
+        </div>
+        <div class="feature-card">
+          <div class="badge">Security</div>
+          <h3>Safety lock</h3>
+          <p>Detects hardcoded secrets, dangerous commands, absolute paths, and unexpected file changes.</p>
+        </div>
+        <div class="feature-card">
+          <div class="badge">History</div>
+          <h3>Review artifacts</h3>
+          <p>Every review is saved to .sego/reviews/ as structured JSON and readable Markdown.</p>
+        </div>
+        <div class="feature-card">
+          <div class="badge">Recovery</div>
+          <h3>Crash recovery</h3>
+          <p>Abnormal shutdown is detected on next launch. Resume without replaying old tool calls.</p>
+        </div>
+        <div class="feature-card">
+          <div class="badge">Permissions</div>
+          <h3>review-trust profile</h3>
+          <p>Read-only commands are auto-allowed, dangerous commands are denied, and review workflows need fewer prompts.</p>
+        </div>
+        <div class="feature-card">
+          <div class="badge">Integration</div>
+          <h3>Sidecar skill (PoC)</h3>
+          <p>Early integration for Claude Code, Codex, and Cursor through a sidecar review interface.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="demo">
+      <h2>See it in action</h2>
+      <div class="demo-box">
+        <div class="muted">AI-generated code (app.py):</div>
+        <span class="file">app.py line 6</span>
+        <div class="critical">CRITICAL: SQL injection</div>
+        <div>Risk: user input concatenated directly into SQL query</div>
+        <div>Fix: use parameterized queries</div>
+        <br>
+        <div class="muted">Sego output:</div>
+        <div>6 findings detected (1 critical, 1 high, 1 medium, 2 low, 1 info)</div>
+        <div>Artifact saved: .sego/reviews/review-001.json</div>
+        <div>Status: review complete, 2 issues must be fixed before commit</div>
+      </div>
+    </section>
+
+    <section id="first-users" class="cta-section">
+      <h2>Looking for the first 20 AI coding users</h2>
+      <p>
+        If you use Cursor, Claude Code, Codex, Copilot or another AI coding tool,
+        send us a small AI-generated project. We will run a free Sego review and
+        send back a structured report.
+      </p>
+      <div class="cta-group">
+        <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=free-audit,pending-review&template=free-sego-audit.yml&title=%5BFree+Audit%5D+" class="btn btn-primary">Apply for Free Sego Audit</a>
+        <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+" class="btn btn-secondary">Request Private Audit ($19+)</a>
+      </div>
+      <p class="note">
+        Temporary launch intake uses GitHub Issues while the public form is being prepared.
+        Do not include secrets, credentials, or private customer data in public issues.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
+    <a href="https://github.com/007M7/Sego-Agent/releases/latest">Download</a>
+    <a href="https://github.com/007M7/Sego-Agent/issues">Report Issue</a>
+    <a href="https://github.com/007M7/Sego-Agent/blob/main/README.md">Docs</a>
+    <a href="LAUNCH.md">Launch</a>
+    <br><br>
+    Sego Agent - MIT License - Built with Rust
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static launch landing page for Cloudflare Pages
- add launch notes and Cloudflare Pages deployment guide
- add GitHub issue templates for free Sego audits and private audit requests
- add README entry for first users and free code audit

## Tests
- checked launch files for Tally placeholders, invalid audit-form JS, and mojibake markers
- verified landing page links route to GitHub Releases and audit issue templates
- docs-only change; Rust tests not run

## Notes
- Tally/Fillout is no longer a Day 1 blocker; current intake uses GitHub Issues.
- Cloudflare Pages deployment should use build output directory: docs.