### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Sego Agent project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-06-20
+- Improved ordinary `sego review` terminal output with a human-readable structured report while keeping Markdown/JSON/index artifacts.
+- Fixed fenced JSON parsing when review finding fields contain nested Markdown code fences.
+- Narrowed natural-language latest-response export routing to avoid accidental export on phrases such as "输出结论" or "write report".
+- Improved Windows startup/update guidance and refreshed README, USAGE, and the Chinese user guide for the v0.1.7 behavior.
+
 ### Added
 - Initial open-source release of Sego Agent
 - Rust-native AI coding agent with 40+ built-in tools

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "api",
  "commands",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 publish = false


### PR DESCRIPTION
﻿## Summary / 摘要

- Bump Sego workspace version from `0.1.6` to `0.1.7`.
- Sync `Cargo.lock` workspace package versions for the v0.1.7 release.
- Add v0.1.7 changelog notes for review output UX, fenced JSON parsing, natural-language export routing, and Windows/startup/update documentation.

---

- 将 Sego workspace 版本从 `0.1.6` 提升到 `0.1.7`。
- 同步 `Cargo.lock` 中 workspace 包版本，确保 v0.1.7 发布文件一致。
- 在 CHANGELOG 中记录 v0.1.7：review 输出体验、fenced JSON 解析、自然语言导出路由、Windows/启动/更新文档。

## Tests / 验证

- `cargo check -p rusty-claude-cli`
- `cargo fmt --all --check`

## Notes / 说明

- Release tag `v0.1.7` should be created after this PR is merged into `main`.
- The tag will trigger `.github/workflows/release.yml` and publish release assets.

---

- 请在该 PR 合并到 `main` 后创建 `v0.1.7` tag。
- tag 会触发 `.github/workflows/release.yml` 并发布二进制产物。
