### PR TITLE
feat(cli): add deterministic natural language intent router

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,26 @@ sego /review safety staged # staged 安全锁
 - **审查历史**：findings 持久化到 `.sego/reviews/`，支持查看、标记状态、复盘
 - **多模型支持**：DeepSeek（含推理模式）和 Anthropic
 
-### 2. Crash Recovery（崩溃恢复）
+### 2. 自然语言本地动作（NL Intent Router）
+
+在交互窗口里，常见控制动作可以直接用口语表达，Sego 会在本地确定执行，不把这些请求交给模型乱试命令：
+
+```text
+当前工作区
+切换到 D:\YourProject
+帮我 review 当前改动
+检查安全问题
+把刚才的审查结果写成 E:\code\review.md
+导出当前会话
+检查更新
+退出
+```
+
+更严谨的命令式入口仍然保留：`/workspace`、`/cd`、`/review`、`/export`、`sego update --check`。
+
+如果 Sego 判断你像是在说本地控制动作、但缺少路径或对象，会提示你补全说法；输入 `/dir` 可以查看常用指令和自然语言示例。
+
+### 3. Crash Recovery（崩溃恢复）
 
 ```bash
 sego --resume latest           # 恢复最近一次会话
@@ -141,7 +160,7 @@ sego --resume latest /status   # 查看恢复状态
 - 恢复时不重放旧工具调用（安全边界）
 - 正常退出的会话不会触发恢复提示
 
-### 3. Review-Trust 权限画像
+### 4. Review-Trust 权限画像
 
 ```bash
 sego --permission-profile review-trust
@@ -155,7 +174,7 @@ sego --permission-profile review-trust
 
 `--permission-mode` 和 `--permission-profile` 互斥（不能同时使用）。
 
-### 4. Sidecar JSON 接口（PoC）
+### 5. Sidecar JSON 接口（PoC）
 
 ```bash
 echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' \
@@ -168,9 +187,9 @@ echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' 
 - skill 包（`skills/sego-review/`）可被 Claude Code / Codex / Cursor / 任何 SKILL.md 兼容工具调用
 - 错误时返回结构化 error envelope（不崩溃）
 
-> **PoC 状态**：sidecar 当前仅支持 `review` action。stdout 混入 banner 输出的已知限制将在后续修复。
+> **PoC 状态**：sidecar 当前仅支持 `review` action；stdout 保持 JSON 输出，诊断信息走 stderr。
 
-### 5. 验证计划
+### 6. 验证计划
 
 ```bash
 sego /verify fast    # 快速验证计划
@@ -179,7 +198,7 @@ sego /verify         # 完整验证
 
 根据项目类型识别验证命令（Rust: cargo build/test，Node: npm test/build）。
 
-### 6. 接入 AI 编码工具（Sidecar skill PoC）
+### 7. 接入 AI 编码工具（Sidecar skill PoC）
 
 Sego 提供一个 sidecar skill 包，让你的 AI 编码工具（Claude Code、Codex、Cursor 等）能自动调用 Sego review。
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -54,25 +54,38 @@ cd rust
 ./target/debug/sego
 ```
 
-Inside the REPL, Sego supports natural workspace language for normal users:
+Inside the REPL, Sego supports deterministic natural-language shortcuts for common local actions:
 
 ```text
 当前工作区
 切换到 D:\YourProject
 打开项目 E:\YourProject
+帮我 review 当前改动
+检查安全问题
+把刚才的审查结果写成 E:\code\review.md
+导出当前会话
+检查更新
+退出
 ```
 
-For stricter CLI usage, the same workflow is available as commands:
+These shortcuts are local control actions. Sego handles them before model calls, so they do not trigger exploratory shell commands. For stricter CLI usage, the same workflows are available as commands:
 
 ```bash
 sego --cwd "D:\YourProject" workspace
+sego update --check
 ```
 
 ```text
 /workspace
 /pwd
 /cd D:\YourProject
+/review
+/review safety staged
+/export
+/dir
 ```
+
+If a sentence looks like a local control action but lacks a path or target, Sego prints a short hint and points you to `/dir`. Normal coding, explanation, and discussion prompts still go to the model.
 
 ### One-shot prompt
 

--- a/rust/crates/commands/src/lib.rs
+++ b/rust/crates/commands/src/lib.rs
@@ -58,6 +58,13 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
         resume_supported: true,
     },
     SlashCommandSpec {
+        name: "dir",
+        aliases: &[],
+        summary: "Show common local actions and natural-language examples",
+        argument_hint: None,
+        resume_supported: true,
+    },
+    SlashCommandSpec {
         name: "status",
         aliases: &[],
         summary: "Show current session status",
@@ -1079,6 +1086,7 @@ const SLASH_COMMAND_SPECS: &[SlashCommandSpec] = &[
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SlashCommand {
     Help,
+    Dir,
     Status,
     Sandbox,
     Pwd,
@@ -1202,6 +1210,10 @@ pub fn validate_slash_command_input(
         "help" => {
             validate_no_args(command, &args)?;
             SlashCommand::Help
+        }
+        "dir" => {
+            validate_no_args(command, &args)?;
+            SlashCommand::Dir
         }
         "status" => {
             validate_no_args(command, &args)?;
@@ -1716,10 +1728,9 @@ pub fn resume_supported_slash_commands() -> Vec<&'static SlashCommandSpec> {
 
 fn slash_command_category(name: &str) -> &'static str {
     match name {
-        "help" | "status" | "sandbox" | "model" | "permissions" | "cost" | "resume" | "session"
-        | "version" | "login" | "logout" | "usage" | "stats" | "rename" | "privacy-settings" => {
-            "Session & visibility"
-        }
+        "help" | "dir" | "status" | "sandbox" | "model" | "permissions" | "cost" | "resume"
+        | "session" | "version" | "login" | "logout" | "usage" | "stats" | "rename"
+        | "privacy-settings" => "Session & visibility",
         "compact" | "clear" | "config" | "memory" | "init" | "diff" | "commit" | "pr" | "issue"
         | "export" | "recovery-export" | "plugin" | "branch" | "add-dir" | "files" | "hooks"
         | "release-notes" => "Workspace & git",
@@ -3018,7 +3029,7 @@ pub fn handle_slash_command(
             };
             Some(SlashCommandResult { message, session: result.compacted_session })
         }
-        SlashCommand::Help => Some(SlashCommandResult {
+        SlashCommand::Help | SlashCommand::Dir => Some(SlashCommandResult {
             message: render_slash_command_help(),
             session: session.clone(),
         }),
@@ -3183,6 +3194,7 @@ mod tests {
     #[test]
     fn parses_supported_slash_commands() {
         assert_eq!(SlashCommand::parse("/help"), Ok(Some(SlashCommand::Help)));
+        assert_eq!(SlashCommand::parse("/dir"), Ok(Some(SlashCommand::Dir)));
         assert_eq!(SlashCommand::parse(" /status "), Ok(Some(SlashCommand::Status)));
         assert_eq!(SlashCommand::parse("/sandbox"), Ok(Some(SlashCommand::Sandbox)));
         assert_eq!(SlashCommand::parse("/pwd"), Ok(Some(SlashCommand::Pwd)));
@@ -3440,6 +3452,7 @@ mod tests {
         assert!(help.contains("Discovery & debugging"));
         assert!(help.contains("Analysis & automation"));
         assert!(help.contains("/help"));
+        assert!(help.contains("/dir"));
         assert!(help.contains("/status"));
         assert!(help.contains("/sandbox"));
         assert!(help.contains("/compact"));
@@ -3472,7 +3485,7 @@ mod tests {
         assert!(help.contains("/agents [list|help]"));
         assert!(help.contains("/skills [list|install <path>|help]"));
         assert!(help.contains("/verify [auto|fast|full]"));
-        assert_eq!(slash_command_specs().len(), 146);
+        assert_eq!(slash_command_specs().len(), 147);
         assert!(resume_supported_slash_commands().len() >= 39);
     }
 

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -8,6 +8,7 @@
 )]
 mod init;
 mod input;
+mod nl_intent;
 mod render;
 mod sidecar;
 
@@ -37,6 +38,7 @@ use commands::{
 };
 use compat_harness::{extract_manifest, UpstreamPaths};
 use init::initialize_repo;
+use nl_intent::{classify_nl_intent_miss, parse_nl_intent, NlIntent, NlIntentMiss};
 use plugins::{PluginHooks, PluginManager, PluginManagerConfig, PluginRegistry};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
@@ -245,7 +247,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         CliAction::Skills { args } => LiveCli::print_skills(args.as_deref())?,
         CliAction::PrintSystemPrompt { cwd, date } => print_system_prompt(cwd, date),
         CliAction::Version => print_version(),
-        CliAction::Update => run_update()?,
+        CliAction::Update { check_only } => run_update(check_only)?,
         CliAction::Workspace { output_format } => print_workspace_snapshot(output_format)?,
         CliAction::ResumeSession { session_path, commands } => {
             resume_session(&session_path, &commands);
@@ -295,6 +297,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             run_repl(model, allowed_tools, permission_mode)?;
         }
         CliAction::Help => print_help(),
+        CliAction::Dir => println!("{}", render_natural_language_directory()),
         CliAction::Review { last_n, output_format } => {
             print_workflow_review(last_n, output_format)?;
         }
@@ -326,7 +329,10 @@ enum CliAction {
         date: String,
     },
     Version,
-    Update,
+    Dir,
+    Update {
+        check_only: bool,
+    },
     Workspace {
         output_format: CliOutputFormat,
     },
@@ -629,7 +635,15 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         "mcp" => Ok(CliAction::Mcp { args: join_optional_args(&rest[1..]) }),
         "skills" => Ok(CliAction::Skills { args: join_optional_args(&rest[1..]) }),
         "system-prompt" => parse_system_prompt_args(&rest[1..]),
-        "update" => Ok(CliAction::Update),
+        "update" => {
+            if rest.len() == 2 && matches!(rest[1].as_str(), "--check" | "check") {
+                Ok(CliAction::Update { check_only: true })
+            } else if rest.len() == 1 {
+                Ok(CliAction::Update { check_only: false })
+            } else {
+                Err("update accepts no arguments except --check".to_string())
+            }
+        }
         "login" => Ok(CliAction::Login),
         "logout" => Ok(CliAction::Logout),
         "init" => Ok(CliAction::Init),
@@ -666,7 +680,7 @@ fn parse_single_word_command_alias(
     match rest[0].as_str() {
         "help" => Some(Ok(CliAction::Help)),
         "version" => Some(Ok(CliAction::Version)),
-        "update" => Some(Ok(CliAction::Update)),
+        "update" => Some(Ok(CliAction::Update { check_only: false })),
         "status" => Some(Ok(CliAction::Status {
             model: model.to_string(),
             permission_mode: permission_mode_override.unwrap_or_else(default_permission_mode),
@@ -732,6 +746,7 @@ fn parse_direct_slash_cli_action(
     let raw = rest.join(" ");
     match SlashCommand::parse(&raw) {
         Ok(Some(SlashCommand::Help)) => Ok(CliAction::Help),
+        Ok(Some(SlashCommand::Dir)) => Ok(CliAction::Dir),
         Ok(Some(SlashCommand::Agents { args })) => Ok(CliAction::Agents { args }),
         Ok(Some(SlashCommand::Mcp { action, target })) => Ok(CliAction::Mcp {
             args: match (action, target) {
@@ -857,166 +872,6 @@ fn apply_requested_cwd(cwd: Option<&PathBuf>) -> Result<(), String> {
             .map_err(|error| format!("failed to switch --cwd to {}: {error}", cwd.display()))?;
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum WorkspaceIntent {
-    Show,
-    Switch(String),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ExportLastResponseIntent {
-    path: Option<String>,
-}
-
-fn parse_workspace_natural_language_intent(input: &str) -> Option<WorkspaceIntent> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() || trimmed.starts_with('/') {
-        return None;
-    }
-    let lower = trimmed.to_ascii_lowercase();
-    if matches!(
-        lower.as_str(),
-        "pwd" | "cwd" | "where am i" | "show workspace" | "current workspace"
-    ) || trimmed.contains("当前目录")
-        || trimmed.contains("工作目录")
-        || trimmed.contains("当前工作区")
-    {
-        return Some(WorkspaceIntent::Show);
-    }
-
-    for prefix in [
-        "切换到",
-        "切换工作区到",
-        "切换工作目录到",
-        "打开项目",
-        "进入项目",
-        "进入目录",
-        "把工作目录切到",
-        "change directory to",
-        "switch workspace to",
-        "open project",
-        "use workspace",
-        "cd ",
-    ] {
-        if let Some(path) = strip_intent_prefix(trimmed, prefix) {
-            return Some(WorkspaceIntent::Switch(path.to_string()));
-        }
-    }
-
-    None
-}
-
-fn parse_export_last_response_intent(input: &str) -> Option<ExportLastResponseIntent> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() || trimmed.starts_with('/') {
-        return None;
-    }
-
-    let lower = trimmed.to_ascii_lowercase();
-    let has_export_verb = lower.contains("export")
-        || lower.contains("save")
-        || lower.contains("write")
-        || trimmed.contains("导出")
-        || trimmed.contains("保存")
-        || trimmed.contains("写入")
-        || trimmed.contains("写成")
-        || trimmed.contains("生成");
-    if !has_export_verb {
-        return None;
-    }
-
-    let targets_last_response = lower.contains("last")
-        || lower.contains("previous")
-        || lower.contains("review")
-        || lower.contains("report")
-        || trimmed.contains("刚才")
-        || trimmed.contains("上一条")
-        || trimmed.contains("上一次")
-        || trimmed.contains("审查")
-        || trimmed.contains("审核")
-        || trimmed.contains("报告")
-        || trimmed.contains("结果");
-    if !targets_last_response {
-        return None;
-    }
-
-    let path = extract_export_path(trimmed);
-    if path.is_none()
-        && !(lower.contains(".md") || lower.contains("markdown") || trimmed.contains("md"))
-    {
-        return None;
-    }
-
-    Some(ExportLastResponseIntent { path })
-}
-
-fn extract_export_path(input: &str) -> Option<String> {
-    for quoted in extract_quoted_segments(input) {
-        if looks_like_export_path(&quoted) {
-            return Some(quoted);
-        }
-    }
-
-    input
-        .split_whitespace()
-        .rev()
-        .map(|part| {
-            part.trim_matches(|ch: char| {
-                matches!(ch, '"' | '\'' | '`' | '。' | '，' | ',' | ';' | '；' | ':' | '：')
-            })
-        })
-        .find(|part| looks_like_export_path(part))
-        .map(ToOwned::to_owned)
-}
-
-fn extract_quoted_segments(input: &str) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let mut quote: Option<char> = None;
-    for ch in input.chars() {
-        match quote {
-            Some(end) if ch == end => {
-                let value = current.trim();
-                if !value.is_empty() {
-                    segments.push(value.to_string());
-                }
-                current.clear();
-                quote = None;
-            }
-            Some(_) => current.push(ch),
-            None if matches!(ch, '"' | '\'' | '`' | '“' | '‘') => {
-                quote = Some(match ch {
-                    '“' => '”',
-                    '‘' => '’',
-                    other => other,
-                });
-            }
-            None => {}
-        }
-    }
-    segments
-}
-
-fn looks_like_export_path(value: &str) -> bool {
-    let path = Path::new(value);
-    path.extension()
-        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
-        || value.contains('\\')
-        || value.contains('/')
-}
-
-fn strip_intent_prefix<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
-    if prefix.is_ascii() {
-        let lower = input.to_ascii_lowercase();
-        let lower_prefix = prefix.to_ascii_lowercase();
-        if lower.starts_with(&lower_prefix) {
-            return Some(input[prefix.len()..].trim().trim_matches('"'));
-        }
-        return None;
-    }
-    input.strip_prefix(prefix).map(|path| path.trim().trim_matches('"'))
 }
 
 fn render_suggestion_line(label: &str, suggestions: &[String]) -> Option<String> {
@@ -1807,6 +1662,10 @@ fn run_resume_command(
         SlashCommand::Help => {
             Ok(ResumeCommandOutcome { session: session.clone(), message: Some(render_repl_help()) })
         }
+        SlashCommand::Dir => Ok(ResumeCommandOutcome {
+            session: session.clone(),
+            message: Some(render_natural_language_directory()),
+        }),
         SlashCommand::Compact => {
             let result = runtime::compact_session(
                 session,
@@ -2070,17 +1929,22 @@ fn run_repl(
                     }
                 }
                 editor.push_history(input);
-                if let Some(intent) = parse_workspace_natural_language_intent(&trimmed) {
-                    match intent {
-                        WorkspaceIntent::Show => LiveCli::print_workspace_status()?,
-                        WorkspaceIntent::Switch(path) => {
-                            cli.switch_workspace(&path)?;
-                        }
+                if let Some(intent) = parse_nl_intent(&trimmed) {
+                    if cli.handle_nl_intent(intent)? {
+                        cli.persist_session()?;
+                        persist_recovery_for_cli(
+                            runtime::recovery::RecoveryExitState::Graceful,
+                            cli.session_id(),
+                            cli.session_path(),
+                            Some(cli.model_name()),
+                            None,
+                        );
+                        break;
                     }
                     continue;
                 }
-                if let Some(intent) = parse_export_last_response_intent(&trimmed) {
-                    cli.export_last_assistant_response(intent.path.as_deref())?;
+                if let Some(miss) = classify_nl_intent_miss(&trimmed) {
+                    println!("{}", render_nl_intent_miss(&miss));
                     continue;
                 }
                 match cli.run_turn(&trimmed) {
@@ -2982,6 +2846,46 @@ impl LiveCli {
         Ok(())
     }
 
+    fn handle_nl_intent(&mut self, intent: NlIntent) -> Result<bool, Box<dyn std::error::Error>> {
+        match intent {
+            NlIntent::WorkspaceShow => {
+                Self::print_workspace_status()?;
+                Ok(false)
+            }
+            NlIntent::WorkspaceSwitch { path } => {
+                self.switch_workspace(&path)?;
+                Ok(false)
+            }
+            NlIntent::Review { scope } => {
+                self.handle_review_command(scope.as_deref())?;
+                Ok(false)
+            }
+            NlIntent::ReviewSafety { staged } => {
+                let scope =
+                    if staged { SafetyReviewScope::Staged } else { SafetyReviewScope::Workspace };
+                print_code_review_safety(scope)?;
+                Ok(false)
+            }
+            NlIntent::ExportLastResponse { path } => {
+                self.export_last_assistant_response(path.as_deref())?;
+                Ok(false)
+            }
+            NlIntent::ExportSession { path } => {
+                self.export_session(path.as_deref())?;
+                Ok(false)
+            }
+            NlIntent::UpdateCheck => {
+                run_update(true)?;
+                Ok(false)
+            }
+            NlIntent::UpdateApply => {
+                run_update(false)?;
+                Ok(false)
+            }
+            NlIntent::Exit => Ok(true),
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     fn handle_repl_command(
         &mut self,
@@ -2990,6 +2894,10 @@ impl LiveCli {
         Ok(match command {
             SlashCommand::Help => {
                 println!("{}", render_repl_help());
+                false
+            }
+            SlashCommand::Dir => {
+                println!("{}", render_natural_language_directory());
                 false
             }
             SlashCommand::Status => {
@@ -4031,6 +3939,7 @@ fn render_repl_help() -> String {
         "REPL".to_string(),
         "  /exit                Quit the REPL".to_string(),
         "  /quit                Quit the REPL".to_string(),
+        "  /dir                 Show common commands and natural-language examples".to_string(),
         "  Up/Down              Navigate prompt history".to_string(),
         "  Tab                  Complete commands, modes, and recent sessions".to_string(),
         "  Ctrl-C               Clear input (or exit on empty prompt)".to_string(),
@@ -4047,6 +3956,40 @@ fn render_repl_help() -> String {
         "
 ",
     )
+}
+
+fn render_natural_language_directory() -> String {
+    [
+        "Sego 常用动作目录".to_string(),
+        "  工作区".to_string(),
+        "    /workspace                 当前工作区 / 当前目录".to_string(),
+        "    /cd D:\\YourProject         切换到 D:\\YourProject / 打开项目 D:\\YourProject"
+            .to_string(),
+        "  审查".to_string(),
+        "    /review                    帮我 review 当前改动".to_string(),
+        "    /review staged             review staged changes / 审查已暂存改动".to_string(),
+        "    /review workspace          审查整个项目代码".to_string(),
+        "    /review safety staged      检查已暂存代码的安全风险".to_string(),
+        "  导出".to_string(),
+        "    /export                    导出当前会话".to_string(),
+        "    /export E:\\code\\session.md 导出当前会话到 E:\\code\\session.md".to_string(),
+        "    本地动作                    把刚才的审查结果写成 E:\\code\\review.md".to_string(),
+        "  更新与退出".to_string(),
+        "    sego update --check         检查更新".to_string(),
+        "    sego update                 更新到最新版".to_string(),
+        "    /exit                       退出 / 关闭 Sego".to_string(),
+        "  说明".to_string(),
+        "    未列出的普通编码、解释、讨论请求会继续交给模型处理。".to_string(),
+    ]
+    .join("\n")
+}
+
+fn render_nl_intent_miss(miss: &NlIntentMiss) -> String {
+    match miss {
+        NlIntentMiss::NeedsMoreDetail { action, example } => format!(
+            "Sego 没能确定要执行的本地动作。\n  疑似动作        {action}\n  可以这样说      {example}\n  查看更多        /dir"
+        ),
+    }
 }
 
 fn print_status_snapshot(
@@ -4591,7 +4534,7 @@ fn maybe_print_update_notice(enabled: bool) {
     }
 }
 
-fn run_update() -> Result<(), Box<dyn std::error::Error>> {
+fn run_update(check_only: bool) -> Result<(), Box<dyn std::error::Error>> {
     let Some(release) = fetch_latest_release()? else {
         println!("Could not check for updates. Please try again later.");
         return Ok(());
@@ -4602,6 +4545,14 @@ fn run_update() -> Result<(), Box<dyn std::error::Error>> {
 
     if !is_newer_version(&release.tag_name, VERSION) {
         println!("Sego is already up to date.");
+        return Ok(());
+    }
+
+    if check_only {
+        println!(
+            "Update available. Run `sego update` to install or download manually: {}",
+            release.html_url
+        );
         return Ok(());
     }
 
@@ -7954,18 +7905,17 @@ mod tests {
         format_resume_report, format_status_report, format_tool_call_start, format_tool_result,
         format_ultraplan_report, format_unknown_slash_command,
         format_unknown_slash_command_message, is_turn_cancelled_message, normalize_permission_mode,
-        parse_args, parse_export_last_response_intent, parse_git_status_branch,
-        parse_git_status_metadata_for, parse_git_workspace_summary,
-        parse_workspace_natural_language_intent, permission_policy, print_help_to,
-        push_output_block, render_code_review_readiness_for, render_code_review_summary_for,
-        render_config_report, render_diff_report, render_diff_report_for, render_memory_report,
-        render_repl_help, render_resume_usage, resolve_model_alias, resolve_session_reference,
-        response_to_events, resume_supported_slash_commands, run_resume_command,
+        parse_args, parse_git_status_branch, parse_git_status_metadata_for,
+        parse_git_workspace_summary, permission_policy, print_help_to, push_output_block,
+        render_code_review_readiness_for, render_code_review_summary_for, render_config_report,
+        render_diff_report, render_diff_report_for, render_memory_report,
+        render_natural_language_directory, render_repl_help, render_resume_usage,
+        resolve_model_alias, resolve_session_reference, response_to_events,
+        resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
-        write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor,
-        ExportLastResponseIntent, GitWorkspaceSummary, InternalPromptProgressEvent,
-        InternalPromptProgressState, LiveCli, SafetyReviewScope, SlashCommand, StatusUsage,
-        WorkspaceIntent, TURN_CANCELLED_MESSAGE,
+        write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor, GitWorkspaceSummary,
+        InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SafetyReviewScope,
+        SlashCommand, StatusUsage, TURN_CANCELLED_MESSAGE,
     };
     use api::{MessageResponse, OutputContentBlock, Usage};
     use plugins::{
@@ -8311,7 +8261,12 @@ mod tests {
     fn parses_update_command_without_initializing_prompt_mode() {
         assert_eq!(
             parse_args(&["update".to_string()]).expect("update should parse"),
-            CliAction::Update
+            CliAction::Update { check_only: false }
+        );
+        assert_eq!(
+            parse_args(&["update".to_string(), "--check".to_string()])
+                .expect("update should parse"),
+            CliAction::Update { check_only: true }
         );
     }
 
@@ -8323,6 +8278,15 @@ mod tests {
                 CliAction::Workspace { output_format: CliOutputFormat::Text }
             );
         }
+    }
+
+    #[test]
+    fn parses_direct_dir_slash_command_without_prompt_mode() {
+        assert_eq!(parse_args(&["/dir".to_string()]).expect("/dir should parse"), CliAction::Dir);
+        let directory = render_natural_language_directory();
+        assert!(directory.contains("Sego 常用动作目录"));
+        assert!(directory.contains("切换到 D:\\YourProject"));
+        assert!(directory.contains("把刚才的审查结果写成 E:\\code\\review.md"));
     }
 
     #[test]
@@ -8342,36 +8306,6 @@ mod tests {
 
         fs::remove_dir_all(root).expect("temp workspace should clean up");
         assert_eq!(action, CliAction::Workspace { output_format: CliOutputFormat::Text });
-    }
-
-    #[test]
-    fn parses_workspace_natural_language_intents() {
-        assert_eq!(
-            parse_workspace_natural_language_intent("当前工作区"),
-            Some(WorkspaceIntent::Show)
-        );
-        assert_eq!(
-            parse_workspace_natural_language_intent("切换到 D:\\Project"),
-            Some(WorkspaceIntent::Switch("D:\\Project".to_string()))
-        );
-        assert_eq!(
-            parse_workspace_natural_language_intent("打开项目 E:\\中文项目"),
-            Some(WorkspaceIntent::Switch("E:\\中文项目".to_string()))
-        );
-        assert_eq!(parse_workspace_natural_language_intent("帮我 review 当前改动"), None);
-    }
-
-    #[test]
-    fn parses_export_last_response_natural_language_intents() {
-        assert_eq!(
-            parse_export_last_response_intent("把刚才的审查结果写成 E:\\code\\PR43-review.md"),
-            Some(ExportLastResponseIntent { path: Some("E:\\code\\PR43-review.md".to_string()) })
-        );
-        assert_eq!(
-            parse_export_last_response_intent("save the last review report to PR43-review.md"),
-            Some(ExportLastResponseIntent { path: Some("PR43-review.md".to_string()) })
-        );
-        assert_eq!(parse_export_last_response_intent("帮我写一个 markdown parser"), None);
     }
 
     #[test]
@@ -8832,6 +8766,7 @@ mod tests {
         let help = render_repl_help();
         assert!(help.contains("REPL"));
         assert!(help.contains("/help"));
+        assert!(help.contains("/dir"));
         assert!(help.contains("Complete commands, modes, and recent sessions"));
         assert!(help.contains("/status"));
         assert!(help.contains("/sandbox"));

--- a/rust/crates/rusty-claude-cli/src/nl_intent.rs
+++ b/rust/crates/rusty-claude-cli/src/nl_intent.rs
@@ -1,0 +1,649 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NlIntent {
+    WorkspaceShow,
+    WorkspaceSwitch { path: String },
+    Review { scope: Option<String> },
+    ReviewSafety { staged: bool },
+    ExportLastResponse { path: Option<String> },
+    ExportSession { path: Option<String> },
+    UpdateCheck,
+    UpdateApply,
+    Exit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NlIntentMiss {
+    NeedsMoreDetail { action: &'static str, example: &'static str },
+}
+
+pub fn parse_nl_intent(input: &str) -> Option<NlIntent> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.starts_with('/') {
+        return None;
+    }
+    let normalized = strip_polite_prefix(trimmed);
+
+    parse_workspace_intent(normalized)
+        .or_else(|| parse_export_last_response_intent(normalized))
+        .or_else(|| parse_export_session_intent(normalized))
+        .or_else(|| parse_review_intent(normalized))
+        .or_else(|| parse_update_intent(normalized))
+        .or_else(|| parse_exit_intent(normalized))
+}
+
+pub fn classify_nl_intent_miss(input: &str) -> Option<NlIntentMiss> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || trimmed.starts_with('/') || parse_nl_intent(trimmed).is_some() {
+        return None;
+    }
+    let normalized = strip_polite_prefix(trimmed);
+    let lower = normalized.to_ascii_lowercase();
+    if is_generation_request(normalized, &lower)
+        || has_explanation_verb(normalized, &lower)
+        || has_how_to_question(normalized, &lower)
+    {
+        return None;
+    }
+
+    if mentions_workspace_switch_without_path(normalized, &lower) {
+        return Some(NlIntentMiss::NeedsMoreDetail {
+            action: "切换工作区",
+            example: "切换到 D:\\YourProject",
+        });
+    }
+    if mentions_export_without_target(normalized, &lower) {
+        return Some(NlIntentMiss::NeedsMoreDetail {
+            action: "导出/保存",
+            example: "把刚才的审查结果写成 E:\\code\\review.md",
+        });
+    }
+    if mentions_update_without_target(normalized, &lower) {
+        return Some(NlIntentMiss::NeedsMoreDetail {
+            action: "更新",
+            example: "检查更新 / 更新到最新版",
+        });
+    }
+    if mentions_review_without_scope(normalized, &lower) {
+        return Some(NlIntentMiss::NeedsMoreDetail {
+            action: "代码审查",
+            example: "帮我 review 当前改动 / 审查整个项目代码",
+        });
+    }
+
+    None
+}
+
+fn parse_workspace_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if has_explanation_verb(input, &lower) || has_how_to_question(input, &lower) {
+        return None;
+    }
+
+    if matches!(
+        lower.as_str(),
+        "pwd" | "cwd" | "where am i" | "show workspace" | "current workspace" | "current directory"
+    ) || is_workspace_show_phrase(input, &lower)
+    {
+        return Some(NlIntent::WorkspaceShow);
+    }
+
+    for prefix in [
+        "切换到",
+        "切到",
+        "切换工作区到",
+        "切换工作目录到",
+        "打开项目",
+        "进入项目",
+        "进入目录",
+        "把工作目录切到",
+        "change directory to",
+        "switch workspace to",
+        "switch to workspace",
+        "open project",
+        "use workspace",
+    ] {
+        if let Some(path) = strip_intent_prefix(input, prefix) {
+            if looks_like_workspace_path(path) {
+                return Some(NlIntent::WorkspaceSwitch { path: path.to_string() });
+            }
+        }
+    }
+
+    if let Some(path) = strip_intent_prefix(input, "cd ") {
+        if looks_like_workspace_path(path) {
+            return Some(NlIntent::WorkspaceSwitch { path: path.to_string() });
+        }
+    }
+
+    None
+}
+
+fn parse_export_last_response_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if is_generation_request(input, &lower)
+        || has_explanation_verb(input, &lower)
+        || has_how_to_question(input, &lower)
+    {
+        return None;
+    }
+
+    let has_export_verb = lower.contains("export")
+        || lower.contains("save")
+        || lower.contains("write")
+        || input.contains("导出")
+        || input.contains("保存")
+        || input.contains("写入")
+        || input.contains("写成")
+        || input.contains("落盘");
+    if !has_export_verb {
+        return None;
+    }
+
+    let targets_last_response = lower.contains("last")
+        || lower.contains("previous")
+        || lower.contains("review")
+        || lower.contains("report")
+        || input.contains("刚才")
+        || input.contains("上一条")
+        || input.contains("上一次")
+        || input.contains("审查")
+        || input.contains("审核")
+        || input.contains("报告")
+        || input.contains("结果");
+    if !targets_last_response {
+        return None;
+    }
+
+    let path = extract_export_path(input);
+    if path.is_none()
+        && !(lower.contains(".md") || lower.contains("markdown") || input.contains("md"))
+    {
+        return None;
+    }
+
+    Some(NlIntent::ExportLastResponse { path })
+}
+
+fn parse_export_session_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if is_generation_request(input, &lower)
+        || has_explanation_verb(input, &lower)
+        || has_how_to_question(input, &lower)
+    {
+        return None;
+    }
+
+    let has_export_verb = lower.contains("export")
+        || lower.contains("save")
+        || input.contains("导出")
+        || input.contains("保存")
+        || input.contains("备份");
+    let targets_session = lower.contains("session")
+        || lower.contains("conversation")
+        || lower.contains("transcript")
+        || input.contains("会话")
+        || input.contains("对话")
+        || input.contains("聊天记录");
+    if has_export_verb && targets_session {
+        return Some(NlIntent::ExportSession { path: extract_export_path(input) });
+    }
+
+    None
+}
+
+fn parse_review_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if is_generation_request(input, &lower)
+        || has_explanation_verb(input, &lower)
+        || has_how_to_question(input, &lower)
+    {
+        return None;
+    }
+
+    let has_review_verb = lower.contains("review")
+        || lower.contains("audit")
+        || lower.contains("check")
+        || input.contains("审查")
+        || input.contains("审核")
+        || input.contains("检查");
+    if !has_review_verb {
+        return None;
+    }
+
+    let mentions_code_or_changes = lower.contains("code")
+        || lower.contains("diff")
+        || lower.contains("changes")
+        || lower.contains("project")
+        || lower.contains("workspace")
+        || input.contains("代码")
+        || input.contains("改动")
+        || input.contains("修改")
+        || input.contains("项目")
+        || input.contains("工作区");
+    let mentions_safety = lower.contains("safety")
+        || lower.contains("security")
+        || lower.contains("vulnerability")
+        || input.contains("安全")
+        || input.contains("漏洞")
+        || input.contains("风险")
+        || input.contains("新手安全");
+
+    if mentions_safety {
+        return Some(NlIntent::ReviewSafety {
+            staged: lower.contains("staged") || input.contains("暂存") || input.contains("已暂存"),
+        });
+    }
+
+    if !mentions_code_or_changes {
+        return None;
+    }
+
+    Some(NlIntent::Review { scope: review_scope_hint(input, &lower) })
+}
+
+fn parse_update_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if is_generation_request(input, &lower)
+        || has_explanation_verb(input, &lower)
+        || has_how_to_question(input, &lower)
+    {
+        return None;
+    }
+
+    let mentions_sego = lower.contains("sego") || input.contains("色狗") || input.contains("色鬼");
+    let check_update = (mentions_sego
+        && (lower.contains("check update")
+            || lower.contains("check for updates")
+            || lower.contains("latest version")))
+        || matches!(lower.as_str(), "check sego update" | "check sego updates")
+        || input.contains("检查更新")
+        || input.contains("有没有新版")
+        || (mentions_sego && input.contains("最新版本"));
+    if check_update {
+        return Some(NlIntent::UpdateCheck);
+    }
+
+    let apply_update = lower == "update"
+        || lower == "upgrade"
+        || (mentions_sego && (lower.contains("update") || lower.contains("upgrade")))
+        || input.contains("更新到最新版")
+        || input.contains("升级到最新版")
+        || input.contains("帮我升级")
+        || input.contains("更新 Sego")
+        || input.contains("升级 Sego")
+        || input.contains("更新sego")
+        || input.contains("升级sego");
+    if apply_update {
+        return Some(NlIntent::UpdateApply);
+    }
+
+    None
+}
+
+fn parse_exit_intent(input: &str) -> Option<NlIntent> {
+    let lower = input.to_ascii_lowercase();
+    if is_generation_request(input, &lower)
+        || has_explanation_verb(input, &lower)
+        || has_how_to_question(input, &lower)
+    {
+        return None;
+    }
+
+    if matches!(lower.as_str(), "exit" | "quit" | "bye" | "close sego")
+        || matches!(input, "退出" | "退出 Sego" | "退出sego" | "关闭 Sego" | "关闭sego")
+        || input == "结束会话"
+    {
+        return Some(NlIntent::Exit);
+    }
+
+    None
+}
+
+fn review_scope_hint(input: &str, lower: &str) -> Option<String> {
+    if lower.contains("staged") || input.contains("暂存") || input.contains("已暂存") {
+        return Some("staged".to_string());
+    }
+    if lower.contains("unstaged") || lower.contains("working tree") || input.contains("未暂存") {
+        return Some("unstaged".to_string());
+    }
+    if lower.contains("workspace")
+        || lower.contains("project")
+        || lower.contains("all")
+        || input.contains("整个项目")
+        || input.contains("全项目")
+        || input.contains("工作区")
+    {
+        return Some("workspace".to_string());
+    }
+    None
+}
+
+fn strip_polite_prefix(input: &str) -> &str {
+    let mut current = input.trim();
+    for prefix in ["请帮我", "麻烦你", "麻烦", "帮我", "请", "please "] {
+        if let Some(rest) = strip_intent_prefix(current, prefix) {
+            current = rest.trim();
+            break;
+        }
+    }
+    current
+}
+
+fn is_workspace_show_phrase(input: &str, lower: &str) -> bool {
+    matches!(
+        input,
+        "当前目录"
+            | "当前工作目录"
+            | "工作目录"
+            | "当前工作区"
+            | "现在在哪个目录"
+            | "现在工作目录"
+            | "现在工作区"
+            | "看当前工作区"
+            | "看工作区"
+            | "显示当前工作区"
+            | "查看当前工作区"
+            | "显示工作目录"
+            | "查看工作目录"
+    ) || matches!(lower, "show cwd" | "show current directory" | "show current workspace")
+}
+
+fn is_generation_request(input: &str, lower: &str) -> bool {
+    lower.starts_with("write ")
+        || lower.starts_with("create ")
+        || lower.starts_with("implement ")
+        || lower.starts_with("generate ")
+        || input.starts_with("写一个")
+        || input.starts_with("写个")
+        || input.starts_with("实现")
+        || input.starts_with("生成一个")
+        || input.starts_with("生成一份")
+        || input.starts_with("开发一个")
+        || input.starts_with("做一个")
+}
+
+fn has_explanation_verb(input: &str, lower: &str) -> bool {
+    lower.contains("explain")
+        || lower.contains("what is")
+        || lower.contains("how does")
+        || input.contains("解释")
+        || input.contains("说明")
+        || input.contains("什么是")
+        || input.contains("是什么意思")
+        || input.contains("什么意思")
+}
+
+fn has_how_to_question(input: &str, lower: &str) -> bool {
+    lower.contains("how to")
+        || lower.contains("how do i")
+        || input.contains("如何")
+        || input.contains("怎么")
+        || input.contains("怎样")
+}
+
+fn mentions_workspace_switch_without_path(input: &str, lower: &str) -> bool {
+    matches!(lower, "cd" | "switch workspace" | "change directory")
+        || matches!(input, "切换目录" | "切换工作区" | "切换工作目录" | "打开项目" | "进入目录")
+}
+
+fn mentions_export_without_target(input: &str, lower: &str) -> bool {
+    matches!(lower, "export" | "save report" | "save review" | "export report")
+        || matches!(input, "导出" | "保存报告" | "导出报告" | "保存审查结果" | "导出审查结果")
+}
+
+fn mentions_update_without_target(input: &str, lower: &str) -> bool {
+    matches!(lower, "update it" | "upgrade it")
+        || matches!(input, "更新一下" | "升级一下" | "帮我更新" | "帮我升级")
+}
+
+fn mentions_review_without_scope(input: &str, lower: &str) -> bool {
+    matches!(lower, "review" | "code review" | "audit" | "check code")
+        || matches!(input, "审查" | "审核" | "检查代码" | "代码审查")
+}
+
+fn extract_export_path(input: &str) -> Option<String> {
+    for quoted in extract_quoted_segments(input) {
+        if looks_like_export_path(&quoted) {
+            return Some(quoted);
+        }
+    }
+
+    input
+        .split_whitespace()
+        .rev()
+        .map(|part| {
+            part.trim_matches(|ch: char| {
+                matches!(ch, '"' | '\'' | '`' | '。' | '，' | ',' | ';' | '；' | ':' | '：')
+            })
+        })
+        .find(|part| looks_like_export_path(part))
+        .map(ToOwned::to_owned)
+}
+
+fn extract_quoted_segments(input: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    for ch in input.chars() {
+        match quote {
+            Some(end) if ch == end => {
+                let value = current.trim();
+                if !value.is_empty() {
+                    segments.push(value.to_string());
+                }
+                current.clear();
+                quote = None;
+            }
+            Some(_) => current.push(ch),
+            None if matches!(ch, '"' | '\'' | '`' | '“' | '‘') => {
+                quote = Some(match ch {
+                    '“' => '”',
+                    '‘' => '’',
+                    other => other,
+                });
+            }
+            None => {}
+        }
+    }
+    segments
+}
+
+fn looks_like_export_path(value: &str) -> bool {
+    let path = Path::new(value);
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+        || value.contains('\\')
+        || value.contains('/')
+}
+
+fn looks_like_workspace_path(value: &str) -> bool {
+    let trimmed = value.trim().trim_matches('"');
+    if trimmed.is_empty()
+        || has_sentence_punctuation(trimmed)
+        || trimmed.contains("是什么")
+        || trimmed.contains("什么意思")
+        || trimmed.contains("如何")
+        || trimmed.contains("怎么")
+    {
+        return false;
+    }
+    trimmed == "."
+        || trimmed.starts_with("..")
+        || trimmed.contains('\\')
+        || trimmed.contains('/')
+        || trimmed.chars().nth(1) == Some(':')
+        || looks_like_simple_relative_path(trimmed)
+}
+
+fn has_sentence_punctuation(value: &str) -> bool {
+    value.chars().any(|ch| matches!(ch, '?' | '？' | '。' | '！' | '!'))
+}
+
+fn looks_like_simple_relative_path(value: &str) -> bool {
+    !value.chars().any(char::is_whitespace)
+        && value.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+        && value.chars().any(|ch| ch.is_ascii_alphanumeric())
+}
+
+fn strip_intent_prefix<'a>(input: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_ascii() {
+        let lower = input.to_ascii_lowercase();
+        let lower_prefix = prefix.to_ascii_lowercase();
+        if lower.starts_with(&lower_prefix) {
+            let value = input[prefix.len()..].trim().trim_matches('"');
+            return (!value.is_empty()).then_some(value);
+        }
+        return None;
+    }
+    input
+        .strip_prefix(prefix)
+        .map(|path| path.trim().trim_matches('"'))
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_nl_intent_miss, parse_nl_intent, NlIntent, NlIntentMiss};
+
+    #[test]
+    fn parses_workspace_show_intents() {
+        assert_eq!(parse_nl_intent("当前工作区"), Some(NlIntent::WorkspaceShow));
+        assert_eq!(parse_nl_intent("请帮我看当前工作区"), Some(NlIntent::WorkspaceShow));
+        assert_eq!(parse_nl_intent("where am i"), Some(NlIntent::WorkspaceShow));
+    }
+
+    #[test]
+    fn parses_workspace_switch_intents_with_windows_paths() {
+        assert_eq!(
+            parse_nl_intent("切换到 D:\\Project"),
+            Some(NlIntent::WorkspaceSwitch { path: "D:\\Project".to_string() })
+        );
+        assert_eq!(
+            parse_nl_intent("打开项目 \"E:\\中文 项目\""),
+            Some(NlIntent::WorkspaceSwitch { path: "E:\\中文 项目".to_string() })
+        );
+        assert_eq!(
+            parse_nl_intent("cd ../demo"),
+            Some(NlIntent::WorkspaceSwitch { path: "../demo".to_string() })
+        );
+        assert_eq!(
+            parse_nl_intent("切到 sego-demo"),
+            Some(NlIntent::WorkspaceSwitch { path: "sego-demo".to_string() })
+        );
+    }
+
+    #[test]
+    fn keeps_ambiguous_cd_text_for_the_model() {
+        assert_eq!(parse_nl_intent("cd command 是什么意思"), None);
+        assert_eq!(parse_nl_intent("cd should be documented in README"), None);
+        assert_eq!(parse_nl_intent("切换到哪个目录更合理？"), None);
+        assert_eq!(parse_nl_intent("工作目录是什么意思"), None);
+    }
+
+    #[test]
+    fn parses_export_last_response_intents() {
+        assert_eq!(
+            parse_nl_intent("把刚才的审查结果写成 E:\\code\\PR43-review.md"),
+            Some(NlIntent::ExportLastResponse {
+                path: Some("E:\\code\\PR43-review.md".to_string())
+            })
+        );
+        assert_eq!(
+            parse_nl_intent("save the last review report to PR43-review.md"),
+            Some(NlIntent::ExportLastResponse { path: Some("PR43-review.md".to_string()) })
+        );
+        assert_eq!(
+            parse_nl_intent("保存刚才的结果到 \"E:\\code\\PR43 review.md\""),
+            Some(NlIntent::ExportLastResponse {
+                path: Some("E:\\code\\PR43 review.md".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn parses_export_session_intents() {
+        assert_eq!(
+            parse_nl_intent("导出当前会话到 E:\\code\\session.md"),
+            Some(NlIntent::ExportSession { path: Some("E:\\code\\session.md".to_string()) })
+        );
+        assert_eq!(
+            parse_nl_intent("save this conversation"),
+            Some(NlIntent::ExportSession { path: None })
+        );
+    }
+
+    #[test]
+    fn parses_review_intents() {
+        assert_eq!(parse_nl_intent("帮我 review 当前改动"), Some(NlIntent::Review { scope: None }));
+        assert_eq!(parse_nl_intent("请审查当前修改"), Some(NlIntent::Review { scope: None }));
+        assert_eq!(
+            parse_nl_intent("审查整个项目代码"),
+            Some(NlIntent::Review { scope: Some("workspace".to_string()) })
+        );
+        assert_eq!(
+            parse_nl_intent("review staged changes"),
+            Some(NlIntent::Review { scope: Some("staged".to_string()) })
+        );
+    }
+
+    #[test]
+    fn parses_safety_review_intents() {
+        assert_eq!(parse_nl_intent("检查安全问题"), Some(NlIntent::ReviewSafety { staged: false }));
+        assert_eq!(
+            parse_nl_intent("检查刚实现的代码安全问题"),
+            Some(NlIntent::ReviewSafety { staged: false })
+        );
+        assert_eq!(
+            parse_nl_intent("检查已暂存代码的安全风险"),
+            Some(NlIntent::ReviewSafety { staged: true })
+        );
+    }
+
+    #[test]
+    fn parses_update_and_exit_intents() {
+        assert_eq!(parse_nl_intent("检查更新"), Some(NlIntent::UpdateCheck));
+        assert_eq!(parse_nl_intent("check Sego updates"), Some(NlIntent::UpdateCheck));
+        assert_eq!(parse_nl_intent("更新到最新版"), Some(NlIntent::UpdateApply));
+        assert_eq!(parse_nl_intent("退出"), Some(NlIntent::Exit));
+    }
+
+    #[test]
+    fn does_not_intercept_generation_or_explanation_requests() {
+        assert_eq!(parse_nl_intent("帮我写一个 markdown parser"), None);
+        assert_eq!(parse_nl_intent("解释一下 update 函数"), None);
+        assert_eq!(parse_nl_intent("实现 review 页面"), None);
+        assert_eq!(parse_nl_intent("create a code review checklist"), None);
+        assert_eq!(parse_nl_intent("怎么更新 Sego"), None);
+        assert_eq!(parse_nl_intent("check for updates in this changelog"), None);
+        assert_eq!(parse_nl_intent("写一份 review 报告模板"), None);
+    }
+
+    #[test]
+    fn ignores_slash_commands() {
+        assert_eq!(parse_nl_intent("/review staged"), None);
+        assert_eq!(parse_nl_intent("/cd D:\\Project"), None);
+    }
+
+    #[test]
+    fn classifies_only_high_confidence_local_action_misses() {
+        assert_eq!(
+            classify_nl_intent_miss("保存报告"),
+            Some(NlIntentMiss::NeedsMoreDetail {
+                action: "导出/保存",
+                example: "把刚才的审查结果写成 E:\\code\\review.md"
+            })
+        );
+        assert_eq!(
+            classify_nl_intent_miss("切换目录"),
+            Some(NlIntentMiss::NeedsMoreDetail {
+                action: "切换工作区",
+                example: "切换到 D:\\YourProject"
+            })
+        );
+        assert_eq!(classify_nl_intent_miss("帮我写一个 review 报告模板"), None);
+        assert_eq!(classify_nl_intent_miss("怎么保存报告"), None);
+        assert_eq!(classify_nl_intent_miss("帮我 review 当前改动"), None);
+    }
+}


### PR DESCRIPTION
## Summary / 摘要

中文：
- 新增确定性自然语言 intent router：在模型调用前本地处理工作区、review、安全检查、导出、更新、退出等高频控制动作。
- 新增 `/dir` 常用动作目录，展示 slash command 与自然语言说法，帮助普通用户不用记复杂命令。
- 对“像本地控制动作但缺少路径/对象”的输入输出短提示并指向 `/dir`，普通编码/解释/讨论请求继续交给模型。
- 修复自然语言切换工作区后 REPL 被误退出的问题。
- 将 `sego update --check` 与 `sego update` 拆分，检查更新不触发安装。

English:
- Add a deterministic natural-language intent router for high-frequency local control actions before model calls.
- Add `/dir` as a discoverable directory of common slash commands and natural-language examples.
- Print a short `/dir` hint only for local-control-like requests missing a path/scope/target; normal coding/explanation prompts still go to the model.
- Fix NL workspace switching so it does not exit the REPL.
- Split `sego update --check` from `sego update`; check-only does not install.

## Tests / 验证

```powershell
cargo fmt --all --check
cargo test -p commands
cargo test -p rusty-claude-cli --bin sego nl_intent
cargo test -p rusty-claude-cli --bin sego
cargo build -p rusty-claude-cli
git diff --check
E:\Sego\source\rust\target\debug\sego.exe /dir
E:\Sego\source\rust\target\debug\sego.exe update --check
cargo clippy -p commands
cargo clippy -p rusty-claude-cli --bin sego
```

Clippy exits successfully; existing repository warnings remain outside this slice.

## Review Handoff / 审查交接

Sego review handoff: `E:\code\sego-cycle14-review-handoff-to-sego-2026-06-19.md`