### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,8 @@ All notable changes to the Sego Agent project will be documented in this file.
 - ROADMAP.md with active development roadmap
 - CONTRIBUTING.md with guidelines for contributors
 - Parity tracking documentation
+
+## [0.1.6] - 2026-06-19
+- Added deterministic natural-language local action routing and /dir action directory.
+- Changed bare sego review to run code review by default and persist .sego/reviews artifacts.
+- Added explicit workflow/session review entrypoints: sego workflow-review / sego session-review.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "api",
  "commands",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
﻿## Summary / 摘要

中文：
- 将 Rust workspace 版本从 `0.1.5` 提升到 `0.1.6`。
- 同步更新 `Cargo.lock` 中的 workspace crate 版本。
- 在 `CHANGELOG.md` 追加 `v0.1.6` 条目，记录 Cycle 14 已合并能力：自然语言本地动作路由、`/dir` 常用动作目录、裸 `sego review` 默认执行代码审查并持久化报告、显式 `workflow-review/session-review` 入口。

English:
- Bump the Rust workspace version from `0.1.5` to `0.1.6`.
- Sync workspace crate versions in `Cargo.lock`.
- Add a `v0.1.6` changelog entry for the merged Cycle 14 capabilities: deterministic natural-language local actions, `/dir` action directory, bare `sego review` running code review with persisted artifacts, and explicit `workflow-review/session-review` entrypoints.

## Tests / 验证

```powershell
cargo fmt --all --check
cargo test -p rusty-claude-cli --bin sego
cargo build -p rusty-claude-cli --release
.\target\release\sego.exe --version
.\target\release\sego.exe --help | Select-String -Pattern "workflow-review|sego review|/dir"
.\target\release\sego.exe review list
git diff --check
```

## Release note / 发布说明

中文：合并后可基于 merge commit 打 `v0.1.6` tag，触发 `.github/workflows/release.yml` 生成 `sego.exe`、`sego-windows.zip`、`sego`、`sego-macos`。

English: After merge, create the `v0.1.6` tag on the merge commit to trigger `.github/workflows/release.yml` and publish `sego.exe`, `sego-windows.zip`, `sego`, and `sego-macos`.
