### PR TITLE
fix(review): add closed-loop verification guardrails

### DIFF
--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -25,6 +25,16 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
         "Task: review the current git diff for correctness, regressions, security risks, data-flow drift, missing tests, and maintainability issues.".to_string(),
         "Findings must be specific and evidence-based. Avoid broad summaries unless there are no findings.".to_string(),
         String::new(),
+        "Closed-loop verification requirements:".to_string(),
+        "- Do not claim a generated file, lint result, syntax check, test, dry-run, or runtime output exists/passed unless that evidence is present in the provided context.".to_string(),
+        "- If an output file or command result is proposed but not verified, label it as proposed/unverified and include the command needed to verify it.".to_string(),
+        "- Flag behavior changes separately from bug fixes, especially output schema, column names, request semantics, retry policy, filesystem paths, or data-flow changes.".to_string(),
+        "- For generated or optimized code, actively look for newly introduced regressions and include verification commands in each finding when practical.".to_string(),
+        String::new(),
+        "Domain review dimensions:".to_string(),
+        "- For network/crawler code, explicitly check URL construction, retry policy, non-retryable 4xx handling, timeout and exception handling, per-request User-Agent/header rotation if claimed, rate limiting/backoff, encoding fallback, SSRF/SSL/secrets/log leakage risks, output filename collision/overwrite behavior, dependency audit, and mockable network IO.".to_string(),
+        "- For shell command generation on Windows, flag cross-shell syntax mixing such as using CMD-only `cd /d` or `^` escaping in Bash/Git Bash, or Bash-only here-doc/path syntax in CMD/PowerShell.".to_string(),
+        String::new(),
         "Output contract:".to_string(),
         "- Prefer JSON only. Do not wrap the JSON in prose.".to_string(),
         "- Shape: {\"findings\":[{\"severity\":\"critical|high|medium|low|info\",\"file\":\"path\",\"line\":123,\"title\":\"short title\",\"evidence\":\"specific diff evidence\",\"risk\":\"why it matters\",\"suggestion\":\"specific fix\",\"confidence\":0.0,\"verification_hint\":\"test or command to run\"}]}.".to_string(),
@@ -146,5 +156,41 @@ mod tests {
         );
 
         assert!(prompt.contains("[truncated: original content exceeded 12 characters]"));
+    }
+
+    #[test]
+    fn prompt_requires_closed_loop_verification_guardrails() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::Workspace,
+            git_status: String::new(),
+            staged_diff: String::new(),
+            unstaged_diff: String::new(),
+        });
+
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+
+        assert!(prompt.contains("Do not claim a generated file"));
+        assert!(prompt.contains("proposed/unverified"));
+        assert!(prompt.contains("behavior changes"));
+        assert!(prompt.contains("newly introduced regressions"));
+    }
+
+    #[test]
+    fn prompt_includes_network_and_shell_specific_review_dimensions() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::Workspace,
+            git_status: String::new(),
+            staged_diff: String::new(),
+            unstaged_diff: String::new(),
+        });
+
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+
+        assert!(prompt.contains("network/crawler code"));
+        assert!(prompt.contains("non-retryable 4xx"));
+        assert!(prompt.contains("SSRF"));
+        assert!(prompt.contains("per-request User-Agent/header rotation"));
+        assert!(prompt.contains("cross-shell syntax mixing"));
+        assert!(prompt.contains("cd /d"));
     }
 }

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -370,6 +370,23 @@ fn render_review_markdown(artifact: &ReviewArtifact, report: &ReviewReport) -> S
         output.push('\n');
     }
 
+    output.push_str("## Verification Self-check\n\n");
+    output.push_str("- Sego only treats tests, lint checks, syntax checks, dry-runs, generated files, and runtime outputs as verified when the evidence is present in the captured review context.\n");
+    output.push_str("- Claims without captured evidence should be treated as unverified recommendations, not completed validation.\n");
+    output.push_str("- Reviewers should double-check behavior changes such as output schema, column names, retry semantics, request headers, filesystem paths, and data-flow changes before accepting fixes.\n");
+    if report.findings.is_empty() {
+        output.push_str("- No structured verification hints were captured.\n");
+    } else {
+        let hint_count =
+            report.findings.iter().filter(|finding| finding.verification_hint.is_some()).count();
+        let _ = writeln!(
+            output,
+            "- Structured findings with verification hints: `{hint_count}/{}`.",
+            report.findings.len()
+        );
+    }
+    output.push('\n');
+
     if report.raw_text.trim().is_empty() {
         output.push_str("## Review Output\n\nNo review output captured.\n");
     } else {
@@ -502,6 +519,7 @@ mod tests {
         let markdown = std::fs::read_to_string(&artifact.markdown_path).expect("read markdown");
         assert!(markdown.contains("# Sego Review Report"));
         assert!(markdown.contains("No findings."));
+        assert!(markdown.contains("## Verification Self-check"));
         let index = std::fs::read_to_string(&artifact.index_path).expect("read index");
         assert!(index.contains(&artifact.id));
 
@@ -692,6 +710,7 @@ mod tests {
         let markdown = std::fs::read_to_string(&artifact.markdown_path).expect("read markdown");
         assert!(markdown.contains("## Findings"));
         assert!(markdown.contains("Credential leak"));
+        assert!(markdown.contains("Structured findings with verification hints: `1/1`"));
 
         let index = std::fs::read_to_string(&artifact.index_path).expect("read index");
         assert!(index.contains("\"finding_count\":1"));

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -471,6 +471,9 @@ fn get_simple_doing_tasks_section() -> String {
         "If an approach fails, diagnose the failure before switching tactics.".to_string(),
         "Be careful not to introduce security vulnerabilities such as command injection, XSS, or SQL injection.".to_string(),
         "Report outcomes faithfully: if verification fails or was not run, say so explicitly.".to_string(),
+        "When generating shell commands, match syntax to the actual target shell. On Windows, do not mix CMD-only syntax such as `cd /d` or `^` escaping with Bash/Git Bash commands, and do not mix Bash-only here-doc or POSIX path syntax with CMD/PowerShell.".to_string(),
+        "Avoid writing source files line-by-line with long `echo >>` command chains. Prefer the available file editing tools; if shell writing is unavoidable, use a shell-appropriate bulk write pattern and verify the file exists before claiming it was created.".to_string(),
+        "Do not claim generated files, tests, lint checks, syntax checks, dry-runs, or runtime outputs exist or passed unless you observed that evidence in tool output.".to_string(),
     ]);
 
     std::iter::once("# Doing tasks".to_string()).chain(items).collect::<Vec<_>>().join("\n")
@@ -728,6 +731,18 @@ mod tests {
         assert!(prompt.contains(SYSTEM_PROMPT_DYNAMIC_BOUNDARY));
 
         fs::remove_dir_all(root).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn system_prompt_contains_shell_and_verification_guardrails() {
+        let prompt = SystemPromptBuilder::new().render();
+
+        assert!(prompt.contains("match syntax to the actual target shell"));
+        assert!(prompt.contains("cd /d"));
+        assert!(prompt.contains("Bash/Git Bash"));
+        assert!(prompt.contains("echo >>"));
+        assert!(prompt.contains("verify the file exists"));
+        assert!(prompt.contains("Do not claim generated files"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 摘要
- EN: Add closed-loop review guardrails so Sego does not claim generated files, tests, lint checks, dry-runs, or runtime outputs were verified without captured evidence.
- 中文：为代码审查增加闭环校验护栏，避免 Sego 在缺少证据时声明生成文件、测试、lint、dry-run 或运行结果已经存在/通过。
- EN: Add domain-specific review dimensions for network/crawler code, including retry policy, non-retryable 4xx, User-Agent rotation, SSRF/SSL/secrets, output collisions, dependency audit, and mockable IO.
- 中文：增强网络/爬虫类代码审查维度，包括重试策略、不可重试 4xx、UA 轮换、SSRF/SSL/密钥泄露、输出文件冲突、依赖审计和可 mock 的网络 IO。
- EN: Add shell-generation guardrails for Windows to reduce CMD/Bash/Git Bash syntax mixing, covering issue #40.
- 中文：增加 Windows shell 命令生成约束，降低 CMD/Bash/Git Bash 语法混用问题，覆盖 issue #40 的主要场景。
- EN: Persist a Verification Self-check section in review markdown reports.
- 中文：在审查 Markdown 报告中落盘 Verification Self-check 自验证说明。

## Tests / 测试
- cargo fmt --all --check
- cargo test -p runtime code_review
- cargo test -p runtime prompt
- cargo clippy -p runtime --lib

## Notes / 说明
- EN: Clippy exits successfully with pre-existing warnings outside this change.
- 中文：Clippy 成功退出，但仓库中仍有本次改动之外的既有 warning。