### PR TITLE
fix: improve first-run auth error guidance

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -47,8 +47,11 @@ if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
   echo   setx DEEPSEEK_API_KEY "your-key"
   echo   setx ANTHROPIC_API_KEY "your-key"
   echo.
+  echo [Sego] After running setx, close this window and open Sego again.
+  echo.
 )
 
+set "SEGO_PAUSE_ON_ERROR=1"
 "%~dp0sego.exe" %*
 set "SEGO_EXIT=%ERRORLEVEL%"
 echo.
@@ -97,4 +100,5 @@ Write-Host "  # Or Anthropic (alternative)" -ForegroundColor White
 Write-Host "  setx ANTHROPIC_API_KEY ""sk-your-anthropic-key""" -ForegroundColor White
 Write-Host ""
 Write-Host "Run from terminal: sego" -ForegroundColor White
-Write-Host "Or double-click the Sego desktop shortcut." -ForegroundColor White
+Write-Host "Or double-click the Sego desktop shortcut / $LauncherPath." -ForegroundColor White
+Write-Host "Tip: do not double-click sego.exe directly; use Sego.cmd so errors stay visible." -ForegroundColor Yellow

--- a/rust/crates/api/src/error.rs
+++ b/rust/crates/api/src/error.rs
@@ -64,8 +64,9 @@ impl Display for ApiError {
         match self {
             Self::MissingCredentials { provider, env_vars } => write!(
                 f,
-                "missing {provider} credentials; export {} before calling the {provider} API",
-                env_vars.join(" or ")
+                "missing {provider} credentials; set {} before calling the {provider} API.\n\n{}",
+                env_vars.join(" or "),
+                credential_setup_hint(provider, env_vars),
             ),
             Self::ExpiredOAuthToken => {
                 write!(f, "saved OAuth token is expired and no refresh token is available")
@@ -77,12 +78,15 @@ impl Display for ApiError {
             Self::Http(error) => write!(f, "http error: {error}"),
             Self::Io(error) => write!(f, "io error: {error}"),
             Self::Json(error) => write!(f, "json error: {error}"),
-            Self::Api { status, error_type, message, body, .. } => match (error_type, message) {
-                (Some(error_type), Some(message)) => {
-                    write!(f, "api returned {status} ({error_type}): {message}")
+            Self::Api { status, error_type, message, body, .. } => {
+                let auth_hint = authentication_error_hint(*status, error_type, message, body);
+                match (error_type, message) {
+                    (Some(error_type), Some(message)) => {
+                        write!(f, "api returned {status} ({error_type}): {message}{auth_hint}")
+                    }
+                    _ => write!(f, "api returned {status}: {body}{auth_hint}"),
                 }
-                _ => write!(f, "api returned {status}: {body}"),
-            },
+            }
             Self::RetriesExhausted { attempts, last_error } => {
                 write!(f, "api failed after {attempts} attempts: {last_error}")
             }
@@ -92,6 +96,45 @@ impl Display for ApiError {
                 "retry backoff overflowed on attempt {attempt} with base delay {base_delay:?}"
             ),
         }
+    }
+}
+
+fn credential_setup_hint(provider: &str, env_vars: &[&str]) -> String {
+    if env_vars.contains(&"DEEPSEEK_API_KEY") || provider.eq_ignore_ascii_case("deepseek") {
+        "DeepSeek setup:\n  PowerShell: setx DEEPSEEK_API_KEY \"sk-your-deepseek-key\"\n  Then close and reopen the terminal before running sego again.".to_string()
+    } else {
+        format!(
+            "Set the required environment variable, then close and reopen the terminal before running sego again.\nRequired: {}",
+            env_vars.join(" or ")
+        )
+    }
+}
+
+fn authentication_error_hint(
+    status: reqwest::StatusCode,
+    error_type: &Option<String>,
+    message: &Option<String>,
+    body: &str,
+) -> &'static str {
+    let status_is_auth = matches!(status.as_u16(), 401 | 403);
+    let haystack = format!(
+        "{} {} {}",
+        error_type.as_deref().unwrap_or_default(),
+        message.as_deref().unwrap_or_default(),
+        body
+    )
+    .to_ascii_lowercase();
+    let looks_like_auth_error = status_is_auth
+        || haystack.contains("authentication")
+        || haystack.contains("unauthorized")
+        || haystack.contains("invalid api key")
+        || haystack.contains("api key")
+        || haystack.contains("auth");
+
+    if looks_like_auth_error {
+        "\n\nAuthentication failed. If you are using the default DeepSeek model, check DEEPSEEK_API_KEY.\nPowerShell setup:\n  setx DEEPSEEK_API_KEY \"sk-your-deepseek-key\"\nThen close and reopen the terminal before running sego again.\nYou can also run `sego doctor` to inspect local setup."
+    } else {
+        ""
     }
 }
 
@@ -118,5 +161,36 @@ impl From<serde_json::Error> for ApiError {
 impl From<VarError> for ApiError {
     fn from(value: VarError) -> Self {
         Self::InvalidApiKeyEnv(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiError;
+
+    #[test]
+    fn missing_deepseek_credentials_show_setup_hint() {
+        let message = ApiError::missing_credentials("DeepSeek", &["DEEPSEEK_API_KEY"]).to_string();
+
+        assert!(message.contains("missing DeepSeek credentials"));
+        assert!(message.contains("setx DEEPSEEK_API_KEY"));
+        assert!(message.contains("close and reopen the terminal"));
+    }
+
+    #[test]
+    fn deepseek_authentication_errors_show_setup_hint() {
+        let message = ApiError::Api {
+            status: reqwest::StatusCode::UNAUTHORIZED,
+            error_type: Some("authentication_error".to_string()),
+            message: Some("Authentication Fails, Your api key is invalid".to_string()),
+            body: String::new(),
+            retryable: false,
+        }
+        .to_string();
+
+        assert!(message.contains("api returned 401 Unauthorized"));
+        assert!(message.contains("Authentication failed"));
+        assert!(message.contains("setx DEEPSEEK_API_KEY"));
+        assert!(message.contains("sego doctor"));
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -179,8 +179,20 @@ fn main() {
 Run `sego --help` for usage."
             );
         }
+        maybe_pause_after_error();
         std::process::exit(1);
     }
+}
+
+fn maybe_pause_after_error() {
+    if !cfg!(windows) || env::var_os("SEGO_PAUSE_ON_ERROR").is_none() {
+        return;
+    }
+
+    eprintln!();
+    eprintln!("Press Enter to close this window.");
+    let mut buffer = String::new();
+    let _ = io::stdin().read_line(&mut buffer);
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary
- add actionable DeepSeek setup guidance for missing credentials and 401/authentication errors
- keep Windows launcher windows readable by enabling SEGO_PAUSE_ON_ERROR
- update installer messaging so users run Sego.cmd / desktop shortcut instead of double-clicking sego.exe directly

## Tests
- cargo fmt --all --check
- cargo test -p api error::tests
- cargo build -p rusty-claude-cli
- git diff --check

## User impact
When DeepSeek returns 401 Unauthorized, users now see how to set DEEPSEEK_API_KEY and are told to reopen the terminal instead of only seeing a raw provider error.