### PR TITLE
feat: add user-triggered update flow

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,7 @@ $Binary = "sego.exe"
 $InstallDir = "$env:USERPROFILE\sego"
 $BinPath = "$InstallDir\$Binary"
 $LauncherPath = "$InstallDir\Sego.cmd"
+$UpdaterPath = "$InstallDir\Update Sego.cmd"
 
 Write-Host "Sego Agent Installer" -ForegroundColor Cyan
 Write-Host ""
@@ -62,6 +63,17 @@ exit /b %SEGO_EXIT%
 Set-Content -Path $LauncherPath -Value $LauncherContent -Encoding ASCII
 Write-Host "Created launcher: $LauncherPath" -ForegroundColor Green
 
+$UpdaterContent = @'
+@echo off
+setlocal EnableExtensions
+title Update Sego
+"%~dp0sego.exe" update
+echo.
+pause
+'@
+Set-Content -Path $UpdaterPath -Value $UpdaterContent -Encoding ASCII
+Write-Host "Created updater: $UpdaterPath" -ForegroundColor Green
+
 # Create desktop shortcut for normal Windows users.
 try {
     $DesktopPath = [Environment]::GetFolderPath("Desktop")
@@ -75,6 +87,15 @@ try {
         $Shortcut.Description = "Open Sego Agent"
         $Shortcut.Save()
         Write-Host "Created desktop shortcut: $ShortcutPath" -ForegroundColor Green
+
+        $UpdateShortcutPath = Join-Path $DesktopPath "Update Sego.lnk"
+        $UpdateShortcut = $Shell.CreateShortcut($UpdateShortcutPath)
+        $UpdateShortcut.TargetPath = $UpdaterPath
+        $UpdateShortcut.WorkingDirectory = $env:USERPROFILE
+        $UpdateShortcut.IconLocation = "$BinPath,0"
+        $UpdateShortcut.Description = "Update Sego Agent"
+        $UpdateShortcut.Save()
+        Write-Host "Created desktop shortcut: $UpdateShortcutPath" -ForegroundColor Green
     }
 } catch {
     Write-Host "Could not create desktop shortcut: $($_.Exception.Message)" -ForegroundColor Yellow
@@ -100,5 +121,7 @@ Write-Host "  # Or Anthropic (alternative)" -ForegroundColor White
 Write-Host "  setx ANTHROPIC_API_KEY ""sk-your-anthropic-key""" -ForegroundColor White
 Write-Host ""
 Write-Host "Run from terminal: sego" -ForegroundColor White
+Write-Host "Update from terminal: sego update" -ForegroundColor White
 Write-Host "Or double-click the Sego desktop shortcut / $LauncherPath." -ForegroundColor White
+Write-Host "Or double-click Update Sego / $UpdaterPath." -ForegroundColor White
 Write-Host "Tip: do not double-click sego.exe directly; use Sego.cmd so errors stay visible." -ForegroundColor Yellow

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "api",
  "commands",
@@ -1197,6 +1197,7 @@ dependencies = [
  "mock-anthropic-service",
  "plugins",
  "pulldown-cmark",
+ "reqwest",
  "runtime",
  "rustyline",
  "serde",
@@ -1446,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -1567,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/rusty-claude-cli/Cargo.toml
+++ b/rust/crates/rusty-claude-cli/Cargo.toml
@@ -15,6 +15,7 @@ commands = { path = "../commands" }
 compat-harness = { path = "../compat-harness" }
 crossterm = "0.28"
 pulldown-cmark = "0.13"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rustyline = "15"
 runtime = { path = "../runtime" }
 plugins = { path = "../plugins" }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -18,7 +18,7 @@ use std::io::{self, Read, Write};
 use std::net::TcpListener;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -149,6 +149,9 @@ const PRIMARY_SESSION_EXTENSION: &str = "jsonl";
 const LEGACY_SESSION_EXTENSION: &str = "json";
 const LATEST_SESSION_REFERENCE: &str = "latest";
 const SESSION_REFERENCE_ALIASES: &[&str] = &[LATEST_SESSION_REFERENCE, "last", "recent"];
+const UPDATE_CHECK_ENV: &str = "SEGO_SKIP_UPDATE_CHECK";
+const UPDATE_LATEST_URL: &str = "https://api.github.com/repos/007M7/Sego-Agent/releases/latest";
+const UPDATE_WINDOWS_ASSET: &str = "sego.exe";
 const CLI_OPTION_SUGGESTIONS: &[&str] = &[
     "--help",
     "-h",
@@ -208,6 +211,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             | CliAction::CodeReview { .. }
             | CliAction::ResumeSession { .. }
     );
+    let triggers_update_check = matches!(
+        action,
+        CliAction::Repl { .. } | CliAction::Prompt { .. } | CliAction::CodeReview { .. }
+    );
+    maybe_print_update_notice(triggers_update_check);
     maybe_print_recovery_notice(triggers_recovery);
 
     match action {
@@ -223,6 +231,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::Skills { args } => LiveCli::print_skills(args.as_deref())?,
         CliAction::PrintSystemPrompt { cwd, date } => print_system_prompt(cwd, date),
         CliAction::Version => print_version(),
+        CliAction::Update => run_update()?,
         CliAction::ResumeSession { session_path, commands } => {
             resume_session(&session_path, &commands);
         }
@@ -302,6 +311,7 @@ enum CliAction {
         date: String,
     },
     Version,
+    Update,
     ResumeSession {
         session_path: PathBuf,
         commands: Vec<String>,
@@ -587,6 +597,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         "mcp" => Ok(CliAction::Mcp { args: join_optional_args(&rest[1..]) }),
         "skills" => Ok(CliAction::Skills { args: join_optional_args(&rest[1..]) }),
         "system-prompt" => parse_system_prompt_args(&rest[1..]),
+        "update" => Ok(CliAction::Update),
         "login" => Ok(CliAction::Login),
         "logout" => Ok(CliAction::Logout),
         "init" => Ok(CliAction::Init),
@@ -623,6 +634,7 @@ fn parse_single_word_command_alias(
     match rest[0].as_str() {
         "help" => Some(Ok(CliAction::Help)),
         "version" => Some(Ok(CliAction::Version)),
+        "update" => Some(Ok(CliAction::Update)),
         "status" => Some(Ok(CliAction::Status {
             model: model.to_string(),
             permission_mode: permission_mode_override.unwrap_or_else(default_permission_mode),
@@ -651,6 +663,7 @@ fn bare_slash_command_guidance(command_name: &str) -> Option<String> {
             | "mcp"
             | "skills"
             | "system-prompt"
+            | "update"
             | "login"
             | "logout"
             | "init"
@@ -4066,6 +4079,147 @@ fn print_doctor(output_format: CliOutputFormat) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+    assets: Vec<GithubReleaseAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+fn maybe_print_update_notice(enabled: bool) {
+    if !enabled || env::var_os(UPDATE_CHECK_ENV).is_some() {
+        return;
+    }
+
+    let Ok(Some(release)) = fetch_latest_release() else {
+        return;
+    };
+    if is_newer_version(&release.tag_name, VERSION) {
+        eprintln!(
+            "Sego update available: current v{VERSION}, latest {}. Run `sego update` to install.",
+            release.tag_name
+        );
+    }
+}
+
+fn run_update() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(release) = fetch_latest_release()? else {
+        println!("Could not check for updates. Please try again later.");
+        return Ok(());
+    };
+
+    println!("Current version: v{VERSION}");
+    println!("Latest version:  {}", release.tag_name);
+
+    if !is_newer_version(&release.tag_name, VERSION) {
+        println!("Sego is already up to date.");
+        return Ok(());
+    }
+
+    let Some(asset) = release.assets.iter().find(|asset| asset.name == UPDATE_WINDOWS_ASSET) else {
+        println!(
+            "Latest release does not include {UPDATE_WINDOWS_ASSET}. Download manually: {}",
+            release.html_url
+        );
+        return Ok(());
+    };
+
+    if !cfg!(windows) {
+        println!(
+            "Automatic update is currently Windows-only. Download manually: {}",
+            release.html_url
+        );
+        return Ok(());
+    }
+
+    let current_exe = env::current_exe()?;
+    let install_dir = current_exe.parent().ok_or("could not resolve Sego install directory")?;
+    let temp_exe = install_dir.join("sego.update.exe");
+
+    println!("Downloading {} ...", asset.browser_download_url);
+    download_file(&asset.browser_download_url, &temp_exe)?;
+
+    let script_path = install_dir.join("sego-update.cmd");
+    let backup_exe = install_dir.join("sego.previous.exe");
+    let script = format!(
+        "@echo off\r\n\
+         setlocal EnableExtensions\r\n\
+         echo Updating Sego to {tag}...\r\n\
+         timeout /t 1 /nobreak >nul\r\n\
+         if exist \"{backup}\" del /f /q \"{backup}\"\r\n\
+         if exist \"{current}\" move /y \"{current}\" \"{backup}\" >nul\r\n\
+         move /y \"{temp}\" \"{current}\" >nul\r\n\
+         echo Sego updated to {tag}.\r\n\
+         \"{current}\" --version\r\n\
+         pause\r\n",
+        tag = release.tag_name,
+        backup = backup_exe.display(),
+        current = current_exe.display(),
+        temp = temp_exe.display(),
+    );
+    fs::write(&script_path, script)?;
+
+    println!("Updater prepared. Sego will close and finish the replacement in a new window.");
+    Command::new("cmd")
+        .args(["/C", "start", "Sego Update", &script_path.display().to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    Ok(())
+}
+
+fn fetch_latest_release() -> Result<Option<GithubRelease>, Box<dyn std::error::Error>> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    runtime.block_on(async {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(10)).build()?;
+        let response = client
+            .get(UPDATE_LATEST_URL)
+            .header("user-agent", concat!("sego/", env!("CARGO_PKG_VERSION")))
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            return Ok(None);
+        }
+        let release = response.json::<GithubRelease>().await?;
+        Ok(Some(release))
+    })
+}
+
+fn download_file(url: &str, destination: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = tokio::runtime::Runtime::new()?;
+    let bytes = runtime.block_on(async {
+        let client = reqwest::Client::builder().timeout(Duration::from_secs(120)).build()?;
+        let response = client
+            .get(url)
+            .header("user-agent", concat!("sego/", env!("CARGO_PKG_VERSION")))
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            return Err(format!("download failed with {}", response.status()).into());
+        }
+        Ok::<_, Box<dyn std::error::Error>>(response.bytes().await?)
+    })?;
+    fs::write(destination, bytes)?;
+    Ok(())
+}
+
+fn is_newer_version(latest_tag: &str, current_version: &str) -> bool {
+    parse_version_triplet(latest_tag) > parse_version_triplet(current_version)
+}
+
+fn parse_version_triplet(value: &str) -> (u64, u64, u64) {
+    let normalized = value.trim().trim_start_matches('v');
+    let mut parts = normalized.split('.').map(|part| part.parse::<u64>().unwrap_or(0));
+    (parts.next().unwrap_or(0), parts.next().unwrap_or(0), parts.next().unwrap_or(0))
+}
+
 fn print_telemetry(
     action: Option<&str>,
     output_format: CliOutputFormat,
@@ -7196,6 +7350,8 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "      Alias for --help")?;
     writeln!(out, "  sego version")?;
     writeln!(out, "      Alias for --version")?;
+    writeln!(out, "  sego update")?;
+    writeln!(out, "      Check GitHub Releases and install the latest Sego on Windows")?;
     writeln!(out, "  sego status")?;
     writeln!(out, "      Show the current local workspace status snapshot")?;
     writeln!(out, "  sego sandbox")?;
@@ -7622,6 +7778,21 @@ mod tests {
             CliAction::Version
         );
         assert_eq!(parse_args(&["-V".to_string()]).expect("args should parse"), CliAction::Version);
+    }
+
+    #[test]
+    fn parses_update_command_without_initializing_prompt_mode() {
+        assert_eq!(
+            parse_args(&["update".to_string()]).expect("update should parse"),
+            CliAction::Update
+        );
+    }
+
+    #[test]
+    fn compares_release_versions() {
+        assert!(super::is_newer_version("v0.1.4", "0.1.3"));
+        assert!(!super::is_newer_version("v0.1.3", "0.1.3"));
+        assert!(!super::is_newer_version("v0.1.2", "0.1.3"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 摘要
- EN: Add sego update so Windows users can install the latest GitHub Release from the CLI.
- 中文：新增 sego update，让 Windows 用户可以从 CLI 主动安装 GitHub Release 最新版本。
- EN: Print a lightweight update notice on normal Sego startup when a newer release exists.
- 中文：正常启动 Sego 时，如果检测到新版，只提示用户运行更新命令，不静默替换。
- EN: Add Update Sego.cmd and a desktop shortcut from the Windows installer.
- 中文：Windows 安装器新增 Update Sego.cmd 和桌面更新快捷方式。
- EN: Bump workspace version to 0.1.4 for the next release.
- 中文：将 workspace 版本提升到 0.1.4，准备下一版发布。

## Tests / 测试
- cargo fmt --all --check
- cargo test -p rusty-claude-cli update
- cargo test -p rusty-claude-cli compares_release_versions
- cargo build -p rusty-claude-cli

## Notes / 说明
- EN: The updater is intentionally user-triggered. Sego only notifies; it does not silently replace binaries.
- 中文：更新机制刻意设计为用户主动触发。Sego 只提示，不会后台静默替换二进制文件。
- EN: Automatic binary replacement is Windows-first in this PR; non-Windows users are pointed to the release page.
- 中文：本 PR 的自动替换优先支持 Windows；非 Windows 用户会被引导到 Release 页面手动下载。