### PR TITLE
docs: add BNB Chain payment flow for private audits

### DIFF
--- a/.github/ISSUE_TEMPLATE/private-audit.yml
+++ b/.github/ISSUE_TEMPLATE/private-audit.yml
@@ -10,11 +10,14 @@ body:
 
         We review your private project or diff with Sego and deliver a structured report.
         Pricing starts at $19 (overseas) or RMB 99 (China).
+        Overseas payments are currently accepted through BNB Chain only, after
+        we confirm the audit scope and delivery plan.
 
         **This is a public GitHub issue. Do not upload sensitive source code, secrets,
         production credentials, customer data, or private business details before we confirm the workflow.**
 
         If you do not want to publish your email, leave it blank and we will reply in this issue first.
+        Do not send payment before the scope is confirmed.
   - type: input
     id: name
     attributes:
@@ -68,13 +71,19 @@ body:
     attributes:
       label: Preferred payment method
       options:
-        - PayPal
-        - Wise
+        - BNB Chain (overseas)
         - WeChat Pay
         - Alipay
-        - Other
+        - Other (will discuss)
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Payment note:** overseas paid audits use BNB Chain for now. We will
+        confirm scope, price, delivery window, and payment details before any
+        transfer. Do not post wallet addresses, transaction hashes, private code,
+        or sensitive business information in this public issue unless requested.
   - type: dropdown
     id: nda
     attributes:

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -36,6 +36,10 @@ For private projects, paid audits start at:
 - $19 / RMB 99 for a basic private audit
 - $99 / RMB 699 for a launch check
 
+Overseas payments are currently accepted through BNB Chain only. Please request
+scope confirmation first; do not send payment before the audit scope, price,
+delivery window, and payment details are confirmed.
+
 Request scope confirmation here:
 
 https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+

--- a/docs/index.html
+++ b/docs/index.html
@@ -573,11 +573,12 @@
           </p>
           <div class="cta-group">
             <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=free-audit,pending-review&template=free-sego-audit.yml&title=%5BFree+Audit%5D+" class="btn btn-primary">Apply for Free Sego Audit</a>
-            <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+" class="btn btn-secondary">Request Private Audit ($19+)</a>
+            <a href="https://github.com/007M7/Sego-Agent/issues/new?assignees=&labels=private-audit,pending-scope&template=private-audit.yml&title=%5BPrivate+Audit%5D+" class="btn btn-secondary">Request Private Audit ($19+, BNB Chain)</a>
           </div>
           <p class="note">
             Temporary launch intake uses GitHub Issues while the public form is being prepared.
-            Do not include secrets, credentials, or private customer data in public issues.
+            Overseas paid audits use BNB Chain after scope confirmation. Do not include secrets,
+            credentials, or private customer data in public issues.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- document BNB Chain as the current overseas payment method for private audits
- update private audit issue template payment options
- keep payment after scope confirmation; no wallet address or transaction details are requested in public issues

## Notes
- This is a docs-only commercialization flow update.
- It intentionally avoids publishing a wallet address on the landing page to reduce mistaken payments and impersonation risk.