### PR TITLE
fix: harden runtime review reliability

### DIFF
--- a/rust/crates/runtime/src/bash_command_classifier.rs
+++ b/rust/crates/runtime/src/bash_command_classifier.rs
@@ -28,6 +28,10 @@ pub enum BashCommandRisk {
     /// Destructive or irreversible commands: `rm -rf`, `git reset --hard`, `git push`, `sudo`.
     /// Denied outright under `review-trust`.
     DenyDangerous,
+    /// Interactive commands that wait for user input and will hang non-interactive sessions.
+    /// `copy con`, `less`, `vim`, `nano`, bare `python`/`powershell`/`cmd`.
+    /// Denied outright.
+    DenyInteractive,
     /// Anything the classifier cannot confidently categorise.
     /// Requires confirmation (fail-safe).
     UnknownAsk,
@@ -69,6 +73,11 @@ pub fn classify_bash_command(command: &str) -> BashCommandRisk {
     // Destructive commands are denied first, even if they start with a safe verb.
     if is_dangerous(trimmed) {
         return BashCommandRisk::DenyDangerous;
+    }
+
+    // Interactive commands that hang non-interactive sessions are denied.
+    if is_interactive_command(trimmed) {
+        return BashCommandRisk::DenyInteractive;
     }
 
     // Read-only inspection commands.
@@ -183,6 +192,67 @@ fn is_dangerous(command: &str) -> bool {
     // Format / mkfs
     if lower.starts_with("format ") || lower.starts_with("mkfs") {
         return true;
+    }
+    false
+}
+
+/// Shared interactive-command detector used by [`classify_bash_command`] and the
+/// tools-layer [`interactive_command_guard`].  Returns `true` when a command is
+/// likely to block waiting for user input (REPL, editor, pager, `copy con`).
+pub fn is_interactive_command(command: &str) -> bool {
+    let lower = command.to_ascii_lowercase();
+    let tokens: Vec<&str> = lower.split_whitespace().collect();
+    let first = tokens.first().copied().unwrap_or("");
+    let second = tokens.get(1).copied().unwrap_or("");
+
+    // `copy con` -- token-level: first two tokens, or after `cmd /c` / `cmd /r`
+    // `echo copy con something` must NOT match.
+    if first == "copy" && second == "con" {
+        return true;
+    }
+    // `cmd /c copy con file.txt`: /c or /r then copy con
+    if first == "cmd" {
+        if let Some(pos) = tokens.iter().position(|t| *t == "/c" || *t == "/r") {
+            if tokens.len() > pos + 2 && tokens[pos + 1] == "copy" && tokens[pos + 2] == "con" {
+                return true;
+            }
+        }
+    }
+    // Interactive pagers/readers
+    if first == "less" || first == "more" {
+        return true;
+    }
+    // Editors
+    if matches!(first, "vim" | "vi" | "nano" | "emacs" | "nvim") {
+        return true;
+    }
+    // Bare python REPL -- only allowed when a -c/-m flag, .py file, heredoc, or pipe is present.
+    // Token-prefix matching accepts `-c"..."`, `-c'...'`, `-c=...`.
+    if first == "python" || first == "python3" {
+        let has_script = tokens.iter().any(|t| t.starts_with("-c") || t.starts_with("-m"))
+            || lower.contains(".py")
+            || lower.contains("<<")
+            || lower.contains('|');
+        if !has_script {
+            return true;
+        }
+    }
+    // Bare powershell -- only allowed when a non-interactive flag is present.
+    // Token-exact matching prevents substring false-positives.
+    if first == "powershell" || first == "pwsh" {
+        let has_flag =
+            tokens.iter().any(|t| matches!(*t, "-command" | "-c" | "-file" | "-encodedcommand"))
+                || lower.contains('|');
+        if !has_flag {
+            return true;
+        }
+    }
+    // Bare cmd -- only allowed when /c or /r is present.  /k is interactive.
+    if first == "cmd" {
+        let has_flag = tokens.iter().any(|t| matches!(*t, "/c" | "/r"));
+        if !has_flag {
+            return true;
+        }
     }
     false
 }
@@ -417,7 +487,65 @@ mod tests {
         assert!(BashCommandRisk::SegaMetadataWrite.is_auto_allow());
         assert!(!BashCommandRisk::AskMutation.is_auto_allow());
         assert!(!BashCommandRisk::DenyDangerous.is_auto_allow());
+        assert!(!BashCommandRisk::DenyInteractive.is_auto_allow());
         assert!(!BashCommandRisk::UnknownAsk.is_auto_allow());
+    }
+
+    #[test]
+    fn interactive_commands_are_denied() {
+        // copy con -- token-level (first two tokens = "copy" "con")
+        assert_eq!(classify_bash_command("copy con"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("copy con file.txt"), BashCommandRisk::DenyInteractive);
+        assert_eq!(
+            classify_bash_command("cmd /c copy con file.txt"),
+            BashCommandRisk::DenyInteractive
+        );
+        // echo copy con NOT interactive (substring false-positive)
+        assert_ne!(
+            classify_bash_command("echo copy con something"),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_eq!(
+            classify_bash_command("cmd /c copy con file.txt"),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_eq!(classify_bash_command("less"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("less file.txt"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("more"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("more file.txt"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("vim file.txt"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("nano file.txt"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("python"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("powershell"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("powershell -NoExit"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("cmd"), BashCommandRisk::DenyInteractive);
+        assert_eq!(classify_bash_command("cmd /k echo hello"), BashCommandRisk::DenyInteractive);
+        // Safe non-interactive variants (using raw string literals)
+        assert_ne!(
+            classify_bash_command(r###"powershell -Command "Get-Date""###),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_ne!(
+            classify_bash_command(r###"cmd /c "echo hello""###),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_ne!(
+            classify_bash_command(r###"python -c "print(1)""###),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_ne!(
+            classify_bash_command(r#"python -c"print(1)""#),
+            BashCommandRisk::DenyInteractive
+        );
+        assert_ne!(classify_bash_command("python -c'print(1)'"), BashCommandRisk::DenyInteractive);
+        assert_ne!(classify_bash_command("python -c=print(1)"), BashCommandRisk::DenyInteractive);
+        assert_ne!(
+            classify_bash_command("powershell -EncodedCommand abc"),
+            BashCommandRisk::DenyInteractive
+        );
+        // Normal read-only commands are unaffected
+        assert_eq!(classify_bash_command("git status"), BashCommandRisk::SafeReadonly);
+        assert_eq!(classify_bash_command("dir"), BashCommandRisk::SafeReadonly);
     }
 
     #[test]

--- a/rust/crates/runtime/src/permissions.rs
+++ b/rust/crates/runtime/src/permissions.rs
@@ -204,6 +204,11 @@ impl PermissionPolicy {
                         reason: format!("review-trust denied bash command as dangerous: {input}"),
                     };
                 }
+                crate::bash_command_classifier::BashCommandRisk::DenyInteractive => {
+                    return PermissionOutcome::Deny {
+                        reason: format!("review-trust denied interactive command: {input}"),
+                    };
+                }
                 crate::bash_command_classifier::BashCommandRisk::AskMutation
                 | crate::bash_command_classifier::BashCommandRisk::UnknownAsk => {
                     return Self::prompt_or_deny(

--- a/rust/crates/runtime/src/prompt.rs
+++ b/rust/crates/runtime/src/prompt.rs
@@ -471,7 +471,7 @@ fn get_simple_doing_tasks_section() -> String {
         "If an approach fails, diagnose the failure before switching tactics.".to_string(),
         "Be careful not to introduce security vulnerabilities such as command injection, XSS, or SQL injection.".to_string(),
         "Report outcomes faithfully: if verification fails or was not run, say so explicitly.".to_string(),
-        "When generating shell commands, match syntax to the actual target shell. On Windows, do not mix CMD-only syntax such as `cd /d` or `^` escaping with Bash/Git Bash commands, and do not mix Bash-only here-doc or POSIX path syntax with CMD/PowerShell.".to_string(),
+        "When generating shell commands, match syntax to the actual target shell. On Windows, do not mix CMD-only syntax such as `cd /d` or `^` escaping with Bash/Git Bash commands, and do not mix Bash-only here-doc or POSIX path syntax with CMD/PowerShell. Windows file viewing: use `type`, not `cat`. Windows directory listing: use `dir`, not `ls`. Windows command lookup: use `where`, not `which`. PowerShell cmdlets must be invoked via `powershell -Command \"...\"`; do not run bare `Get-Content` or other cmdlets outside PowerShell.".to_string(),
         "Avoid writing source files line-by-line with long `echo >>` command chains. Prefer the available file editing tools; if shell writing is unavoidable, use a shell-appropriate bulk write pattern and verify the file exists before claiming it was created.".to_string(),
         "Do not claim generated files, tests, lint checks, syntax checks, dry-runs, or runtime outputs exist or passed unless you observed that evidence in tool output.".to_string(),
     ]);

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -257,6 +257,28 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
         CliAction::Sandbox { output_format } => print_sandbox_status_snapshot(output_format)?,
         CliAction::Prompt { prompt, model, output_format, allowed_tools, permission_mode } => {
+            // Route high-confidence NL review intents to deterministic code review
+            // before falling through to the model conversation path. (Cycle 15 P0-B)
+            if let Some(intent) = parse_nl_intent(&prompt) {
+                match intent {
+                    NlIntent::Review { scope } => {
+                        run_code_review_cli(
+                            model,
+                            allowed_tools,
+                            permission_mode,
+                            scope.as_deref(),
+                        )?;
+                        return Ok(());
+                    }
+                    NlIntent::ReviewSafety { staged } => {
+                        let scope = if staged { Some("staged") } else { Some("workspace") };
+                        run_code_review_cli(model, allowed_tools, permission_mode, scope)?;
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+
             // A2 session 状态写入：active 在 LiveCli 创建后写，graceful 在成功返回后写。
             // 错误路径（?返回 / 崩溃）不写 graceful，保留 active，下次启动提示可恢复。
             let mut cli = LiveCli::new(model.clone(), true, allowed_tools, permission_mode)?;
@@ -3661,8 +3683,13 @@ impl LiveCli {
     }
 
     fn run_review(&mut self, scope: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+        let cwd = env::current_dir()?;
+        if !is_git_worktree(&cwd) {
+            eprintln!("{}", non_git_review_error(&cwd));
+            return Ok(());
+        }
         let review_scope = ReviewScope::parse(scope)?;
-        let target = collect_review_target(&env::current_dir()?, review_scope)?;
+        let target = collect_review_target(&cwd, review_scope)?;
         if target.is_empty() {
             print_clean_review_scope(&target);
             return Ok(());
@@ -3685,6 +3712,11 @@ impl LiveCli {
         &mut self,
         target: ReviewTarget,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let cwd = env::current_dir()?;
+        if !is_git_worktree(&cwd) {
+            eprintln!("{}", non_git_review_error(&cwd));
+            return Ok(()); // REPL: print friendly message and continue, do not exit process
+        }
         let context = ReviewContext::new(target);
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
         let review_text = self.run_turn_capture_text(&prompt)?;
@@ -4982,8 +5014,13 @@ fn run_code_review_cli(
     permission_mode: PermissionMode,
     scope: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let cwd = env::current_dir()?;
+    if !is_git_worktree(&cwd) {
+        eprintln!("{}", non_git_review_error(&cwd));
+        std::process::exit(1);
+    }
     let review_scope = ReviewScope::parse(scope)?;
-    let target = collect_review_target(&env::current_dir()?, review_scope)?;
+    let target = collect_review_target(&cwd, review_scope)?;
     if target.is_empty() {
         print_clean_review_scope(&target);
         return Ok(());
@@ -5903,6 +5940,26 @@ fn run_git_diff_command_in(
         return Err(format!("git {} failed: {stderr}", args.join(" ")).into());
     }
     Ok(String::from_utf8(output.stdout)?)
+}
+
+fn is_git_worktree(cwd: &Path) -> bool {
+    std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn non_git_review_error(cwd: &Path) -> String {
+    format!(
+        "Sego review needs a Git project.\n\
+         Current directory: {}\n\
+         Try:\n  sego --cwd \"D:\\YourProject\" review\n  /cd \"D:\\YourProject\"\n  cd D:\\YourProject; sego review",
+        cwd.display()
+    )
 }
 
 fn render_teleport_report(target: &str) -> Result<String, Box<dyn std::error::Error>> {
@@ -7966,14 +8023,14 @@ mod tests {
         format_permissions_report, format_permissions_switch_report, format_pr_report,
         format_resume_report, format_status_report, format_tool_call_start, format_tool_result,
         format_ultraplan_report, format_unknown_slash_command,
-        format_unknown_slash_command_message, is_turn_cancelled_message, normalize_permission_mode,
-        parse_args, parse_git_status_branch, parse_git_status_metadata_for,
-        parse_git_workspace_summary, permission_policy, print_help_to, push_output_block,
-        render_code_review_readiness_for, render_code_review_summary_for, render_config_report,
-        render_diff_report, render_diff_report_for, render_memory_report,
-        render_natural_language_directory, render_repl_help, render_resume_usage,
-        resolve_model_alias, resolve_session_reference, response_to_events,
-        resume_supported_slash_commands, run_resume_command,
+        format_unknown_slash_command_message, is_git_worktree, is_turn_cancelled_message,
+        non_git_review_error, normalize_permission_mode, parse_args, parse_git_status_branch,
+        parse_git_status_metadata_for, parse_git_workspace_summary, permission_policy,
+        print_help_to, push_output_block, render_code_review_readiness_for,
+        render_code_review_summary_for, render_config_report, render_diff_report,
+        render_diff_report_for, render_memory_report, render_natural_language_directory,
+        render_repl_help, render_resume_usage, resolve_model_alias, resolve_session_reference,
+        response_to_events, resume_supported_slash_commands, run_resume_command,
         slash_command_completion_candidates_with_sessions, status_context, validate_no_args,
         write_mcp_server_fixture, CliAction, CliOutputFormat, CliToolExecutor, GitWorkspaceSummary,
         InternalPromptProgressEvent, InternalPromptProgressState, LiveCli, SafetyReviewScope,
@@ -9306,6 +9363,21 @@ UU conflicted.rs",
         assert!(report.contains("Staged files     0"));
         assert!(report.contains("stage changes before running /review ready"));
 
+        fs::remove_dir_all(root).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn non_git_directory_review_shows_friendly_error() {
+        let _guard = env_lock();
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("root dir");
+        assert!(!is_git_worktree(&root));
+        let error = non_git_review_error(&root);
+        assert!(error.contains("needs a Git project"));
+        assert!(error.contains("sego --cwd"));
+        assert!(!error.contains("fatal:"));
+        git(&["init", "--quiet"], &root);
+        assert!(is_git_worktree(&root));
         fs::remove_dir_all(root).expect("cleanup temp dir");
     }
 

--- a/rust/crates/rusty-claude-cli/src/nl_intent.rs
+++ b/rust/crates/rusty-claude-cli/src/nl_intent.rs
@@ -577,13 +577,20 @@ mod tests {
     #[test]
     fn parses_review_intents() {
         assert_eq!(parse_nl_intent("帮我 review 当前改动"), Some(NlIntent::Review { scope: None }));
+        assert_eq!(parse_nl_intent("帮我review当前改动"), Some(NlIntent::Review { scope: None }));
         assert_eq!(parse_nl_intent("请审查当前修改"), Some(NlIntent::Review { scope: None }));
+        assert_eq!(parse_nl_intent("检查当前改动"), Some(NlIntent::Review { scope: None }));
+        assert_eq!(parse_nl_intent("审查当前改动"), Some(NlIntent::Review { scope: None }));
         assert_eq!(
             parse_nl_intent("审查整个项目代码"),
             Some(NlIntent::Review { scope: Some("workspace".to_string()) })
         );
         assert_eq!(
             parse_nl_intent("review staged changes"),
+            Some(NlIntent::Review { scope: Some("staged".to_string()) })
+        );
+        assert_eq!(
+            parse_nl_intent("检查已暂存代码"),
             Some(NlIntent::Review { scope: Some("staged".to_string()) })
         );
     }

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -1727,6 +1727,9 @@ fn from_value<T: for<'de> Deserialize<'de>>(input: &Value) -> Result<T, String> 
 }
 
 fn run_bash(input: BashCommandInput) -> Result<String, String> {
+    if let Some(output) = interactive_command_guard(&input.command) {
+        return serde_json::to_string_pretty(&output).map_err(|error| error.to_string());
+    }
     if let Some(output) = bash_file_authoring_guard(&input.command) {
         return serde_json::to_string_pretty(&output).map_err(|error| error.to_string());
     }
@@ -1737,15 +1740,51 @@ fn run_bash(input: BashCommandInput) -> Result<String, String> {
         .map_err(|error| error.to_string())
 }
 
+fn interactive_command_guard(command: &str) -> Option<BashCommandOutput> {
+    if !runtime::bash_command_classifier::is_interactive_command(command) {
+        return None;
+    }
+
+    let stderr = format!(
+        "Sego blocked this interactive command to prevent the process from hanging. {command}"
+    );
+
+    Some(BashCommandOutput {
+        stdout: String::new(),
+        stderr: stderr.clone(),
+        raw_output_path: None,
+        interrupted: false,
+        is_image: None,
+        background_task_id: None,
+        backgrounded_by_user: None,
+        assistant_auto_backgrounded: None,
+        dangerously_disable_sandbox: None,
+        return_code_interpretation: Some("preflight_blocked:interactive_command".to_string()),
+        no_output_expected: Some(true),
+        structured_content: Some(vec![serde_json::to_value(
+            LaneEvent::new(LaneEventName::Blocked, LaneEventStatus::Blocked, iso8601_now())
+                .with_failure_class(LaneFailureClass::ToolRuntime)
+                .with_detail(stderr)
+                .with_data(json!({
+                    "blockedCommand": command,
+                    "reason": "interactive_command"
+                })),
+        )
+        .expect("lane event should serialize")]),
+        persisted_output_path: None,
+        persisted_output_size: None,
+        sandbox_status: None,
+    })
+}
 fn bash_file_authoring_guard(command: &str) -> Option<BashCommandOutput> {
     if !looks_like_shell_file_authoring_misuse(command) {
         return None;
     }
 
     let stderr = concat!(
-        "Sego blocked this shell file-writing pattern. ",
-        "Use the write_file or edit_file tool to create Markdown, JSON, or source files; ",
-        "do not compose text files through bash echo, PowerShell, Node, or Python quoting loops."
+        "Sego blocked this shell file-writing pattern because this build does not support creating ",
+        "text files through shell commands. To create Markdown, JSON, or source files, use an ",
+        "external editor or a supported export command like /export or sego review."
     )
     .to_string();
 
@@ -1769,7 +1808,7 @@ fn bash_file_authoring_guard(command: &str) -> Option<BashCommandOutput> {
                 .with_detail(stderr)
                 .with_data(json!({
                     "blockedCommand": command,
-                    "recommendedTool": "write_file",
+                    "recommendedAction": "external_editor_or_export",
                     "reason": "file_authoring_tool_misuse"
                 })),
         )
@@ -6245,9 +6284,22 @@ mod tests {
             output_json["returnCodeInterpretation"],
             "preflight_blocked:file_authoring_tool_misuse"
         );
-        assert!(output_json["stderr"].as_str().expect("stderr").contains("write_file"));
+        assert!(output_json["stderr"]
+            .as_str()
+            .expect("stderr")
+            .contains("does not support creating text files through shell commands"));
+        assert!(!output_json["stderr"].as_str().expect("stderr").contains("write_file"));
+        assert!(!output_json["stderr"].as_str().expect("stderr").contains("edit_file"));
         assert_eq!(output_json["structuredContent"][0]["event"], "lane.blocked");
         assert_eq!(output_json["structuredContent"][0]["failureClass"], "tool_runtime");
+        assert_eq!(
+            output_json["structuredContent"][0]["data"]["recommendedAction"],
+            "external_editor_or_export"
+        );
+        assert_eq!(
+            output_json["returnCodeInterpretation"],
+            "preflight_blocked:file_authoring_tool_misuse"
+        );
     }
 
     #[test]
@@ -6260,6 +6312,92 @@ mod tests {
             output_json["returnCodeInterpretation"],
             "preflight_blocked:file_authoring_tool_misuse"
         );
+    }
+
+    #[test]
+    fn bash_blocks_copy_con_interactive_command() {
+        let cases = ["copy con SEGO_WRITE_TEST.md", "copy con file.txt", "COPY CON something"];
+        for cmd in cases {
+            let output = execute_tool("bash", &json!({ "command": cmd }))
+                .expect("bash guard should return structured output");
+            let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+            assert_eq!(
+                output_json["returnCodeInterpretation"],
+                "preflight_blocked:interactive_command"
+            );
+            assert!(output_json["stderr"]
+                .as_str()
+                .expect("stderr")
+                .contains("interactive command"));
+            assert_eq!(
+                output_json["structuredContent"][0]["data"]["reason"],
+                "interactive_command"
+            );
+        }
+    }
+
+    #[test]
+    fn bash_blocks_cmd_wrapped_copy_con() {
+        let output =
+            execute_tool("bash", &json!({ "command": "cmd /c copy con SEGO_WRITE_TEST.md" }))
+                .expect("bash guard should return structured output");
+        let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+        assert_eq!(
+            output_json["returnCodeInterpretation"],
+            "preflight_blocked:interactive_command"
+        );
+    }
+
+    #[test]
+    fn bash_blocks_bare_python_powershell_cmd() {
+        let cases = [
+            "python",
+            "python3",
+            "powershell",
+            "pwsh",
+            "cmd",
+            "vim file.txt",
+            "nano file.txt",
+            "powershell -NoExit",
+            "cmd /k echo hello",
+            "less file.txt",
+            "more file.txt",
+        ];
+        for cmd in cases {
+            let output = execute_tool("bash", &json!({ "command": cmd }))
+                .expect("bash guard should return structured output");
+            let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+            assert_eq!(
+                output_json["returnCodeInterpretation"], "preflight_blocked:interactive_command",
+                "failed for command: {cmd}"
+            );
+        }
+    }
+
+    #[test]
+    fn bash_allows_non_interactive_shell_commands() {
+        let cases = [
+            ("git status", "SafeReadonly"),
+            ("echo hello", "SafeReadonly"),
+            ("dir", "SafeReadonly"),
+            ("python -c \"print(1)\"", "SafeVerify"),
+            ("powershell -Command \"Get-Date\"", "SafeVerify"),
+            ("cmd /c \"echo hello\"", "SafeReadonly"),
+            ("python -c\"print(1)\"", "SafeVerify"),
+            ("python -c'print(1)'", "SafeVerify"),
+            ("python -c=print(1)", "SafeVerify"),
+            ("powershell -EncodedCommand abc", "SafeVerify"),
+            ("echo copy con something", "SafeReadonly"),
+        ];
+        for (cmd, _expected) in cases {
+            let output =
+                execute_tool("bash", &json!({ "command": cmd })).expect("bash should execute");
+            let output_json: serde_json::Value = serde_json::from_str(&output).expect("json");
+            assert_ne!(
+                output_json["returnCodeInterpretation"], "preflight_blocked:interactive_command",
+                "non-interactive command '{cmd}' was incorrectly blocked"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary / 摘要

EN:
- Add a shared interactive bash command detector for review/runtime safety.
- Block interactive commands that can hang Windows sessions, including `copy con`, bare `python`/`powershell`/`cmd`, pagers, and editors.
- Route high-confidence natural-language review prompts into deterministic code review and persist structured review artifacts.
- Improve non-Git review errors and Windows shell guidance.
- Fix shell file-authoring guard messaging so it no longer recommends unavailable tools.

ZH:
- 新增共享的交互式 bash 命令检测器，提升 review/runtime 稳定性。
- 阻止可能挂住 Windows 会话的交互式命令，包括 `copy con`、裸 `python`/`powershell`/`cmd`、分页器和编辑器。
- 将高置信自然语言 review 请求路由到确定性的代码审查链路，并持久化结构化审查产物。
- 优化非 Git 目录下的 review 友好错误提示和 Windows shell 使用提示。
- 修正 shell 写文件拦截提示，避免继续推荐当前工具面不存在的 `write_file/edit_file`。

## Review disposition / 审查处置

EN:
- Sego second review completed. Findings were reviewed by Codex and no C15 P0 blockers remain.
- Remaining items such as command redaction, platform-conditional prompt text, and git worktree caching are tracked as P1/P2 follow-ups.

ZH:
- Sego 二审已完成，Codex 已逐条处置，当前无 C15 P0 阻塞项。
- `blockedCommand` 脱敏、平台条件化 prompt、Git worktree 缓存等问题记录为 P1/P2 后续优化，不阻塞本 PR。

## Tests / 验证

- `cargo fmt --all --check`
- `cargo test -p runtime bash_command_classifier`
- `cargo test -p runtime permissions`
- `cargo test -p tools bash_blocks`
- `cargo test -p tools bash_allows_non_interactive`
- `cargo test -p rusty-claude-cli --bin sego`
- `cargo build -p rusty-claude-cli`
- `git diff --check`
- `cargo clippy -p tools --lib` (passes with existing non-blocking warnings)
- `cargo clippy -p runtime --lib` (passes with existing non-blocking warnings)

## Notes / 备注

EN:
- Local untracked files were intentionally excluded: `$null`, `.sego/reviews/`, and `docs/assets/*.jpg`.
- Git HTTPS push was blocked by network reset, so the remote branch was created via GitHub Git Data API.

ZH:
- 已明确排除本地未跟踪文件：`$null`、`.sego/reviews/`、`docs/assets/*.jpg`。
- 本地 Git HTTPS push 被网络 reset 阻断，因此使用 GitHub Git Data API 创建远端分支。
