### PR TITLE
fix: route launch links to landing page section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -473,7 +473,7 @@
         <a href="#features">Features</a>
         <a href="#demo">Demo</a>
         <a href="#first-users">Get Started</a>
-        <a href="LAUNCH.md">Launch</a>
+        <a href="#first-users">Launch</a>
         <a href="https://github.com/007M7/Sego-Agent">GitHub</a>
       </div>
     </nav>
@@ -490,7 +490,7 @@
           <div class="cta-group">
             <a href="https://github.com/007M7/Sego-Agent/releases/latest" class="btn btn-primary">Download Sego</a>
             <a href="#first-users" class="btn btn-secondary">Apply for Free Code Audit</a>
-            <a href="LAUNCH.md" class="btn btn-ghost">Read Launch Notes</a>
+            <a href="#first-users" class="btn btn-ghost">Join Launch</a>
           </div>
         </div>
 
@@ -588,7 +588,7 @@
       <a href="https://github.com/007M7/Sego-Agent/releases/latest">Download</a>
       <a href="https://github.com/007M7/Sego-Agent/issues">Report Issue</a>
       <a href="https://github.com/007M7/Sego-Agent/blob/main/README.md">Docs</a>
-      <a href="LAUNCH.md">Launch</a>
+      <a href="#first-users">Launch</a>
       <br><br>
       Sego Agent - MIT License - Built with Rust
     </footer>


### PR DESCRIPTION
## Summary
- change public launch page links from raw LAUNCH.md to the first-users section
- rename the hero ghost CTA to Join Launch so visitors stay inside the polished landing page
- keep LAUNCH.md in the repo as an internal/reference note, but avoid exposing raw markdown from the website nav

## Tests
- verified docs/index.html no longer links to LAUNCH.md
- reviewed git diff: only docs/index.html changed