### PR TITLE
fix(cli): keep cancelled turns inside repl

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "api",
  "commands",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -170,10 +170,16 @@ const CLI_OPTION_SUGGESTIONS: &[&str] = &[
 
 type AllowedToolSet = BTreeSet<String>;
 
+const TURN_CANCELLED_MESSAGE: &str = "conversation turn cancelled by user";
+
 fn main() {
     if let Err(error) = run() {
         let message = error.to_string();
-        if message.contains("`sego --help`") || message == "verification failed" {
+        if is_turn_cancelled_message(&message) {
+            eprintln!("Sego cancelled the current task.");
+            maybe_pause_after_error();
+            std::process::exit(130);
+        } else if message.contains("`sego --help`") || message == "verification failed" {
             eprintln!("error: {message}");
         } else {
             eprintln!(
@@ -185,6 +191,14 @@ Run `sego --help` for usage."
         maybe_pause_after_error();
         std::process::exit(1);
     }
+}
+
+fn is_turn_cancelled_message(message: &str) -> bool {
+    message.contains(TURN_CANCELLED_MESSAGE)
+}
+
+fn is_turn_cancelled_error(error: &(dyn std::error::Error + 'static)) -> bool {
+    is_turn_cancelled_message(&error.to_string())
 }
 
 fn maybe_pause_after_error() {
@@ -2069,7 +2083,14 @@ fn run_repl(
                     cli.export_last_assistant_response(intent.path.as_deref())?;
                     continue;
                 }
-                cli.run_turn(&trimmed)?;
+                match cli.run_turn(&trimmed) {
+                    Ok(()) => {}
+                    Err(error) if is_turn_cancelled_error(error.as_ref()) => {
+                        eprintln!("Sego cancelled the current task. You can continue.");
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
             }
             input::ReadOutcome::Cancel => {}
             input::ReadOutcome::Exit => {
@@ -7932,19 +7953,19 @@ mod tests {
         format_permissions_report, format_permissions_switch_report, format_pr_report,
         format_resume_report, format_status_report, format_tool_call_start, format_tool_result,
         format_ultraplan_report, format_unknown_slash_command,
-        format_unknown_slash_command_message, normalize_permission_mode, parse_args,
-        parse_export_last_response_intent, parse_git_status_branch, parse_git_status_metadata_for,
-        parse_git_workspace_summary, parse_workspace_natural_language_intent, permission_policy,
-        print_help_to, push_output_block, render_code_review_readiness_for,
-        render_code_review_summary_for, render_config_report, render_diff_report,
-        render_diff_report_for, render_memory_report, render_repl_help, render_resume_usage,
-        resolve_model_alias, resolve_session_reference, response_to_events,
-        resume_supported_slash_commands, run_resume_command,
+        format_unknown_slash_command_message, is_turn_cancelled_message, normalize_permission_mode,
+        parse_args, parse_export_last_response_intent, parse_git_status_branch,
+        parse_git_status_metadata_for, parse_git_workspace_summary,
+        parse_workspace_natural_language_intent, permission_policy, print_help_to,
+        push_output_block, render_code_review_readiness_for, render_code_review_summary_for,
+        render_config_report, render_diff_report, render_diff_report_for, render_memory_report,
+        render_repl_help, render_resume_usage, resolve_model_alias, resolve_session_reference,
+        response_to_events, resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
         write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor,
         ExportLastResponseIntent, GitWorkspaceSummary, InternalPromptProgressEvent,
         InternalPromptProgressState, LiveCli, SafetyReviewScope, SlashCommand, StatusUsage,
-        WorkspaceIntent,
+        WorkspaceIntent, TURN_CANCELLED_MESSAGE,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
     use plugins::{
@@ -8043,6 +8064,13 @@ mod tests {
                 "python3".to_string()
             }
         })
+    }
+
+    #[test]
+    fn identifies_turn_cancelled_errors_without_usage_hint() {
+        assert!(is_turn_cancelled_message(TURN_CANCELLED_MESSAGE));
+        assert!(is_turn_cancelled_message("runtime failed: conversation turn cancelled by user"));
+        assert!(!is_turn_cancelled_message("missing DeepSeek credentials; set DEEPSEEK_API_KEY"));
     }
 
     fn git(args: &[&str], cwd: &Path) {


### PR DESCRIPTION
## 中文说明

### Summary
- 将用户 Ctrl+C 取消从 fatal error 改为 REPL 内可恢复事件：当前任务取消后回到交互循环，不再关闭窗口。
- 顶层 one-shot 取消不再显示 `Run sego --help`，改用简洁取消提示并返回 Ctrl+C 语义退出码 130。
- 将 workspace 版本提升到 `0.1.5`，为下一版 release 和 `sego update` 对齐版本号。

### Tests
- `cargo fmt --all --check`
- `cargo test -p rusty-claude-cli --bin sego`
- `cargo test -p runtime conversation`
- `cargo test -p tools bash`
- `cargo build -p rusty-claude-cli --release`
- `git diff --check`

## English

### Summary
- Treat Ctrl+C cancellation as a recoverable REPL event: cancel the current turn and keep the window/session alive.
- Avoid printing the generic usage hint for user-initiated cancellation in one-shot mode; return exit code 130 instead.
- Bump the workspace version to `0.1.5` so the release and `sego update` can target the fixed build.

### Tests
- `cargo fmt --all --check`
- `cargo test -p rusty-claude-cli --bin sego`
- `cargo test -p runtime conversation`
- `cargo test -p tools bash`
- `cargo build -p rusty-claude-cli --release`
- `git diff --check`