### PR TITLE
feat(windows): improve workspace switching UX

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -54,6 +54,26 @@ cd rust
 ./target/debug/sego
 ```
 
+Inside the REPL, Sego supports natural workspace language for normal users:
+
+```text
+当前工作区
+切换到 D:\YourProject
+打开项目 E:\YourProject
+```
+
+For stricter CLI usage, the same workflow is available as commands:
+
+```bash
+sego --cwd "D:\YourProject" workspace
+```
+
+```text
+/workspace
+/pwd
+/cd D:\YourProject
+```
+
 ### One-shot prompt
 
 ```bash

--- a/install.ps1
+++ b/install.ps1
@@ -40,7 +40,6 @@ $LauncherContent = @'
 @echo off
 setlocal EnableExtensions
 title Sego Agent
-cd /d "%USERPROFILE%"
 
 if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
   echo [Sego] No API key was found in your environment.
@@ -51,6 +50,11 @@ if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
   echo [Sego] After running setx, close this window and open Sego again.
   echo.
 )
+
+echo [Sego] Active workspace: %CD%
+echo [Sego] Tip: you can say "切换到 D:\YourProject" inside Sego, or launch with:
+echo        Sego.cmd --cwd "D:\YourProject"
+echo.
 
 set "SEGO_PAUSE_ON_ERROR=1"
 "%~dp0sego.exe" %*
@@ -82,7 +86,7 @@ try {
         $Shell = New-Object -ComObject WScript.Shell
         $Shortcut = $Shell.CreateShortcut($ShortcutPath)
         $Shortcut.TargetPath = $LauncherPath
-        $Shortcut.WorkingDirectory = $env:USERPROFILE
+        $Shortcut.WorkingDirectory = $InstallDir
         $Shortcut.IconLocation = "$BinPath,0"
         $Shortcut.Description = "Open Sego Agent"
         $Shortcut.Save()

--- a/install.ps1
+++ b/install.ps1
@@ -52,16 +52,17 @@ if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
 )
 
 echo [Sego] Active workspace: %CD%
-echo [Sego] Tip: you can say "切换到 D:\YourProject" inside Sego, or launch with:
+echo [Sego] Tip: inside Sego, type /cd "D:\YourProject" or launch with:
 echo        Sego.cmd --cwd "D:\YourProject"
 echo.
 
 set "SEGO_PAUSE_ON_ERROR=1"
 "%~dp0sego.exe" %*
 set "SEGO_EXIT=%ERRORLEVEL%"
-echo.
-echo Sego exited with code %SEGO_EXIT%.
-pause
+if not "%SEGO_EXIT%"=="0" (
+  echo.
+  echo Sego exited with code %SEGO_EXIT%.
+)
 exit /b %SEGO_EXIT%
 '@
 Set-Content -Path $LauncherPath -Value $LauncherContent -Encoding ASCII

--- a/packaging/windows/README-WINDOWS.txt
+++ b/packaging/windows/README-WINDOWS.txt
@@ -6,4 +6,10 @@ Quick start:
    setx DEEPSEEK_API_KEY "your-key"
    setx ANTHROPIC_API_KEY "your-key"
 
-You can also run sego.exe directly from a terminal.
+Workspace tips:
+- Sego uses the folder where it was launched as the active workspace.
+- Inside Sego, you can say: 切换到 D:\YourProject
+- You can also start directly in a project:
+  Sego.cmd --cwd "D:\YourProject"
+
+You can also run sego.exe directly from a terminal, but Sego.cmd keeps errors visible.

--- a/packaging/windows/Sego.cmd
+++ b/packaging/windows/Sego.cmd
@@ -18,14 +18,15 @@ if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
 )
 
 echo [Sego] Active workspace: %CD%
-echo [Sego] Tip: you can say "切换到 D:\YourProject" inside Sego, or launch with:
+echo [Sego] Tip: inside Sego, type /cd "D:\YourProject" or launch with:
 echo        Sego.cmd --cwd "D:\YourProject"
 echo.
 
 set "SEGO_PAUSE_ON_ERROR=1"
 "%~dp0sego.exe" %*
 set "SEGO_EXIT=%ERRORLEVEL%"
-echo.
-echo Sego exited with code %SEGO_EXIT%.
-pause
+if not "%SEGO_EXIT%"=="0" (
+  echo.
+  echo Sego exited with code %SEGO_EXIT%.
+)
 exit /b %SEGO_EXIT%

--- a/packaging/windows/Sego.cmd
+++ b/packaging/windows/Sego.cmd
@@ -1,7 +1,6 @@
 @echo off
 setlocal EnableExtensions
 title Sego Agent
-cd /d "%USERPROFILE%"
 
 if not exist "%~dp0sego.exe" (
   echo [Sego] sego.exe was not found next to this launcher.
@@ -18,6 +17,12 @@ if "%DEEPSEEK_API_KEY%%ANTHROPIC_API_KEY%"=="" (
   echo.
 )
 
+echo [Sego] Active workspace: %CD%
+echo [Sego] Tip: you can say "切换到 D:\YourProject" inside Sego, or launch with:
+echo        Sego.cmd --cwd "D:\YourProject"
+echo.
+
+set "SEGO_PAUSE_ON_ERROR=1"
 "%~dp0sego.exe" %*
 set "SEGO_EXIT=%ERRORLEVEL%"
 echo.

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -72,6 +72,27 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: true,
     },
     SlashCommandSpec {
+        name: "pwd",
+        aliases: &["cwd"],
+        summary: "Show the active workspace directory",
+        argument_hint: None,
+        resume_supported: true,
+    },
+    SlashCommandSpec {
+        name: "cd",
+        aliases: &[],
+        summary: "Switch the active workspace directory",
+        argument_hint: Some("<path>"),
+        resume_supported: false,
+    },
+    SlashCommandSpec {
+        name: "workspace",
+        aliases: &["workdir"],
+        summary: "Show workspace and sandbox path context",
+        argument_hint: Some("[path]"),
+        resume_supported: false,
+    },
+    SlashCommandSpec {
         name: "compact",
         aliases: &[],
         summary: "Compact local session history",
@@ -1060,6 +1081,9 @@ pub enum SlashCommand {
     Help,
     Status,
     Sandbox,
+    Pwd,
+    Cd { path: Option<String> },
+    Workspace { path: Option<String> },
     Compact,
     Bughunter { scope: Option<String> },
     Commit,
@@ -1187,6 +1211,12 @@ pub fn validate_slash_command_input(
             validate_no_args(command, &args)?;
             SlashCommand::Sandbox
         }
+        "pwd" | "cwd" => {
+            validate_no_args(command, &args)?;
+            SlashCommand::Pwd
+        }
+        "cd" => SlashCommand::Cd { path: remainder },
+        "workspace" | "workdir" => SlashCommand::Workspace { path: remainder },
         "compact" => {
             validate_no_args(command, &args)?;
             SlashCommand::Compact
@@ -3001,6 +3031,9 @@ pub fn handle_slash_command(
         | SlashCommand::Teleport { .. }
         | SlashCommand::DebugToolCall
         | SlashCommand::Sandbox
+        | SlashCommand::Pwd
+        | SlashCommand::Cd { .. }
+        | SlashCommand::Workspace { .. }
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
         | SlashCommand::Clear { .. }
@@ -3152,6 +3185,20 @@ mod tests {
         assert_eq!(SlashCommand::parse("/help"), Ok(Some(SlashCommand::Help)));
         assert_eq!(SlashCommand::parse(" /status "), Ok(Some(SlashCommand::Status)));
         assert_eq!(SlashCommand::parse("/sandbox"), Ok(Some(SlashCommand::Sandbox)));
+        assert_eq!(SlashCommand::parse("/pwd"), Ok(Some(SlashCommand::Pwd)));
+        assert_eq!(SlashCommand::parse("/cwd"), Ok(Some(SlashCommand::Pwd)));
+        assert_eq!(
+            SlashCommand::parse("/cd D:\\Project"),
+            Ok(Some(SlashCommand::Cd { path: Some("D:\\Project".to_string()) }))
+        );
+        assert_eq!(
+            SlashCommand::parse("/workspace D:\\Project"),
+            Ok(Some(SlashCommand::Workspace { path: Some("D:\\Project".to_string()) }))
+        );
+        assert_eq!(
+            SlashCommand::parse("/workdir"),
+            Ok(Some(SlashCommand::Workspace { path: None }))
+        );
         assert_eq!(
             SlashCommand::parse("/bughunter runtime"),
             Ok(Some(SlashCommand::Bughunter { scope: Some("runtime".to_string()) }))

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -3472,7 +3472,7 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help]"));
         assert!(help.contains("/verify [auto|fast|full]"));
-        assert_eq!(slash_command_specs().len(), 143);
+        assert_eq!(slash_command_specs().len(), 146);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/runtime/src/conversation.rs
+++ b/rust/crates/runtime/src/conversation.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use serde_json::{Map, Value};
 use telemetry::SessionTracer;
@@ -98,6 +102,28 @@ impl Display for RuntimeError {
 
 impl std::error::Error for RuntimeError {}
 
+/// Shared cancellation flag for an in-flight conversation turn.
+#[derive(Debug, Clone, Default)]
+pub struct TurnAbortSignal {
+    aborted: Arc<AtomicBool>,
+}
+
+impl TurnAbortSignal {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn abort(&self) {
+        self.aborted.store(true, Ordering::SeqCst);
+    }
+
+    #[must_use]
+    pub fn is_aborted(&self) -> bool {
+        self.aborted.load(Ordering::SeqCst)
+    }
+}
+
 /// Summary of one completed runtime turn, including tool results and usage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TurnSummary {
@@ -127,6 +153,7 @@ pub struct ConversationRuntime<C, T> {
     hook_runner: HookRunner,
     auto_compaction_input_tokens_threshold: u32,
     hook_abort_signal: HookAbortSignal,
+    turn_abort_signal: TurnAbortSignal,
     hook_progress_reporter: Option<Box<dyn HookProgressReporter>>,
     session_tracer: Option<SessionTracer>,
 }
@@ -176,6 +203,7 @@ where
             hook_runner: HookRunner::from_feature_config(feature_config),
             auto_compaction_input_tokens_threshold: auto_compaction_threshold_from_env(),
             hook_abort_signal: HookAbortSignal::default(),
+            turn_abort_signal: TurnAbortSignal::default(),
             hook_progress_reporter: None,
             session_tracer: None,
         }
@@ -196,6 +224,12 @@ where
     #[must_use]
     pub fn with_hook_abort_signal(mut self, hook_abort_signal: HookAbortSignal) -> Self {
         self.hook_abort_signal = hook_abort_signal;
+        self
+    }
+
+    #[must_use]
+    pub fn with_turn_abort_signal(mut self, turn_abort_signal: TurnAbortSignal) -> Self {
+        self.turn_abort_signal = turn_abort_signal;
         self
     }
 
@@ -303,6 +337,12 @@ where
         let mut iterations = 0;
 
         loop {
+            if self.turn_abort_signal.is_aborted() {
+                let error = RuntimeError::new("conversation turn cancelled by user");
+                self.record_turn_failed(iterations, &error);
+                return Err(error);
+            }
+
             iterations += 1;
             if iterations > self.max_iterations {
                 let error = RuntimeError::new(
@@ -342,6 +382,11 @@ where
                 system_prompt: self.system_prompt.clone(),
                 messages: self.session.messages.clone(),
             };
+            if self.turn_abort_signal.is_aborted() {
+                let error = RuntimeError::new("conversation turn cancelled by user");
+                self.record_turn_failed(iterations, &error);
+                return Err(error);
+            }
             let events = match self.api_client.stream(request) {
                 Ok(events) => events,
                 Err(error) => {
@@ -357,6 +402,11 @@ where
                         return Err(error);
                     }
                 };
+            if self.turn_abort_signal.is_aborted() {
+                let error = RuntimeError::new("conversation turn cancelled by user");
+                self.record_turn_failed(iterations, &error);
+                return Err(error);
+            }
             if let Some(usage) = usage {
                 self.usage_tracker.record(usage);
             }
@@ -387,6 +437,11 @@ where
             }
 
             for (tool_use_id, tool_name, input) in pending_tool_uses {
+                if self.turn_abort_signal.is_aborted() {
+                    let error = RuntimeError::new("conversation turn cancelled by user");
+                    self.record_turn_failed(iterations, &error);
+                    return Err(error);
+                }
                 let pre_hook_result = self.run_pre_tool_use_hook(&tool_name, &input);
                 let effective_input = pre_hook_result
                     .updated_input()
@@ -435,12 +490,22 @@ where
 
                 let result_message = match permission_outcome {
                     PermissionOutcome::Allow => {
+                        if self.turn_abort_signal.is_aborted() {
+                            let error = RuntimeError::new("conversation turn cancelled by user");
+                            self.record_turn_failed(iterations, &error);
+                            return Err(error);
+                        }
                         self.record_tool_started(iterations, &tool_name);
                         let (mut output, mut is_error) =
                             match self.tool_executor.execute(&tool_name, &effective_input) {
                                 Ok(output) => (output, false),
                                 Err(error) => (error.to_string(), true),
                             };
+                        if self.turn_abort_signal.is_aborted() {
+                            let error = RuntimeError::new("conversation turn cancelled by user");
+                            self.record_turn_failed(iterations, &error);
+                            return Err(error);
+                        }
                         output = merge_hook_feedback(pre_hook_result.messages(), output, false);
 
                         let post_hook_result = if is_error {
@@ -769,7 +834,8 @@ mod tests {
     use super::{
         build_assistant_message, parse_auto_compaction_threshold, ApiClient, ApiRequest,
         AssistantEvent, AutoCompactionEvent, ConversationRuntime, PromptCacheEvent, RuntimeError,
-        StaticToolExecutor, ToolExecutor, DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
+        StaticToolExecutor, ToolExecutor, TurnAbortSignal,
+        DEFAULT_AUTO_COMPACTION_INPUT_TOKENS_THRESHOLD,
     };
     use crate::compact::CompactionConfig;
     use crate::config::{RuntimeFeatureConfig, RuntimeHookConfig};
@@ -1555,6 +1621,37 @@ mod tests {
         assert!(error
             .to_string()
             .contains("conversation loop exceeded the maximum number of iterations"));
+    }
+
+    #[test]
+    fn run_turn_cancels_before_request_when_signal_is_aborted() {
+        struct PanickingApi;
+
+        impl ApiClient for PanickingApi {
+            fn stream(
+                &mut self,
+                _request: ApiRequest,
+            ) -> Result<Vec<AssistantEvent>, RuntimeError> {
+                panic!("API should not be called after turn cancellation");
+            }
+        }
+
+        let turn_abort_signal = TurnAbortSignal::new();
+        turn_abort_signal.abort();
+        let mut runtime = ConversationRuntime::new(
+            Session::new(),
+            PanickingApi,
+            StaticToolExecutor::new(),
+            PermissionPolicy::new(PermissionMode::DangerFullAccess),
+            vec!["system".to_string()],
+        )
+        .with_turn_abort_signal(turn_abort_signal);
+
+        let error = runtime
+            .run_turn("cancel this turn", None)
+            .expect_err("aborted turn should return a cancellation error");
+
+        assert!(error.to_string().contains("conversation turn cancelled by user"));
     }
 
     #[test]

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -82,7 +82,7 @@ pub use config::{
 pub use conversation::{
     auto_compaction_threshold_from_env, ApiClient, ApiRequest, AssistantEvent, AutoCompactionEvent,
     ConversationRuntime, PromptCacheEvent, RuntimeError, StaticToolExecutor, ToolError,
-    ToolExecutor, TurnSummary,
+    ToolExecutor, TurnAbortSignal, TurnSummary,
 };
 pub use file_ops::{
     edit_file, glob_search, grep_search, read_file, write_file, EditFileOutput, GlobSearchOutput,

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -851,6 +851,11 @@ enum WorkspaceIntent {
     Switch(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExportLastResponseIntent {
+    path: Option<String>,
+}
+
 fn parse_workspace_natural_language_intent(input: &str) -> Option<WorkspaceIntent> {
     let trimmed = input.trim();
     if trimmed.is_empty() || trimmed.starts_with('/') {
@@ -887,6 +892,105 @@ fn parse_workspace_natural_language_intent(input: &str) -> Option<WorkspaceInten
     }
 
     None
+}
+
+fn parse_export_last_response_intent(input: &str) -> Option<ExportLastResponseIntent> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.starts_with('/') {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let has_export_verb = lower.contains("export")
+        || lower.contains("save")
+        || lower.contains("write")
+        || trimmed.contains("导出")
+        || trimmed.contains("保存")
+        || trimmed.contains("写入")
+        || trimmed.contains("写成")
+        || trimmed.contains("生成");
+    if !has_export_verb {
+        return None;
+    }
+
+    let targets_last_response = lower.contains("last")
+        || lower.contains("previous")
+        || lower.contains("review")
+        || lower.contains("report")
+        || trimmed.contains("刚才")
+        || trimmed.contains("上一条")
+        || trimmed.contains("上一次")
+        || trimmed.contains("审查")
+        || trimmed.contains("审核")
+        || trimmed.contains("报告")
+        || trimmed.contains("结果");
+    if !targets_last_response {
+        return None;
+    }
+
+    let path = extract_export_path(trimmed);
+    if path.is_none()
+        && !(lower.contains(".md") || lower.contains("markdown") || trimmed.contains("md"))
+    {
+        return None;
+    }
+
+    Some(ExportLastResponseIntent { path })
+}
+
+fn extract_export_path(input: &str) -> Option<String> {
+    for quoted in extract_quoted_segments(input) {
+        if looks_like_export_path(&quoted) {
+            return Some(quoted);
+        }
+    }
+
+    input
+        .split_whitespace()
+        .rev()
+        .map(|part| {
+            part.trim_matches(|ch: char| {
+                matches!(ch, '"' | '\'' | '`' | '。' | '，' | ',' | ';' | '；' | ':' | '：')
+            })
+        })
+        .find(|part| looks_like_export_path(part))
+        .map(ToOwned::to_owned)
+}
+
+fn extract_quoted_segments(input: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    for ch in input.chars() {
+        match quote {
+            Some(end) if ch == end => {
+                let value = current.trim();
+                if !value.is_empty() {
+                    segments.push(value.to_string());
+                }
+                current.clear();
+                quote = None;
+            }
+            Some(_) => current.push(ch),
+            None if matches!(ch, '"' | '\'' | '`' | '“' | '‘') => {
+                quote = Some(match ch {
+                    '“' => '”',
+                    '‘' => '’',
+                    other => other,
+                });
+            }
+            None => {}
+        }
+    }
+    segments
+}
+
+fn looks_like_export_path(value: &str) -> bool {
+    let path = Path::new(value);
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+        || value.contains('\\')
+        || value.contains('/')
 }
 
 fn strip_intent_prefix<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
@@ -1961,6 +2065,10 @@ fn run_repl(
                     }
                     continue;
                 }
+                if let Some(intent) = parse_export_last_response_intent(&trimmed) {
+                    cli.export_last_assistant_response(intent.path.as_deref())?;
+                    continue;
+                }
                 cli.run_turn(&trimmed)?;
             }
             input::ReadOutcome::Cancel => {}
@@ -2052,6 +2160,13 @@ impl BuiltRuntime {
         let runtime =
             self.runtime.take().expect("runtime should exist before installing hook abort signal");
         self.runtime = Some(runtime.with_hook_abort_signal(hook_abort_signal));
+        self
+    }
+
+    fn with_turn_abort_signal(mut self, turn_abort_signal: runtime::TurnAbortSignal) -> Self {
+        let runtime =
+            self.runtime.take().expect("runtime should exist before installing turn abort signal");
+        self.runtime = Some(runtime.with_turn_abort_signal(turn_abort_signal));
         self
     }
 
@@ -2400,36 +2515,72 @@ struct HookAbortMonitor {
 }
 
 impl HookAbortMonitor {
-    fn spawn(abort_signal: runtime::HookAbortSignal) -> Self {
-        Self::spawn_with_waiter(abort_signal, move |stop_rx, abort_signal| {
-            let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build()
-            else {
-                return;
-            };
+    fn spawn(
+        hook_abort_signal: runtime::HookAbortSignal,
+        turn_abort_signal: runtime::TurnAbortSignal,
+        emit_output: bool,
+    ) -> Self {
+        Self::spawn_with_waiter(
+            hook_abort_signal,
+            turn_abort_signal,
+            emit_output,
+            move |stop_rx, hook_abort_signal, turn_abort_signal, emit_output| {
+                let Ok(runtime) =
+                    tokio::runtime::Builder::new_current_thread().enable_all().build()
+                else {
+                    return;
+                };
 
-            runtime.block_on(async move {
+                runtime.block_on(async move {
                 let wait_for_stop = tokio::task::spawn_blocking(move || {
                     let _ = stop_rx.recv();
                 });
+                tokio::pin!(wait_for_stop);
+                let mut cancelled_once = false;
 
-                tokio::select! {
-                    result = tokio::signal::ctrl_c() => {
-                        if result.is_ok() {
-                            abort_signal.abort();
+                loop {
+                    tokio::select! {
+                        _ = &mut wait_for_stop => break,
+                        result = tokio::signal::ctrl_c() => {
+                            if result.is_err() {
+                                break;
+                            }
+                            if cancelled_once {
+                                if emit_output {
+                                    eprintln!("Sego force exiting.");
+                                }
+                                std::process::exit(130);
+                            }
+                            cancelled_once = true;
+                            hook_abort_signal.abort();
+                            turn_abort_signal.abort();
+                            if emit_output {
+                                eprintln!();
+                                eprintln!("Sego cancelled the current task. Press Ctrl+C again to force exit.");
+                            }
                         }
                     }
-                    _ = wait_for_stop => {}
                 }
             });
-        })
+            },
+        )
     }
 
-    fn spawn_with_waiter<F>(abort_signal: runtime::HookAbortSignal, wait_for_interrupt: F) -> Self
+    fn spawn_with_waiter<F>(
+        abort_signal: runtime::HookAbortSignal,
+        turn_abort_signal: runtime::TurnAbortSignal,
+        emit_output: bool,
+        wait_for_interrupt: F,
+    ) -> Self
     where
-        F: FnOnce(Receiver<()>, runtime::HookAbortSignal) + Send + 'static,
+        F: FnOnce(Receiver<()>, runtime::HookAbortSignal, runtime::TurnAbortSignal, bool)
+            + Send
+            + 'static,
     {
         let (stop_tx, stop_rx) = mpsc::channel();
-        let join_handle = thread::spawn(move || wait_for_interrupt(stop_rx, abort_signal));
+        let join_handle = thread::spawn(move || {
+            wait_for_interrupt(stop_rx, abort_signal, turn_abort_signal, emit_output);
+        });
 
         Self { stop_tx: Some(stop_tx), join_handle: Some(join_handle) }
     }
@@ -2612,6 +2763,7 @@ impl LiveCli {
         emit_output: bool,
     ) -> Result<(BuiltRuntime, HookAbortMonitor), Box<dyn std::error::Error>> {
         let hook_abort_signal = runtime::HookAbortSignal::new();
+        let turn_abort_signal = runtime::TurnAbortSignal::new();
         let runtime = build_runtime(
             self.runtime.session().clone(),
             &self.session.id,
@@ -2623,8 +2775,10 @@ impl LiveCli {
             self.permission_mode,
             None,
         )?
-        .with_hook_abort_signal(hook_abort_signal.clone());
-        let hook_abort_monitor = HookAbortMonitor::spawn(hook_abort_signal);
+        .with_hook_abort_signal(hook_abort_signal.clone())
+        .with_turn_abort_signal(turn_abort_signal.clone());
+        let hook_abort_monitor =
+            HookAbortMonitor::spawn(hook_abort_signal, turn_abort_signal, emit_output);
 
         Ok((runtime, hook_abort_monitor))
     }
@@ -3280,6 +3434,23 @@ impl LiveCli {
             "Export\n  Result           wrote transcript\n  File             {}\n  Messages         {}",
             export_path.display(),
             self.runtime.session().messages.len(),
+        );
+        Ok(())
+    }
+
+    fn export_last_assistant_response(
+        &self,
+        requested_path: Option<&str>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let text = latest_assistant_text(self.runtime.session())
+            .ok_or("no assistant response is available to export yet")?;
+        let export_path = resolve_direct_export_path(requested_path, || {
+            format!("sego-response-{}.md", default_date().replace('-', ""))
+        })?;
+        fs::write(&export_path, text)?;
+        println!(
+            "Export\n  Result           wrote latest assistant response\n  File             {}",
+            export_path.display()
         );
         Ok(())
     }
@@ -5978,6 +6149,26 @@ fn render_export_text(session: &Session) -> String {
     lines.join("\n")
 }
 
+fn latest_assistant_text(session: &Session) -> Option<String> {
+    session.messages.iter().rev().find_map(|message| {
+        if message.role != MessageRole::Assistant {
+            return None;
+        }
+
+        let text = message
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.trim()),
+                _ => None,
+            })
+            .filter(|text| !text.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        (!text.is_empty()).then_some(text)
+    })
+}
+
 fn default_export_filename(session: &Session) -> String {
     let stem = session
         .messages
@@ -6016,6 +6207,21 @@ fn resolve_export_path(
             format!("{file_name}.txt")
         };
     Ok(cwd.join(final_name))
+}
+
+fn resolve_direct_export_path(
+    requested_path: Option<&str>,
+    default_name: impl FnOnce() -> String,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    let file_name = requested_path.map_or_else(default_name, |path| path.trim().to_string());
+    let candidate = PathBuf::from(file_name);
+    let candidate = if candidate.is_absolute() { candidate } else { cwd.join(candidate) };
+    if candidate.extension().is_some() {
+        Ok(candidate)
+    } else {
+        Ok(candidate.with_extension("md"))
+    }
 }
 
 fn build_system_prompt() -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -7727,16 +7933,18 @@ mod tests {
         format_resume_report, format_status_report, format_tool_call_start, format_tool_result,
         format_ultraplan_report, format_unknown_slash_command,
         format_unknown_slash_command_message, normalize_permission_mode, parse_args,
-        parse_git_status_branch, parse_git_status_metadata_for, parse_git_workspace_summary,
-        parse_workspace_natural_language_intent, permission_policy, print_help_to,
-        push_output_block, render_code_review_readiness_for, render_code_review_summary_for,
-        render_config_report, render_diff_report, render_diff_report_for, render_memory_report,
-        render_repl_help, render_resume_usage, resolve_model_alias, resolve_session_reference,
-        response_to_events, resume_supported_slash_commands, run_resume_command,
+        parse_export_last_response_intent, parse_git_status_branch, parse_git_status_metadata_for,
+        parse_git_workspace_summary, parse_workspace_natural_language_intent, permission_policy,
+        print_help_to, push_output_block, render_code_review_readiness_for,
+        render_code_review_summary_for, render_config_report, render_diff_report,
+        render_diff_report_for, render_memory_report, render_repl_help, render_resume_usage,
+        resolve_model_alias, resolve_session_reference, response_to_events,
+        resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
-        write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor, GitWorkspaceSummary,
-        InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SafetyReviewScope,
-        SlashCommand, StatusUsage, WorkspaceIntent,
+        write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor,
+        ExportLastResponseIntent, GitWorkspaceSummary, InternalPromptProgressEvent,
+        InternalPromptProgressState, LiveCli, SafetyReviewScope, SlashCommand, StatusUsage,
+        WorkspaceIntent,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
     use plugins::{
@@ -8123,6 +8331,19 @@ mod tests {
             Some(WorkspaceIntent::Switch("E:\\中文项目".to_string()))
         );
         assert_eq!(parse_workspace_natural_language_intent("帮我 review 当前改动"), None);
+    }
+
+    #[test]
+    fn parses_export_last_response_natural_language_intents() {
+        assert_eq!(
+            parse_export_last_response_intent("把刚才的审查结果写成 E:\\code\\PR43-review.md"),
+            Some(ExportLastResponseIntent { path: Some("E:\\code\\PR43-review.md".to_string()) })
+        );
+        assert_eq!(
+            parse_export_last_response_intent("save the last review report to PR43-review.md"),
+            Some(ExportLastResponseIntent { path: Some("PR43-review.md".to_string()) })
+        );
+        assert_eq!(parse_export_last_response_intent("帮我写一个 markdown parser"), None);
     }
 
     #[test]
@@ -10001,10 +10222,13 @@ mod sandbox_report_tests {
         let (ready_tx, ready_rx) = mpsc::channel();
         let monitor = HookAbortMonitor::spawn_with_waiter(
             abort_signal.clone(),
-            move |stop_rx, abort_signal| {
+            runtime::TurnAbortSignal::new(),
+            false,
+            move |stop_rx, abort_signal, turn_abort_signal, _emit_output| {
                 ready_tx.send(()).expect("ready signal");
                 let _ = stop_rx.recv();
                 assert!(!abort_signal.is_aborted());
+                assert!(!turn_abort_signal.is_aborted());
             },
         );
 
@@ -10020,8 +10244,11 @@ mod sandbox_report_tests {
         let (done_tx, done_rx) = mpsc::channel();
         let monitor = HookAbortMonitor::spawn_with_waiter(
             abort_signal.clone(),
-            move |_stop_rx, abort_signal| {
+            runtime::TurnAbortSignal::new(),
+            false,
+            move |_stop_rx, abort_signal, turn_abort_signal, _emit_output| {
                 abort_signal.abort();
+                turn_abort_signal.abort();
                 done_tx.send(()).expect("done signal");
             },
         );

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -232,6 +232,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::PrintSystemPrompt { cwd, date } => print_system_prompt(cwd, date),
         CliAction::Version => print_version(),
         CliAction::Update => run_update()?,
+        CliAction::Workspace { output_format } => print_workspace_snapshot(output_format)?,
         CliAction::ResumeSession { session_path, commands } => {
             resume_session(&session_path, &commands);
         }
@@ -312,6 +313,9 @@ enum CliAction {
     },
     Version,
     Update,
+    Workspace {
+        output_format: CliOutputFormat,
+    },
     ResumeSession {
         session_path: PathBuf,
         commands: Vec<String>,
@@ -411,6 +415,7 @@ impl CliOutputFormat {
 
 #[allow(clippy::too_many_lines)]
 fn parse_args(args: &[String]) -> Result<CliAction, String> {
+    let mut requested_cwd: Option<PathBuf> = None;
     let mut model = default_model();
     let mut output_format = CliOutputFormat::Text;
     let mut permission_mode_override = None;
@@ -439,6 +444,16 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             }
             flag if flag.starts_with("--model=") => {
                 model = resolve_model_alias(&flag[8..]).to_string();
+                index += 1;
+            }
+            "--cwd" if rest.is_empty() => {
+                let value =
+                    args.get(index + 1).ok_or_else(|| "missing value for --cwd".to_string())?;
+                requested_cwd = Some(resolve_cli_cwd(value)?);
+                index += 2;
+            }
+            flag if rest.is_empty() && flag.starts_with("--cwd=") => {
+                requested_cwd = Some(resolve_cli_cwd(&flag[6..])?);
                 index += 1;
             }
             "--output-format" => {
@@ -484,6 +499,7 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
                 if prompt.trim().is_empty() {
                     return Err("-p requires a prompt string".to_string());
                 }
+                apply_requested_cwd(requested_cwd.as_ref())?;
                 return Ok(CliAction::Prompt {
                     prompt,
                     model: resolve_model_alias(&model).to_string(),
@@ -531,6 +547,8 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
             }
         }
     }
+
+    apply_requested_cwd(requested_cwd.as_ref())?;
 
     // c10/b: --permission-profile review-trust handling.
     // review-trust maps to workspace-write mode + bash command classifier.
@@ -641,6 +659,7 @@ fn parse_single_word_command_alias(
             output_format,
         })),
         "sandbox" => Some(Ok(CliAction::Sandbox { output_format })),
+        "workspace" | "workdir" | "pwd" | "cwd" => Some(Ok(CliAction::Workspace { output_format })),
         "review" => {
             Some(Ok(CliAction::Review { last_n: None, output_format: CliOutputFormat::Text }))
         }
@@ -709,6 +728,16 @@ fn parse_direct_slash_cli_action(
             },
         }),
         Ok(Some(SlashCommand::Skills { args })) => Ok(CliAction::Skills { args }),
+        Ok(Some(SlashCommand::Pwd | SlashCommand::Workspace { path: None })) => {
+            let _ = (model, permission_mode);
+            Ok(CliAction::Workspace { output_format: CliOutputFormat::Text })
+        }
+        Ok(Some(SlashCommand::Cd { .. } | SlashCommand::Workspace { path: Some(_) })) => Err(
+            format!(
+                "slash command {command_name} changes the live workspace and is REPL-only. Start `sego` and run it there, or launch directly with `sego --cwd <path>`.",
+                command_name = rest[0],
+            ),
+        ),
         Ok(Some(SlashCommand::Review { scope })) => {
             parse_code_review_slash_action(scope.as_deref(), model, allowed_tools)
         }
@@ -784,6 +813,92 @@ fn format_unknown_slash_command(name: &str) -> String {
     }
     message.push_str("\n  Help             /help lists available slash commands");
     message
+}
+
+fn resolve_cli_cwd(value: &str) -> Result<PathBuf, String> {
+    let trimmed = value.trim().trim_matches('"');
+    if trimmed.is_empty() {
+        return Err("workspace path must not be empty".to_string());
+    }
+    let raw = PathBuf::from(trimmed);
+    let candidate = if raw.is_absolute() {
+        raw
+    } else {
+        env::current_dir().map_err(|error| error.to_string())?.join(raw)
+    };
+    if !candidate.exists() {
+        return Err(format!("workspace path does not exist: {}", candidate.display()));
+    }
+    if !candidate.is_dir() {
+        return Err(format!("workspace path is not a directory: {}", candidate.display()));
+    }
+    candidate.canonicalize().map_err(|error| {
+        format!("failed to normalize workspace path {}: {error}", candidate.display())
+    })
+}
+
+fn apply_requested_cwd(cwd: Option<&PathBuf>) -> Result<(), String> {
+    if let Some(cwd) = cwd {
+        env::set_current_dir(cwd)
+            .map_err(|error| format!("failed to switch --cwd to {}: {error}", cwd.display()))?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WorkspaceIntent {
+    Show,
+    Switch(String),
+}
+
+fn parse_workspace_natural_language_intent(input: &str) -> Option<WorkspaceIntent> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.starts_with('/') {
+        return None;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "pwd" | "cwd" | "where am i" | "show workspace" | "current workspace"
+    ) || trimmed.contains("当前目录")
+        || trimmed.contains("工作目录")
+        || trimmed.contains("当前工作区")
+    {
+        return Some(WorkspaceIntent::Show);
+    }
+
+    for prefix in [
+        "切换到",
+        "切换工作区到",
+        "切换工作目录到",
+        "打开项目",
+        "进入项目",
+        "进入目录",
+        "把工作目录切到",
+        "change directory to",
+        "switch workspace to",
+        "open project",
+        "use workspace",
+        "cd ",
+    ] {
+        if let Some(path) = strip_intent_prefix(trimmed, prefix) {
+            return Some(WorkspaceIntent::Switch(path.to_string()));
+        }
+    }
+
+    None
+}
+
+fn strip_intent_prefix<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_ascii() {
+        let lower = input.to_ascii_lowercase();
+        let lower_prefix = prefix.to_ascii_lowercase();
+        if lower.starts_with(&lower_prefix) {
+            return Some(input[prefix.len()..].trim().trim_matches('"'));
+        }
+        return None;
+    }
+    input.strip_prefix(prefix).map(|path| path.trim().trim_matches('"'))
 }
 
 fn render_suggestion_line(label: &str, suggestions: &[String]) -> Option<String> {
@@ -1245,6 +1360,14 @@ struct StatusContext {
     sandbox_status: runtime::SandboxStatus,
 }
 
+struct WorkspaceContext {
+    cwd: PathBuf,
+    project_root: Option<PathBuf>,
+    session_dir: PathBuf,
+    recovery_dir: PathBuf,
+    sandbox_status: runtime::SandboxStatus,
+}
+
 #[derive(Debug, Clone, Copy)]
 struct StatusUsage {
     message_count: usize,
@@ -1635,6 +1758,10 @@ fn run_resume_command(
                 ))),
             })
         }
+        SlashCommand::Pwd | SlashCommand::Workspace { path: None } => Ok(ResumeCommandOutcome {
+            session: session.clone(),
+            message: Some(format_workspace_report(&workspace_context()?)),
+        }),
         SlashCommand::Cost => {
             let usage = UsageTracker::from_session(session).cumulative_usage();
             Ok(ResumeCommandOutcome {
@@ -1723,6 +1850,8 @@ fn run_resume_command(
         | SlashCommand::Resume { .. }
         | SlashCommand::Model { .. }
         | SlashCommand::Permissions { .. }
+        | SlashCommand::Cd { .. }
+        | SlashCommand::Workspace { path: Some(_) }
         | SlashCommand::Session { .. }
         | SlashCommand::Plugins { .. }
         | SlashCommand::Doctor
@@ -1823,6 +1952,15 @@ fn run_repl(
                     }
                 }
                 editor.push_history(input);
+                if let Some(intent) = parse_workspace_natural_language_intent(&trimmed) {
+                    match intent {
+                        WorkspaceIntent::Show => LiveCli::print_workspace_status()?,
+                        WorkspaceIntent::Switch(path) => {
+                            cli.switch_workspace(&path)?;
+                        }
+                    }
+                    continue;
+                }
                 cli.run_turn(&trimmed)?;
             }
             input::ReadOutcome::Cancel => {}
@@ -2372,6 +2510,56 @@ impl LiveCli {
         self
     }
 
+    fn print_workspace_status() -> Result<(), Box<dyn std::error::Error>> {
+        println!("{}", format_workspace_report(&workspace_context()?));
+        Ok(())
+    }
+
+    fn switch_workspace(
+        &mut self,
+        requested_path: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let previous = env::current_dir()?;
+        let next = resolve_cli_cwd(requested_path)?;
+        if next == previous {
+            println!("{}", format_workspace_switch_report(&previous, &next, false));
+            return Ok(false);
+        }
+
+        self.persist_session()?;
+        env::set_current_dir(&next)?;
+
+        let system_prompt = build_system_prompt()?;
+        let session_state = Session::new();
+        let session = create_managed_session_handle(&session_state.session_id)?;
+        let runtime = build_runtime(
+            session_state.with_persistence_path(session.path.clone()),
+            &session.id,
+            self.model.clone(),
+            system_prompt.clone(),
+            true,
+            true,
+            self.allowed_tools.clone(),
+            self.permission_mode,
+            None,
+        )?;
+        let store = WorkflowStore::new(&next);
+        let mut workflow = WorkflowSnapshot::new(session.id.clone());
+        workflow.started_at = Some(default_date());
+        workflow.record_event(LaneEvent::started(default_date()));
+
+        self.system_prompt = system_prompt;
+        self.runtime = runtime;
+        self.session = session;
+        self.workflow = workflow;
+        self.workflow_store = store;
+        self.community = CommunityLearning::new(&next);
+        self.persist_session()?;
+
+        println!("{}", format_workspace_switch_report(&previous, &next, true));
+        Ok(true)
+    }
+
     fn startup_banner(&self) -> String {
         let cwd = env::current_dir()
             .map_or_else(|_| "<unknown>".to_string(), |path| path.display().to_string());
@@ -2664,6 +2852,18 @@ impl LiveCli {
             SlashCommand::Sandbox => {
                 Self::print_sandbox_status();
                 false
+            }
+            SlashCommand::Pwd | SlashCommand::Workspace { path: None } => {
+                Self::print_workspace_status()?;
+                false
+            }
+            SlashCommand::Workspace { path: Some(path) } => self.switch_workspace(&path)?,
+            SlashCommand::Cd { path } => {
+                let Some(path) = path else {
+                    println!("Usage: /cd <path>");
+                    return Ok(false);
+                };
+                self.switch_workspace(&path)?
             }
             SlashCommand::Compact => {
                 self.compact()?;
@@ -3646,6 +3846,8 @@ fn render_repl_help() -> String {
         "  Auto-save            .claw/sessions/<session-id>.jsonl".to_string(),
         "  Resume latest        /resume latest".to_string(),
         "  Browse sessions      /session list".to_string(),
+        "  Workspace            /workspace, /pwd, /cd <path>".to_string(),
+        "  Natural workspace    say: 切换到 D:\\YourProject / 当前工作区".to_string(),
         String::new(),
         render_slash_command_help(),
     ]
@@ -3699,6 +3901,32 @@ fn print_status_snapshot(
     Ok(())
 }
 
+fn print_workspace_snapshot(
+    output_format: CliOutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let context = workspace_context()?;
+    match output_format {
+        CliOutputFormat::Json => {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "cwd": context.cwd.display().to_string(),
+                    "project_root": context
+                        .project_root
+                        .as_ref()
+                        .map(|path| path.display().to_string()),
+                    "session_dir": context.session_dir.display().to_string(),
+                    "recovery_dir": context.recovery_dir.display().to_string(),
+                    "filesystem_mode": context.sandbox_status.filesystem_mode.as_str(),
+                    "allowed_mounts": context.sandbox_status.allowed_mounts,
+                })
+            );
+        }
+        CliOutputFormat::Text => println!("{}", format_workspace_report(&context)),
+    }
+    Ok(())
+}
+
 fn status_context(
     session_path: Option<&Path>,
 ) -> Result<StatusContext, Box<dyn std::error::Error>> {
@@ -3720,6 +3948,20 @@ fn status_context(
         project_root,
         git_branch,
         git_summary,
+        sandbox_status,
+    })
+}
+
+fn workspace_context() -> Result<WorkspaceContext, Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    let loader = ConfigLoader::default_for(&cwd);
+    let runtime_config = loader.load().unwrap_or_else(|_| runtime::RuntimeConfig::empty());
+    let sandbox_status = resolve_sandbox_status(runtime_config.sandbox(), &cwd);
+    Ok(WorkspaceContext {
+        project_root: find_git_root_in(&cwd).ok(),
+        session_dir: cwd.join(".claw").join("sessions"),
+        recovery_dir: runtime::recovery::recovery_dir(&cwd),
+        cwd,
         sandbox_status,
     })
 }
@@ -3791,6 +4033,55 @@ fn format_status_report(
 
 ",
     )
+}
+
+fn format_workspace_report(context: &WorkspaceContext) -> String {
+    format!(
+        "Workspace
+  Active cwd       {}
+  Project root     {}
+  Session dir      {}
+  Recovery dir     {}
+  Filesystem mode  {}
+  Allowed mounts   {}
+  Natural input    say `切换到 D:\\YourProject` or `当前工作区`
+  Command input    `sego --cwd <path>`, `/workspace`, `/cd <path>`",
+        context.cwd.display(),
+        context
+            .project_root
+            .as_ref()
+            .map_or_else(|| "unknown".to_string(), |path| path.display().to_string()),
+        context.session_dir.display(),
+        context.recovery_dir.display(),
+        context.sandbox_status.filesystem_mode.as_str(),
+        if context.sandbox_status.allowed_mounts.is_empty() {
+            "<workspace only>".to_string()
+        } else {
+            context.sandbox_status.allowed_mounts.join(", ")
+        },
+    )
+}
+
+fn format_workspace_switch_report(previous: &Path, next: &Path, switched: bool) -> String {
+    if switched {
+        format!(
+            "Workspace switched
+  Previous cwd     {}
+  Active cwd       {}
+  Session scope    new workspace-local session
+  Config scope     reloaded from active cwd
+  Tip              say `当前工作区` or run `/workspace` to inspect context",
+            previous.display(),
+            next.display(),
+        )
+    } else {
+        format!(
+            "Workspace unchanged
+  Active cwd       {}
+  Reason           requested path is already active",
+            next.display(),
+        )
+    }
 }
 
 fn format_sandbox_report(status: &runtime::SandboxStatus) -> String {
@@ -7437,15 +7728,15 @@ mod tests {
         format_ultraplan_report, format_unknown_slash_command,
         format_unknown_slash_command_message, normalize_permission_mode, parse_args,
         parse_git_status_branch, parse_git_status_metadata_for, parse_git_workspace_summary,
-        permission_policy, print_help_to, push_output_block, render_code_review_readiness_for,
-        render_code_review_summary_for, render_config_report, render_diff_report,
-        render_diff_report_for, render_memory_report, render_repl_help, render_resume_usage,
-        resolve_model_alias, resolve_session_reference, response_to_events,
-        resume_supported_slash_commands, run_resume_command,
+        parse_workspace_natural_language_intent, permission_policy, print_help_to,
+        push_output_block, render_code_review_readiness_for, render_code_review_summary_for,
+        render_config_report, render_diff_report, render_diff_report_for, render_memory_report,
+        render_repl_help, render_resume_usage, resolve_model_alias, resolve_session_reference,
+        response_to_events, resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
         write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor, GitWorkspaceSummary,
         InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SafetyReviewScope,
-        SlashCommand, StatusUsage,
+        SlashCommand, StatusUsage, WorkspaceIntent,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
     use plugins::{
@@ -7786,6 +8077,52 @@ mod tests {
             parse_args(&["update".to_string()]).expect("update should parse"),
             CliAction::Update
         );
+    }
+
+    #[test]
+    fn parses_workspace_command_aliases_without_initializing_prompt_mode() {
+        for command in ["workspace", "workdir", "pwd", "cwd", "/workspace", "/pwd"] {
+            assert_eq!(
+                parse_args(&[command.to_string()]).expect("workspace command should parse"),
+                CliAction::Workspace { output_format: CliOutputFormat::Text }
+            );
+        }
+    }
+
+    #[test]
+    fn parses_global_cwd_before_workspace_action() {
+        let root = temp_dir();
+        let workspace = root.join("中文项目");
+        fs::create_dir_all(&workspace).expect("workspace dir");
+
+        let action = with_current_dir(&root, || {
+            parse_args(&[
+                "--cwd".to_string(),
+                workspace.display().to_string(),
+                "workspace".to_string(),
+            ])
+            .expect("args should parse")
+        });
+
+        fs::remove_dir_all(root).expect("temp workspace should clean up");
+        assert_eq!(action, CliAction::Workspace { output_format: CliOutputFormat::Text });
+    }
+
+    #[test]
+    fn parses_workspace_natural_language_intents() {
+        assert_eq!(
+            parse_workspace_natural_language_intent("当前工作区"),
+            Some(WorkspaceIntent::Show)
+        );
+        assert_eq!(
+            parse_workspace_natural_language_intent("切换到 D:\\Project"),
+            Some(WorkspaceIntent::Switch("D:\\Project".to_string()))
+        );
+        assert_eq!(
+            parse_workspace_natural_language_intent("打开项目 E:\\中文项目"),
+            Some(WorkspaceIntent::Switch("E:\\中文项目".to_string()))
+        );
+        assert_eq!(parse_workspace_natural_language_intent("帮我 review 当前改动"), None);
     }
 
     #[test]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1727,11 +1727,104 @@ fn from_value<T: for<'de> Deserialize<'de>>(input: &Value) -> Result<T, String> 
 }
 
 fn run_bash(input: BashCommandInput) -> Result<String, String> {
+    if let Some(output) = bash_file_authoring_guard(&input.command) {
+        return serde_json::to_string_pretty(&output).map_err(|error| error.to_string());
+    }
     if let Some(output) = workspace_test_branch_preflight(&input.command) {
         return serde_json::to_string_pretty(&output).map_err(|error| error.to_string());
     }
     serde_json::to_string_pretty(&execute_bash(input).map_err(|error| error.to_string())?)
         .map_err(|error| error.to_string())
+}
+
+fn bash_file_authoring_guard(command: &str) -> Option<BashCommandOutput> {
+    if !looks_like_shell_file_authoring_misuse(command) {
+        return None;
+    }
+
+    let stderr = concat!(
+        "Sego blocked this shell file-writing pattern. ",
+        "Use the write_file or edit_file tool to create Markdown, JSON, or source files; ",
+        "do not compose text files through bash echo, PowerShell, Node, or Python quoting loops."
+    )
+    .to_string();
+
+    Some(BashCommandOutput {
+        stdout: String::new(),
+        stderr: stderr.clone(),
+        raw_output_path: None,
+        interrupted: false,
+        is_image: None,
+        background_task_id: None,
+        backgrounded_by_user: None,
+        assistant_auto_backgrounded: None,
+        dangerously_disable_sandbox: None,
+        return_code_interpretation: Some(
+            "preflight_blocked:file_authoring_tool_misuse".to_string(),
+        ),
+        no_output_expected: Some(true),
+        structured_content: Some(vec![serde_json::to_value(
+            LaneEvent::new(LaneEventName::Blocked, LaneEventStatus::Blocked, iso8601_now())
+                .with_failure_class(LaneFailureClass::ToolRuntime)
+                .with_detail(stderr)
+                .with_data(json!({
+                    "blockedCommand": command,
+                    "recommendedTool": "write_file",
+                    "reason": "file_authoring_tool_misuse"
+                })),
+        )
+        .expect("lane event should serialize")]),
+        persisted_output_path: None,
+        persisted_output_size: None,
+        sandbox_status: None,
+    })
+}
+
+fn looks_like_shell_file_authoring_misuse(command: &str) -> bool {
+    let lower = format!(" {} ", command.to_ascii_lowercase());
+    let targets_text_file = [
+        ".md",
+        ".markdown",
+        ".txt",
+        ".json",
+        ".rs",
+        ".py",
+        ".js",
+        ".ts",
+        ".tsx",
+        ".jsx",
+        ".toml",
+        ".yaml",
+        ".yml",
+    ]
+    .iter()
+    .any(|extension| lower.contains(extension));
+    if !targets_text_file {
+        return false;
+    }
+
+    let shell_write = lower.contains(" > ")
+        || lower.contains(">>")
+        || lower.contains(" set-content ")
+        || lower.contains(" out-file ")
+        || lower.contains("writefile")
+        || lower.contains("writefilesync")
+        || lower.contains("python -c")
+        || lower.contains("node -e");
+    if !shell_write {
+        return false;
+    }
+
+    let echo_count = lower.matches(" echo ").count()
+        + lower.matches("&echo ").count()
+        + lower.matches(";echo ").count();
+    echo_count >= 2
+        || lower.contains(" set-content ")
+        || lower.contains(" out-file ")
+        || lower.contains("writefile")
+        || lower.contains("writefilesync")
+        || lower.contains("python -c")
+        || lower.contains("node -e")
 }
 
 fn workspace_test_branch_preflight(command: &str) -> Option<BashCommandOutput> {
@@ -6136,6 +6229,37 @@ mod tests {
         let background_output: serde_json::Value = serde_json::from_str(&background).expect("json");
         assert!(background_output["backgroundTaskId"].as_str().is_some());
         assert_eq!(background_output["noOutputExpected"], true);
+    }
+
+    #[test]
+    fn bash_blocks_shell_text_file_authoring_loops() {
+        let output = execute_tool(
+            "bash",
+            &json!({
+                "command": "echo # Review > E:\\code\\PR43-review.md & echo finding >> E:\\code\\PR43-review.md"
+            }),
+        )
+        .expect("bash guard should return structured output");
+        let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+        assert_eq!(
+            output_json["returnCodeInterpretation"],
+            "preflight_blocked:file_authoring_tool_misuse"
+        );
+        assert!(output_json["stderr"].as_str().expect("stderr").contains("write_file"));
+        assert_eq!(output_json["structuredContent"][0]["event"], "lane.blocked");
+        assert_eq!(output_json["structuredContent"][0]["failureClass"], "tool_runtime");
+    }
+
+    #[test]
+    fn bash_allows_simple_echo_without_file_authoring() {
+        let output = execute_tool("bash", &json!({ "command": shell_stdout_command("hello") }))
+            .expect("simple echo should still execute");
+        let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+        assert_eq!(output_json["stdout"].as_str().expect("stdout").trim(), "hello");
+        assert_ne!(
+            output_json["returnCodeInterpretation"],
+            "preflight_blocked:file_authoring_tool_misuse"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 摘要

- EN: Add global `--cwd <path>` support so users can launch Sego directly in a chosen project folder, including Windows cross-drive and Chinese path names.
- 中文：新增全局 `--cwd <path>`，用户可以直接在指定项目目录启动 Sego，支持 Windows 跨盘符与中文路径。
- EN: Add `/pwd`, `/cd <path>`, and `/workspace [path]` plus REPL natural-language workspace intents such as “切换到 D:\YourProject” and “当前工作区”.
- 中文：新增 `/pwd`、`/cd <path>`、`/workspace [path]`，并支持“切换到 D:\YourProject”“当前工作区”等自然语言工作区操作。
- EN: Add natural-language export handling for prompts like “把刚才的审查结果写成 E:\code\PR43-review.md”; Sego writes the latest assistant response directly instead of asking the model to generate shell commands.
- 中文：新增“把刚才的审查结果写成 E:\code\PR43-review.md”等自然语言导出路径，Sego 会直接写入上一条助手回复，不再让模型绕去拼 Bash。
- EN: Add turn-level cancellation wiring so Ctrl+C cancels the active model/tool turn first; pressing Ctrl+C again force exits.
- 中文：新增 turn 级取消信号，Ctrl+C 会先取消当前模型/工具任务，第二次 Ctrl+C 才强制退出。
- EN: Add a Bash preflight guard for shell text-file authoring loops (`echo`/PowerShell/Node/Python redirects) and steer the model to `write_file` / `edit_file`.
- 中文：新增 Bash 工具层拦截，阻止用 `echo`/PowerShell/Node/Python 重定向拼写 Markdown/源码文件的低质量循环，并引导使用 `write_file` / `edit_file`。
- EN: Rebuild the live runtime/session/workflow scope after REPL workspace switching so tools, config, prompt, review, and recovery state follow the active workspace.
- 中文：REPL 内切换工作区后会重建运行时、会话和工作流作用域，让工具、配置、提示词、review 与 recovery 状态跟随当前工作区。
- EN: Update Windows launchers to keep error windows visible while avoiding a forced pause after successful exits; launcher hints stay ASCII to avoid code-page mojibake.
- 中文：更新 Windows 启动器：错误时保留窗口，成功退出不再强制 pause；启动器提示保持 ASCII，减少 Windows 代码页乱码。

## Tests / 测试

- `cargo fmt --all --check`
- `cargo test -p commands renders_help_from_shared_specs`
- `cargo test -p rusty-claude-cli --bin sego`
- `cargo test -p runtime conversation`
- `cargo test -p tools bash`
- `cargo build -p rusty-claude-cli`
- `git diff --check`
- `cargo clippy -p runtime --lib`
- `cargo clippy -p tools --lib`
- `cargo clippy -p rusty-claude-cli --bin sego`

## Notes / 备注

- EN: Normal `git push` failed in this environment with HTTPS transport resets, so this update was pushed through GitHub Git Data API. The remote tree matches the local verified tree.
- 中文：当前环境普通 `git push` 遇到 HTTPS 传输 reset，因此本次通过 GitHub Git Data API 更新远端分支；远端 tree 与本地已验证 tree 完全一致。
- EN: Clippy exits successfully; existing warnings remain outside this slice.
- 中文：Clippy 退出码通过；仓库中仍有与本次改动无关的既有 warning。