### PR TITLE
docs: polish launch page blue-white UI

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,14 +7,17 @@
   <meta name="description" content="Sego reviews AI-generated code after it is written. Cursor, Claude Code and Codex can write code fast. Sego checks whether that code is safe enough to ship.">
   <style>
     :root {
-      --bg: #0f1117;
-      --surface: #1a1d27;
-      --accent: #1f6f8b;
-      --accent-light: #4ec9f5;
-      --text: #e0e0e0;
-      --text-dim: #8a8f9a;
-      --danger: #f06292;
-      --border: #2a2e3a;
+      --page: #f6fbff;
+      --ink: #172033;
+      --muted: #5b6b82;
+      --soft: rgba(255, 255, 255, 0.78);
+      --card: rgba(255, 255, 255, 0.92);
+      --line: rgba(68, 109, 151, 0.16);
+      --blue: #1269d3;
+      --blue-2: #2b9cff;
+      --blue-3: #69c8ff;
+      --danger: #d53569;
+      --shadow: 0 22px 70px rgba(23, 73, 130, 0.13);
     }
 
     * {
@@ -24,84 +27,130 @@
     }
 
     body {
-      max-width: 880px;
-      margin: 0 auto;
-      padding: 0 24px;
-      background: var(--bg);
-      color: var(--text);
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 12% 8%, rgba(105, 200, 255, 0.32), transparent 34%),
+        radial-gradient(circle at 82% 2%, rgba(18, 105, 211, 0.16), transparent 30%),
+        linear-gradient(135deg, #ffffff 0%, #edf7ff 48%, #dcedff 100%);
+      color: var(--ink);
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
       line-height: 1.7;
     }
 
+    .page {
+      width: min(1180px, calc(100% - 48px));
+      margin: 0 auto;
+    }
+
     nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 20px 0;
+      margin: 18px 0 0;
+      padding: 14px 18px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.72);
+      box-shadow: 0 12px 36px rgba(40, 92, 145, 0.08);
+      backdrop-filter: blur(18px);
     }
 
-    nav .logo {
-      color: var(--accent-light);
-      font-size: 1.4rem;
-      font-weight: 700;
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--ink);
+      font-size: 1.16rem;
+      font-weight: 800;
+      text-decoration: none;
+    }
+
+    .brand img {
+      width: 34px;
+      height: 34px;
+      object-fit: contain;
     }
 
     nav .links a {
-      margin-left: 24px;
-      color: var(--text-dim);
-      font-size: 0.9rem;
+      margin-left: 22px;
+      color: var(--muted);
+      font-size: 0.92rem;
+      font-weight: 600;
       text-decoration: none;
     }
 
     nav .links a:hover {
-      color: var(--text);
+      color: var(--blue);
     }
 
     .hero {
-      padding: 80px 0 60px;
-      text-align: center;
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+      gap: clamp(32px, 5vw, 64px);
+      align-items: center;
+      min-height: calc(100vh - 92px);
+      padding: 70px 0 72px;
+    }
+
+    .eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 18px;
+      padding: 7px 12px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--soft);
+      color: var(--blue);
+      font-size: 0.88rem;
+      font-weight: 700;
     }
 
     .hero h1 {
-      margin-bottom: 16px;
-      font-size: 2.8rem;
-      font-weight: 800;
-      line-height: 1.2;
+      max-width: 780px;
+      margin-bottom: 20px;
+      color: #101828;
+      font-size: clamp(2.45rem, 6vw, 4.65rem);
+      font-weight: 850;
+      line-height: 1.02;
+      letter-spacing: 0;
     }
 
     .hero h1 span {
-      color: var(--accent-light);
+      color: var(--blue);
     }
 
     .tagline {
-      max-width: 590px;
-      margin: 0 auto 40px;
-      color: var(--text-dim);
-      font-size: 1.25rem;
+      max-width: 690px;
+      margin-bottom: 32px;
+      color: var(--muted);
+      font-size: 1.18rem;
     }
 
-    .tagline-cn {
-      display: block;
-      margin-top: 8px;
-      font-size: 1rem;
-      opacity: 0.75;
+    .tagline strong {
+      color: var(--ink);
     }
 
     .cta-group {
       display: flex;
       flex-wrap: wrap;
-      justify-content: center;
-      gap: 16px;
+      gap: 14px;
     }
 
     .btn {
-      display: inline-block;
-      padding: 14px 32px;
-      border-radius: 8px;
-      font-size: 1rem;
-      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 13px 24px;
+      border-radius: 10px;
+      font-size: 0.98rem;
+      font-weight: 750;
       text-decoration: none;
-      transition: opacity 0.15s, transform 0.15s, border-color 0.15s;
+      transition: transform 0.15s, box-shadow 0.15s, border-color 0.15s, background 0.15s;
     }
 
     .btn:hover {
@@ -109,173 +158,259 @@
     }
 
     .btn-primary {
-      background: var(--accent);
+      background: linear-gradient(135deg, var(--blue) 0%, var(--blue-2) 100%);
       color: #fff;
-    }
-
-    .btn-primary:hover {
-      opacity: 0.9;
+      box-shadow: 0 14px 28px rgba(18, 105, 211, 0.24);
     }
 
     .btn-secondary {
-      border: 1px solid var(--border);
-      background: var(--surface);
-      color: var(--text);
+      border: 1px solid rgba(18, 105, 211, 0.2);
+      background: rgba(255, 255, 255, 0.78);
+      color: var(--blue);
     }
 
     .btn-secondary:hover {
-      border-color: var(--accent);
+      border-color: rgba(18, 105, 211, 0.45);
+      box-shadow: 0 12px 26px rgba(39, 115, 190, 0.12);
     }
 
     .btn-ghost {
-      color: var(--text-dim);
+      color: var(--muted);
+    }
+
+    .hero-card {
+      justify-self: end;
+      width: min(100%, 380px);
+      position: relative;
+      padding: 34px 30px;
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(245, 250, 255, 0.88));
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .hero-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 50% 0%, rgba(105, 200, 255, 0.28), transparent 45%);
+      pointer-events: none;
+    }
+
+    .hero-icon {
+      position: relative;
+      display: block;
+      width: 154px;
+      height: 154px;
+      margin: 0 auto 20px;
+      object-fit: contain;
+      filter: drop-shadow(0 22px 34px rgba(18, 105, 211, 0.2));
+    }
+
+    .hero-card h2 {
+      position: relative;
+      margin-bottom: 12px;
+      font-size: 1.28rem;
+      text-align: center;
+    }
+
+    .hero-card p {
+      position: relative;
+      color: var(--muted);
+      font-size: 0.96rem;
+      text-align: center;
     }
 
     section {
-      padding: 60px 0;
+      padding: 56px 0;
     }
 
     section h2 {
       margin-bottom: 24px;
-      font-size: 1.8rem;
-      font-weight: 700;
+      color: #132238;
+      font-size: 2rem;
+      font-weight: 800;
       text-align: center;
     }
 
     section h3 {
       margin-bottom: 8px;
-      font-size: 1.2rem;
-      font-weight: 600;
+      font-size: 1.12rem;
+      font-weight: 780;
     }
 
     .problem-list {
-      max-width: 620px;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+      max-width: 940px;
       margin: 0 auto;
     }
 
     .problem-list li {
       list-style: none;
-      padding: 12px 0;
-      border-bottom: 1px solid var(--border);
-      font-size: 1.05rem;
-    }
-
-    .problem-list li:last-child {
-      border-bottom: 0;
+      padding: 18px 20px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: var(--card);
+      box-shadow: 0 12px 36px rgba(45, 111, 180, 0.07);
+      font-size: 0.98rem;
     }
 
     .label {
-      display: inline-block;
-      min-width: 82px;
-      color: var(--accent-light);
-      font-weight: 700;
+      display: block;
+      margin-bottom: 4px;
+      color: var(--blue);
+      font-weight: 800;
     }
 
     .features {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 24px;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+      max-width: 1060px;
+      margin: 0 auto;
     }
 
     .feature-card {
+      min-height: 190px;
       padding: 24px;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: var(--surface);
-      transition: border-color 0.2s;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: var(--card);
+      box-shadow: 0 14px 42px rgba(37, 102, 168, 0.08);
+      transition: transform 0.18s, border-color 0.18s, box-shadow 0.18s;
     }
 
     .feature-card:hover {
-      border-color: var(--accent);
+      border-color: rgba(18, 105, 211, 0.32);
+      box-shadow: 0 20px 54px rgba(37, 102, 168, 0.13);
+      transform: translateY(-2px);
     }
 
     .feature-card .badge {
-      color: var(--accent-light);
-      font-size: 0.75rem;
-      font-weight: 600;
-      letter-spacing: 0.5px;
+      display: inline-flex;
+      margin-bottom: 10px;
+      padding: 4px 9px;
+      border-radius: 999px;
+      background: #e8f4ff;
+      color: var(--blue);
+      font-size: 0.72rem;
+      font-weight: 800;
+      letter-spacing: 0.4px;
       text-transform: uppercase;
     }
 
     .feature-card p {
-      margin-top: 8px;
-      color: var(--text-dim);
+      color: var(--muted);
       font-size: 0.95rem;
     }
 
     .demo-box {
-      max-width: 640px;
+      max-width: 820px;
       margin: 0 auto;
-      padding: 32px;
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: var(--surface);
+      padding: 28px;
+      border: 1px solid rgba(18, 105, 211, 0.16);
+      border-radius: 18px;
+      background: #0f1f35;
+      color: #dbeafe;
+      box-shadow: 0 22px 62px rgba(15, 31, 53, 0.18);
       font-family: "Consolas", "Courier New", monospace;
-      font-size: 0.9rem;
-      line-height: 1.6;
+      font-size: 0.92rem;
+      line-height: 1.65;
     }
 
     .demo-box .muted {
-      color: var(--text-dim);
+      color: #94a9c7;
     }
 
     .demo-box .critical {
-      color: var(--danger);
-      font-weight: 600;
+      color: #ff7aa2;
+      font-weight: 800;
     }
 
     .demo-box .file {
-      color: var(--accent-light);
+      color: #7dd3fc;
     }
 
     .cta-section {
-      padding: 80px 0;
+      padding: 72px 0 86px;
       text-align: center;
     }
 
-    .cta-section h2 {
-      font-size: 2rem;
+    .cta-panel {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 44px 28px;
+      border: 1px solid var(--line);
+      border-radius: 24px;
+      background: rgba(255, 255, 255, 0.86);
+      box-shadow: var(--shadow);
     }
 
     .cta-section p {
-      max-width: 520px;
-      margin: 16px auto 32px;
-      color: var(--text-dim);
+      max-width: 600px;
+      margin: 14px auto 28px;
+      color: var(--muted);
     }
 
     .note {
-      max-width: 600px;
-      margin: 24px auto 0;
-      color: var(--text-dim);
+      max-width: 680px;
+      margin: 22px auto 0;
+      color: var(--muted);
       font-size: 0.88rem;
-      text-align: center;
     }
 
     footer {
-      padding: 32px 0;
-      border-top: 1px solid var(--border);
-      color: var(--text-dim);
-      font-size: 0.85rem;
+      padding: 34px 0;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.88rem;
       text-align: center;
     }
 
     footer a {
       margin: 0 12px;
-      color: var(--text-dim);
+      color: var(--muted);
       text-decoration: none;
     }
 
     footer a:hover {
-      color: var(--text);
+      color: var(--blue);
     }
 
-    @media (max-width: 600px) {
-      .hero h1 {
-        font-size: 2rem;
+    @media (max-width: 900px) {
+      .page {
+        width: min(100% - 32px, 760px);
       }
 
-      .tagline {
-        font-size: 1rem;
+      .hero {
+        grid-template-columns: 1fr;
+        gap: 30px;
+        min-height: auto;
+        padding-top: 60px;
+        text-align: center;
+      }
+
+      .cta-group {
+        justify-content: center;
+      }
+
+      .hero-card {
+        max-width: 420px;
+        width: 100%;
+        margin: 0 auto;
+      }
+
+      .features {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+
+    @media (max-width: 620px) {
+      .page {
+        width: min(100% - 28px, 460px);
       }
 
       nav {
@@ -291,124 +426,152 @@
         margin: 0 0 6px 12px;
         font-size: 0.8rem;
       }
+
+      .hero {
+        padding-top: 44px;
+      }
+
+      .problem-list,
+      .features {
+        grid-template-columns: 1fr;
+      }
+
+      .btn {
+        width: 100%;
+      }
     }
   </style>
 </head>
 <body>
-  <nav>
-    <div class="logo">Sego</div>
-    <div class="links">
-      <a href="#features">Features</a>
-      <a href="#demo">Demo</a>
-      <a href="#first-users">Get Started</a>
-      <a href="LAUNCH.md">Launch</a>
+  <div class="page">
+    <nav>
+      <a class="brand" href="#">
+        <img src="../assets/sego-ui-icon-512.png" alt="Sego icon">
+        <span>Sego</span>
+      </a>
+      <div class="links">
+        <a href="#features">Features</a>
+        <a href="#demo">Demo</a>
+        <a href="#first-users">Get Started</a>
+        <a href="LAUNCH.md">Launch</a>
+        <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
+      </div>
+    </nav>
+
+    <main>
+      <section class="hero">
+        <div>
+          <div class="eyebrow">Local-first AI code review</div>
+          <h1>The engineering trust layer for <span>AI-generated code</span></h1>
+          <p class="tagline">
+            Cursor, Claude Code and Codex can write code fast.
+            <strong>Sego checks whether that code is safe enough to ship.</strong>
+          </p>
+          <div class="cta-group">
+            <a href="https://github.com/007M7/Sego-Agent/releases/latest" class="btn btn-primary">Download Sego</a>
+            <a href="#first-users" class="btn btn-secondary">Apply for Free Code Audit</a>
+            <a href="LAUNCH.md" class="btn btn-ghost">Read Launch Notes</a>
+          </div>
+        </div>
+
+        <aside class="hero-card" aria-label="Sego product mark">
+          <img class="hero-icon" src="../assets/sego-ui-icon-512.png" alt="Sego lily shield icon">
+          <h2>AI writes code. Sego reviews the risk.</h2>
+          <p>Structured findings, review history, crash recovery, and a lower-friction review-trust workflow.</p>
+        </aside>
+      </section>
+
+      <section id="problem">
+        <h2>The gap AI coding does not close</h2>
+        <ul class="problem-list">
+          <li><span class="label">Security</span> Is the code safe? Are there hardcoded secrets?</li>
+          <li><span class="label">Risk</span> Is there SQL injection or dangerous command execution?</li>
+          <li><span class="label">Merge</span> Is this PR ready to merge?</li>
+          <li><span class="label">Diff</span> Did the AI change more than expected?</li>
+        </ul>
+      </section>
+
+      <section id="features">
+        <h2>What Sego does</h2>
+        <div class="features">
+          <div class="feature-card">
+            <div class="badge">Review</div>
+            <h3>Structured code review</h3>
+            <p>Reviews staged changes and outputs severity, file, line, evidence, risk, and suggestion for each finding.</p>
+          </div>
+          <div class="feature-card">
+            <div class="badge">Security</div>
+            <h3>Safety lock</h3>
+            <p>Detects hardcoded secrets, dangerous commands, absolute paths, and unexpected file changes.</p>
+          </div>
+          <div class="feature-card">
+            <div class="badge">History</div>
+            <h3>Review artifacts</h3>
+            <p>Every review is saved to .sego/reviews/ as structured JSON and readable Markdown.</p>
+          </div>
+          <div class="feature-card">
+            <div class="badge">Recovery</div>
+            <h3>Crash recovery</h3>
+            <p>Abnormal shutdown is detected on next launch. Resume without replaying old tool calls.</p>
+          </div>
+          <div class="feature-card">
+            <div class="badge">Permissions</div>
+            <h3>review-trust profile</h3>
+            <p>Read-only commands are auto-allowed, dangerous commands are denied, and review workflows need fewer prompts.</p>
+          </div>
+          <div class="feature-card">
+            <div class="badge">Integration</div>
+            <h3>Sidecar skill (PoC)</h3>
+            <p>Early integration for Claude Code, Codex, and Cursor through a sidecar review interface.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="demo">
+        <h2>See it in action</h2>
+        <div class="demo-box">
+          <div class="muted">AI-generated code (app.py):</div>
+          <span class="file">app.py line 6</span>
+          <div class="critical">CRITICAL: SQL injection</div>
+          <div>Risk: user input concatenated directly into SQL query</div>
+          <div>Fix: use parameterized queries</div>
+          <br>
+          <div class="muted">Sego output:</div>
+          <div>6 findings detected (1 critical, 1 high, 1 medium, 2 low, 1 info)</div>
+          <div>Artifact saved: .sego/reviews/review-001.json</div>
+          <div>Status: review complete, 2 issues must be fixed before commit</div>
+        </div>
+      </section>
+
+      <section id="first-users" class="cta-section">
+        <div class="cta-panel">
+          <h2>Looking for the first 20 AI coding users</h2>
+          <p>
+            If you use Cursor, Claude Code, Codex, Copilot or another AI coding tool,
+            send us a small AI-generated project. We will run a free Sego review and
+            send back a structured report.
+          </p>
+          <div class="cta-group">
+            <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=free-audit,pending-review&template=free-sego-audit.yml&title=%5BFree+Audit%5D+" class="btn btn-primary">Apply for Free Sego Audit</a>
+            <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+" class="btn btn-secondary">Request Private Audit ($19+)</a>
+          </div>
+          <p class="note">
+            Temporary launch intake uses GitHub Issues while the public form is being prepared.
+            Do not include secrets, credentials, or private customer data in public issues.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <footer>
       <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
-    </div>
-  </nav>
-
-  <main>
-    <section class="hero">
-      <h1>The engineering trust layer<br>for <span>AI-generated code</span></h1>
-      <p class="tagline">
-        Cursor, Claude Code and Codex can write code fast.<br>
-        Sego checks whether that code is safe enough to ship.
-        <span class="tagline-cn">AI writes code. Sego checks whether it is safe to ship.</span>
-      </p>
-      <div class="cta-group">
-        <a href="https://github.com/007M7/Sego-Agent/releases/latest" class="btn btn-primary">Download Sego</a>
-        <a href="#first-users" class="btn btn-secondary">Apply for Free Code Audit</a>
-        <a href="LAUNCH.md" class="btn btn-ghost">Read Launch Notes</a>
-      </div>
-    </section>
-
-    <section id="problem">
-      <h2>The gap AI coding does not close</h2>
-      <ul class="problem-list">
-        <li><span class="label">Security</span> Is the code safe? Are there hardcoded secrets?</li>
-        <li><span class="label">Risk</span> Is there SQL injection or dangerous command execution?</li>
-        <li><span class="label">Merge</span> Is this PR ready to merge?</li>
-        <li><span class="label">Diff</span> Did the AI change more than expected?</li>
-      </ul>
-    </section>
-
-    <section id="features">
-      <h2>What Sego does</h2>
-      <div class="features">
-        <div class="feature-card">
-          <div class="badge">Review</div>
-          <h3>Structured code review</h3>
-          <p>Reviews staged changes and outputs severity, file, line, evidence, risk, and suggestion for each finding.</p>
-        </div>
-        <div class="feature-card">
-          <div class="badge">Security</div>
-          <h3>Safety lock</h3>
-          <p>Detects hardcoded secrets, dangerous commands, absolute paths, and unexpected file changes.</p>
-        </div>
-        <div class="feature-card">
-          <div class="badge">History</div>
-          <h3>Review artifacts</h3>
-          <p>Every review is saved to .sego/reviews/ as structured JSON and readable Markdown.</p>
-        </div>
-        <div class="feature-card">
-          <div class="badge">Recovery</div>
-          <h3>Crash recovery</h3>
-          <p>Abnormal shutdown is detected on next launch. Resume without replaying old tool calls.</p>
-        </div>
-        <div class="feature-card">
-          <div class="badge">Permissions</div>
-          <h3>review-trust profile</h3>
-          <p>Read-only commands are auto-allowed, dangerous commands are denied, and review workflows need fewer prompts.</p>
-        </div>
-        <div class="feature-card">
-          <div class="badge">Integration</div>
-          <h3>Sidecar skill (PoC)</h3>
-          <p>Early integration for Claude Code, Codex, and Cursor through a sidecar review interface.</p>
-        </div>
-      </div>
-    </section>
-
-    <section id="demo">
-      <h2>See it in action</h2>
-      <div class="demo-box">
-        <div class="muted">AI-generated code (app.py):</div>
-        <span class="file">app.py line 6</span>
-        <div class="critical">CRITICAL: SQL injection</div>
-        <div>Risk: user input concatenated directly into SQL query</div>
-        <div>Fix: use parameterized queries</div>
-        <br>
-        <div class="muted">Sego output:</div>
-        <div>6 findings detected (1 critical, 1 high, 1 medium, 2 low, 1 info)</div>
-        <div>Artifact saved: .sego/reviews/review-001.json</div>
-        <div>Status: review complete, 2 issues must be fixed before commit</div>
-      </div>
-    </section>
-
-    <section id="first-users" class="cta-section">
-      <h2>Looking for the first 20 AI coding users</h2>
-      <p>
-        If you use Cursor, Claude Code, Codex, Copilot or another AI coding tool,
-        send us a small AI-generated project. We will run a free Sego review and
-        send back a structured report.
-      </p>
-      <div class="cta-group">
-        <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=free-audit,pending-review&template=free-sego-audit.yml&title=%5BFree+Audit%5D+" class="btn btn-primary">Apply for Free Sego Audit</a>
-        <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+" class="btn btn-secondary">Request Private Audit ($19+)</a>
-      </div>
-      <p class="note">
-        Temporary launch intake uses GitHub Issues while the public form is being prepared.
-        Do not include secrets, credentials, or private customer data in public issues.
-      </p>
-    </section>
-  </main>
-
-  <footer>
-    <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
-    <a href="https://github.com/007M7/Sego-Agent/releases/latest">Download</a>
-    <a href="https://github.com/007M7/Sego-Agent/issues">Report Issue</a>
-    <a href="https://github.com/007M7/Sego-Agent/blob/main/README.md">Docs</a>
-    <a href="LAUNCH.md">Launch</a>
-    <br><br>
-    Sego Agent - MIT License - Built with Rust
-  </footer>
+      <a href="https://github.com/007M7/Sego-Agent/releases/latest">Download</a>
+      <a href="https://github.com/007M7/Sego-Agent/issues">Report Issue</a>
+      <a href="https://github.com/007M7/Sego-Agent/blob/main/README.md">Docs</a>
+      <a href="LAUNCH.md">Launch</a>
+      <br><br>
+      Sego Agent - MIT License - Built with Rust
+    </footer>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the launch page with a blue-white gradient visual system
- add the Sego UI icon to the nav and hero card
- improve desktop responsive layout with a wider container, adaptive hero columns, and stable feature grids
- keep mobile as a single-column layout with full-width CTAs

## Tests
- checked no Tally placeholder, audit-form JS, or mojibake markers remain
- verified launch CTAs still point to Releases and audit issue templates
- docs-only change; Rust tests not run