### PR TITLE
feat(review): add full repository audit mode

### DIFF
--- a/rust/crates/runtime/src/code_review/context.rs
+++ b/rust/crates/runtime/src/code_review/context.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::ReviewScope;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -6,12 +8,22 @@ pub struct ReviewTarget {
     pub git_status: String,
     pub staged_diff: String,
     pub unstaged_diff: String,
+    /// For `FullRepo` scope: pre-collected file tree + key-file contents.
+    /// Empty for diff-based scopes.
+    pub full_tree: String,
+    /// For `FullRepo` scope: the root directory of the audited repository.
+    /// Used to place `.sego/reviews/` artifacts into the target repo, not cwd.
+    /// `None` for diff-based scopes (falls back to cwd).
+    pub workspace_root: Option<PathBuf>,
 }
 
 impl ReviewTarget {
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.staged_diff.trim().is_empty() && self.unstaged_diff.trim().is_empty()
+        match &self.scope {
+            ReviewScope::FullRepo(_) => self.full_tree.trim().is_empty(),
+            _ => self.staged_diff.trim().is_empty() && self.unstaged_diff.trim().is_empty(),
+        }
     }
 }
 

--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -17,32 +17,63 @@ impl Default for ReviewPromptOptions {
 
 #[must_use]
 pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions) -> String {
+    let is_full_repo = matches!(&context.target.scope, ReviewScope::FullRepo(_));
+
     let mut prompt = vec![
         "You are Sego Review Agent.".to_string(),
         "Mode: read-only code review. Do not modify files, run write operations, commit, or change permissions.".to_string(),
         format!("Review scope: {}", context.target.scope.label()),
         String::new(),
-        "Task: review the current git diff for correctness, regressions, security risks, data-flow drift, missing tests, and maintainability issues.".to_string(),
-        "Findings must be specific and evidence-based. Avoid broad summaries unless there are no findings.".to_string(),
-        String::new(),
-        "Closed-loop verification requirements:".to_string(),
-        "- Do not claim a generated file, lint result, syntax check, test, dry-run, or runtime output exists/passed unless that evidence is present in the provided context.".to_string(),
-        "- If an output file or command result is proposed but not verified, label it as proposed/unverified and include the command needed to verify it.".to_string(),
-        "- Flag behavior changes separately from bug fixes, especially output schema, column names, request semantics, retry policy, filesystem paths, or data-flow changes.".to_string(),
-        "- For generated or optimized code, actively look for newly introduced regressions and include verification commands in each finding when practical.".to_string(),
-        String::new(),
-        "Domain review dimensions:".to_string(),
-        "- For network/crawler code, explicitly check URL construction, retry policy, non-retryable 4xx handling, timeout and exception handling, per-request User-Agent/header rotation if claimed, rate limiting/backoff, encoding fallback, SSRF/SSL/secrets/log leakage risks, output filename collision/overwrite behavior, dependency audit, and mockable network IO.".to_string(),
-        "- For shell command generation on Windows, flag cross-shell syntax mixing such as using CMD-only `cd /d` or `^` escaping in Bash/Git Bash, or Bash-only here-doc/path syntax in CMD/PowerShell.".to_string(),
-        String::new(),
-        "Output contract:".to_string(),
-        "- Prefer JSON only. Do not wrap the JSON in prose.".to_string(),
-        "- Shape: {\"findings\":[{\"severity\":\"critical|high|medium|low|info\",\"file\":\"path\",\"line\":123,\"title\":\"short title\",\"evidence\":\"specific diff evidence\",\"risk\":\"why it matters\",\"suggestion\":\"specific fix\",\"confidence\":0.0,\"verification_hint\":\"test or command to run\"}]}.".to_string(),
-        "- Order findings by severity.".to_string(),
-        "- If no issues are found, say exactly: No findings.".to_string(),
-        "- Do not claim tests passed unless evidence is provided in the context.".to_string(),
-        String::new(),
     ];
+
+    if is_full_repo {
+        prompt.push(
+            "Task: audit the full repository for correctness, regressions, security risks, data-flow drift, missing tests, and maintainability issues."
+                .to_string(),
+        );
+        prompt.push(
+            "The context below contains a file tree and the contents of key files (manifests, config, and entry points). Use this to identify structural issues, dependency risks, and code quality problems."
+                .to_string(),
+        );
+    } else {
+        prompt.push(
+            "Task: review the current git diff for correctness, regressions, security risks, data-flow drift, missing tests, and maintainability issues."
+                .to_string(),
+        );
+    }
+    prompt.push("Findings must be specific and evidence-based. Avoid broad summaries unless there are no findings.".to_string());
+    prompt.push(String::new());
+
+    prompt.push("Closed-loop verification requirements:".to_string());
+    prompt.push("- Do not claim a generated file, lint result, syntax check, test, dry-run, or runtime output exists/passed unless that evidence is present in the provided context.".to_string());
+    prompt.push("- If an output file or command result is proposed but not verified, label it as proposed/unverified and include the command needed to verify it.".to_string());
+    prompt.push("- Flag behavior changes separately from bug fixes, especially output schema, column names, request semantics, retry policy, filesystem paths, or data-flow changes.".to_string());
+    prompt.push("- For generated or optimized code, actively look for newly introduced regressions and include verification commands in each finding when practical.".to_string());
+    prompt.push(String::new());
+
+    if is_full_repo {
+        prompt.push("Evidence gate (full repository audit):".to_string());
+        prompt.push("- Every file path mentioned in a finding MUST appear in the file tree below. If you cannot locate a file, label it as unverified.".to_string());
+        prompt.push("- Dependency issues MUST reference a manifest file present in the tree (e.g., Cargo.toml, pyproject.toml, package.json, requirements.txt).".to_string());
+        prompt.push("- Do NOT assign critical/high severity to findings that lack direct evidence in the provided file contents.".to_string());
+        prompt.push("- For findings about missing tests or missing error handling, cite the specific file and line range from the file contents below.".to_string());
+        prompt.push(String::new());
+    }
+
+    prompt.push("Domain review dimensions:".to_string());
+    prompt.push("- For network/crawler code, explicitly check URL construction, retry policy, non-retryable 4xx handling, timeout and exception handling, per-request User-Agent/header rotation if claimed, rate limiting/backoff, encoding fallback, SSRF/SSL/secrets/log leakage risks, output filename collision/overwrite behavior, dependency audit, and mockable network IO.".to_string());
+    prompt.push("- For shell command generation on Windows, flag cross-shell syntax mixing such as using CMD-only `cd /d` or `^` escaping in Bash/Git Bash, or Bash-only here-doc/path syntax in CMD/PowerShell.".to_string());
+    prompt.push(String::new());
+
+    prompt.push("Output contract:".to_string());
+    prompt.push("- Prefer JSON only. Do not wrap the JSON in prose.".to_string());
+    prompt.push("- Shape: {\"findings\":[{\"severity\":\"critical|high|medium|low|info\",\"file\":\"path\",\"line\":123,\"title\":\"short title\",\"evidence\":\"specific diff evidence\",\"risk\":\"why it matters\",\"suggestion\":\"specific fix\",\"confidence\":0.0,\"verification_hint\":\"test or command to run\"}]}.".to_string());
+    prompt.push("- Order findings by severity.".to_string());
+    prompt.push("- If no issues are found, say exactly: No findings.".to_string());
+    prompt.push(
+        "- Do not claim tests passed unless evidence is provided in the context.".to_string(),
+    );
+    prompt.push(String::new());
 
     if !context.project_rules.is_empty() {
         prompt.push("Project rules:".to_string());
@@ -57,12 +88,22 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
         prompt.push(String::new());
     }
 
-    let diff = diff_for_scope(context);
-    if diff.trim().is_empty() {
-        prompt.push("Diff: no current changes for this review scope.".to_string());
+    if is_full_repo {
+        let tree = context.target.full_tree.trim();
+        if tree.is_empty() {
+            prompt.push("Repository snapshot: no files captured.".to_string());
+        } else {
+            prompt.push("Repository snapshot:".to_string());
+            prompt.push(fenced("text", &truncate_for_prompt(tree, options.max_diff_chars)));
+        }
     } else {
-        prompt.push("Diff:".to_string());
-        prompt.push(fenced("diff", &truncate_for_prompt(&diff, options.max_diff_chars)));
+        let diff = diff_for_scope(context);
+        if diff.trim().is_empty() {
+            prompt.push("Diff: no current changes for this review scope.".to_string());
+        } else {
+            prompt.push("Diff:".to_string());
+            prompt.push(fenced("diff", &truncate_for_prompt(&diff, options.max_diff_chars)));
+        }
     }
 
     prompt.join("\n")
@@ -86,6 +127,7 @@ fn diff_for_scope(context: &ReviewContext) -> String {
         }
         ReviewScope::Staged => context.target.staged_diff.clone(),
         ReviewScope::Unstaged => context.target.unstaged_diff.clone(),
+        ReviewScope::FullRepo(_) => String::new(),
     }
 }
 
@@ -114,6 +156,8 @@ mod tests {
             git_status: "## main\n M src/lib.rs".to_string(),
             staged_diff: String::new(),
             unstaged_diff: "diff --git a/src/lib.rs b/src/lib.rs\n".to_string(),
+            full_tree: String::new(),
+            workspace_root: None,
         });
 
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
@@ -132,6 +176,8 @@ mod tests {
             git_status: "## main".to_string(),
             staged_diff: String::new(),
             unstaged_diff: "diff --git a/src/lib.rs b/src/lib.rs\n".to_string(),
+            full_tree: String::new(),
+            workspace_root: None,
         });
 
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
@@ -148,6 +194,8 @@ mod tests {
             git_status: String::new(),
             staged_diff: String::new(),
             unstaged_diff: "x".repeat(100),
+            full_tree: String::new(),
+            workspace_root: None,
         });
 
         let prompt = build_review_prompt(
@@ -165,6 +213,8 @@ mod tests {
             git_status: String::new(),
             staged_diff: String::new(),
             unstaged_diff: String::new(),
+            full_tree: String::new(),
+            workspace_root: None,
         });
 
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
@@ -182,6 +232,8 @@ mod tests {
             git_status: String::new(),
             staged_diff: String::new(),
             unstaged_diff: String::new(),
+            full_tree: String::new(),
+            workspace_root: None,
         });
 
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
@@ -192,5 +244,27 @@ mod tests {
         assert!(prompt.contains("per-request User-Agent/header rotation"));
         assert!(prompt.contains("cross-shell syntax mixing"));
         assert!(prompt.contains("cd /d"));
+    }
+
+    #[test]
+    fn full_repo_prompt_includes_snapshot_and_evidence_gate() {
+        let context = ReviewContext::new(ReviewTarget {
+            scope: ReviewScope::FullRepo(".".into()),
+            git_status: String::new(),
+            staged_diff: String::new(),
+            unstaged_diff: String::new(),
+            full_tree: "## File tree\nsrc/lib.rs\n\n## Key files\n\n### Cargo.toml [full]\n```\n[package]\n```\n"
+                .to_string(),
+            workspace_root: Some(".".into()),
+        });
+
+        let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
+
+        assert!(prompt.contains("Review scope: full_repo:."));
+        assert!(prompt.contains("Repository snapshot:"));
+        assert!(prompt.contains("Evidence gate (full repository audit)"));
+        assert!(prompt.contains("## File tree"));
+        assert!(prompt.contains("### Cargo.toml"));
+        assert!(!prompt.contains("Diff:"));
     }
 }

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -8,7 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::{ReviewSeverity, ReviewTarget};
+use super::{ReviewScope, ReviewSeverity, ReviewTarget};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ReviewFinding {
@@ -313,10 +313,15 @@ pub fn latest_review_finding_statuses(
 pub fn review_diff_hash(target: &ReviewTarget) -> String {
     let mut hasher = Sha256::new();
     hasher.update(target.scope.label().as_bytes());
-    hasher.update(b"\n---staged---\n");
-    hasher.update(target.staged_diff.as_bytes());
-    hasher.update(b"\n---unstaged---\n");
-    hasher.update(target.unstaged_diff.as_bytes());
+    if matches!(&target.scope, ReviewScope::FullRepo(_)) {
+        hasher.update(b"\n---full_tree---\n");
+        hasher.update(target.full_tree.as_bytes());
+    } else {
+        hasher.update(b"\n---staged---\n");
+        hasher.update(target.staged_diff.as_bytes());
+        hasher.update(b"\n---unstaged---\n");
+        hasher.update(target.unstaged_diff.as_bytes());
+    }
     format!("{:x}", hasher.finalize())
 }
 
@@ -833,7 +838,47 @@ mod tests {
             git_status: "## main\n M src/lib.rs".to_string(),
             staged_diff: String::new(),
             unstaged_diff: diff.to_string(),
+            full_tree: String::new(),
+            workspace_root: None,
         }
+    }
+
+    fn target_full_repo(full_tree: &str) -> ReviewTarget {
+        ReviewTarget {
+            scope: ReviewScope::FullRepo("/test/repo".into()),
+            git_status: String::new(),
+            staged_diff: String::new(),
+            unstaged_diff: String::new(),
+            full_tree: full_tree.to_string(),
+            workspace_root: Some("/test/repo".into()),
+        }
+    }
+
+    #[test]
+    fn full_repo_diff_hash_uses_full_tree_not_diffs() {
+        let t1 = target_full_repo("tree content A");
+        let t2 = target_full_repo("tree content B");
+        let t1_dup = target_full_repo("tree content A");
+
+        let h1 = review_diff_hash(&t1);
+        let h2 = review_diff_hash(&t2);
+        let h1_dup = review_diff_hash(&t1_dup);
+
+        assert_eq!(h1, h1_dup, "same full_tree should produce same hash");
+        assert_ne!(h1, h2, "different full_tree should produce different hash");
+        assert!(!h1.is_empty());
+        assert!(!h2.is_empty());
+    }
+
+    #[test]
+    fn full_repo_hash_differs_from_diff_based_hash() {
+        let full = target_full_repo("content");
+        let diff = target_with_diff("diff --git a/a b/a\n");
+
+        let h_full = review_diff_hash(&full);
+        let h_diff = review_diff_hash(&diff);
+
+        assert_ne!(h_full, h_diff, "FullRepo hash should differ from diff-based hash");
     }
 
     fn temp_path(name: &str) -> std::path::PathBuf {

--- a/rust/crates/runtime/src/code_review/scope.rs
+++ b/rust/crates/runtime/src/code_review/scope.rs
@@ -7,6 +7,9 @@ pub enum ReviewScope {
     Staged,
     Unstaged,
     Path(PathBuf),
+    /// Full repository audit: walk the entire directory tree (skipping
+    /// `.git`, `node_modules`, virtual envs, build artifacts, caches).
+    FullRepo(PathBuf),
 }
 
 impl ReviewScope {
@@ -19,6 +22,16 @@ impl ReviewScope {
             "workspace" | "all" | "." => Ok(Self::Workspace),
             "staged" | "--staged" | "cached" | "--cached" => Ok(Self::Staged),
             "unstaged" | "--unstaged" | "working" | "worktree" => Ok(Self::Unstaged),
+            // --full [path]  → FullRepo audit (C20)
+            raw if raw == "--full" => Ok(Self::FullRepo(PathBuf::from("."))),
+            raw if raw.starts_with("--full ") => {
+                let path = raw["--full ".len()..].trim();
+                if path.is_empty() {
+                    Ok(Self::FullRepo(PathBuf::from(".")))
+                } else {
+                    Ok(Self::FullRepo(PathBuf::from(path)))
+                }
+            }
             value if value.starts_with('-') => {
                 Err(ReviewScopeParseError::UnsupportedFlag { value: value.to_string() })
             }
@@ -33,6 +46,7 @@ impl ReviewScope {
             Self::Staged => "staged".to_string(),
             Self::Unstaged => "unstaged".to_string(),
             Self::Path(path) => format!("path:{}", path.display()),
+            Self::FullRepo(path) => format!("full_repo:{}", path.display()),
         }
     }
 }
@@ -88,5 +102,30 @@ mod tests {
             ReviewScope::parse(Some("--json")),
             Err(ReviewScopeParseError::UnsupportedFlag { value: "--json".to_string() })
         );
+    }
+
+    #[test]
+    fn parses_full_repo_scope() {
+        assert_eq!(ReviewScope::parse(Some("--full")), Ok(ReviewScope::FullRepo(".".into())));
+        assert_eq!(
+            ReviewScope::parse(Some("--full /home/user/project")),
+            Ok(ReviewScope::FullRepo("/home/user/project".into()))
+        );
+        assert_eq!(ReviewScope::parse(Some("--full ")), Ok(ReviewScope::FullRepo(".".into())));
+    }
+
+    #[test]
+    fn parses_full_repo_with_spaces_in_path() {
+        // R1: path with spaces must be parsed correctly.
+        assert_eq!(
+            ReviewScope::parse(Some("--full E:\\Path With Spaces")),
+            Ok(ReviewScope::FullRepo("E:\\Path With Spaces".into()))
+        );
+    }
+
+    #[test]
+    fn full_repo_label_includes_path() {
+        let scope = ReviewScope::FullRepo("/tmp/repo".into());
+        assert_eq!(scope.label(), "full_repo:/tmp/repo");
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3697,11 +3697,13 @@ impl LiveCli {
 
     fn run_review(&mut self, scope: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = env::current_dir()?;
-        if !is_git_worktree(&cwd) {
+        let review_scope = ReviewScope::parse(scope)?;
+        let is_full_repo = matches!(&review_scope, ReviewScope::FullRepo(_));
+        // Full repo audit works on non-Git directories too (C20).
+        if !is_full_repo && !is_git_worktree(&cwd) {
             eprintln!("{}", non_git_review_error(&cwd));
             return Ok(());
         }
-        let review_scope = ReviewScope::parse(scope)?;
         let target = collect_review_target(&cwd, review_scope)?;
         if target.is_empty() {
             print_clean_review_scope(&target);
@@ -3726,15 +3728,19 @@ impl LiveCli {
         target: ReviewTarget,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let cwd = env::current_dir()?;
-        if !is_git_worktree(&cwd) {
+        let is_full_repo = matches!(&target.scope, ReviewScope::FullRepo(_));
+        // Full repo audit works on non-Git directories too (C20).
+        if !is_full_repo && !is_git_worktree(&cwd) {
             eprintln!("{}", non_git_review_error(&cwd));
             return Ok(()); // REPL: print friendly message and continue, do not exit process
         }
+        // R1: for FullRepo, persist artifacts into the target repo, not cwd.
+        let workspace_root = target.workspace_root.clone().unwrap_or_else(|| cwd.clone());
         let context = ReviewContext::new(target);
         let prompt = build_review_prompt(&context, ReviewPromptOptions::default());
         let review_text = self.run_turn_capture_text(&prompt, false)?;
         let report = ReviewReport::from_model_output(review_text);
-        let artifact = persist_review_artifact(&env::current_dir()?, &context.target, &report)?;
+        let artifact = persist_review_artifact(&workspace_root, &context.target, &report)?;
         println!("{}", format_review_completion_summary(&report, &artifact));
         Ok(())
     }
@@ -5074,6 +5080,39 @@ fn collect_review_target(
     cwd: &Path,
     scope: ReviewScope,
 ) -> Result<ReviewTarget, Box<dyn std::error::Error>> {
+    // C20: Full repository audit — walk the tree instead of running git diff.
+    if let ReviewScope::FullRepo(ref audit_path) = scope {
+        let repo_root_raw =
+            if audit_path.is_absolute() { audit_path.clone() } else { cwd.join(audit_path) };
+        // R2: canonicalize for stable hash/label.
+        let repo_root = std::fs::canonicalize(&repo_root_raw).map_err(|e| {
+            format!("cannot resolve full repo audit path {}: {e}", repo_root_raw.display())
+        })?;
+        if !repo_root.is_dir() {
+            return Err(format!(
+                "full repo audit target is not a directory: {}",
+                repo_root.display()
+            )
+            .into());
+        }
+        let full_tree = collect_full_repo_snapshot(&repo_root)?;
+        // R2: git_status from the target repo, not cwd.
+        let git_status = if is_git_worktree(&repo_root) {
+            run_git_diff_command_in(&repo_root, &["status", "--short", "--branch"])
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        return Ok(ReviewTarget {
+            scope,
+            git_status,
+            staged_diff: String::new(),
+            unstaged_diff: String::new(),
+            full_tree,
+            workspace_root: Some(repo_root),
+        });
+    }
+
     let git_status = run_git_diff_command_in(cwd, &["status", "--short", "--branch"])?;
     let (staged_diff, unstaged_diff) = match &scope {
         ReviewScope::Workspace => (
@@ -5091,15 +5130,327 @@ fn collect_review_target(
                 run_git_diff_command_in(cwd, &["diff", "--", path.as_ref()])?,
             )
         }
+        ReviewScope::FullRepo(_) => unreachable!("FullRepo handled above"),
     };
 
-    Ok(ReviewTarget { scope, git_status, staged_diff, unstaged_diff })
+    Ok(ReviewTarget {
+        scope,
+        git_status,
+        staged_diff,
+        unstaged_diff,
+        full_tree: String::new(),
+        workspace_root: None,
+    })
 }
 
 fn collect_staged_review_paths(cwd: &Path) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
     let output =
         run_git_diff_command_in(cwd, &["diff", "--cached", "--name-only", "--diff-filter=ACMR"])?;
     Ok(output.lines().map(str::trim).filter(|line| !line.is_empty()).map(PathBuf::from).collect())
+}
+/// C20+R1: Walk a repository directory, collect file tree, manifest contents,
+/// and bounded key source file sampling.
+/// Skips `.git`, `node_modules`, virtual envs, build artifacts, and cache dirs.
+fn collect_full_repo_snapshot(repo_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    const SKIP_DIRS: &[&str] = &[
+        ".git",
+        "node_modules",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "target",
+        "build",
+        "dist",
+        ".next",
+        ".nuxt",
+        "coverage",
+        ".cache",
+        ".idea",
+        ".vscode",
+        ".vs",
+        ".cargo",
+    ];
+
+    // R3: lock files excluded from key content (noisy, large). They still appear in file tree.
+    const KEY_MANIFEST_FILES: &[&str] = &[
+        "Cargo.toml",
+        "pyproject.toml",
+        "requirements.txt",
+        "setup.py",
+        "setup.cfg",
+        "package.json",
+        "go.mod",
+        "go.sum",
+        "Makefile",
+        "CMakeLists.txt",
+        "Dockerfile",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        ".github/workflows",
+    ];
+
+    // R1: entry-point files.
+    const ENTRY_FILES: &[&str] = &[
+        "main.py",
+        "app.py",
+        "webapp.py",
+        "lib.rs",
+        "main.rs",
+        "index.ts",
+        "index.js",
+        "main.go",
+        "manage.py",
+        "cli.py",
+        "run.py",
+    ];
+
+    // R1: README-like files.
+    const README_FILES: &[&str] =
+        &["README.md", "README_zh.md", "README.txt", "README.rst", "README"];
+
+    // R1: key source dirs to sample.
+    const KEY_SOURCE_DIRS: &[&str] = &["src", "crates", "packages", "lib"];
+    const MAX_SOURCE_FILES_PER_DIR: usize = 8;
+    const MAX_SOURCE_FILE_CHARS: usize = 6_000;
+
+    const MAX_DEPTH: usize = 64;
+    // R3: aggregate byte cap on key_contents to avoid huge prompts.
+    const MAX_SNAPSHOT_BYTES: usize = 256 * 1024;
+
+    let mut file_list: Vec<String> = Vec::new();
+    let mut key_contents: Vec<String> = Vec::new();
+    let mut total_key_bytes: usize = 0;
+    let mut skipped_large: usize = 0;
+    let mut unreadable: usize = 0;
+    // R2: key for sampling cap is the first matching key-source ancestor component.
+    let mut dir_source_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    // R2: stable ordering — collect top-level entries, sort, then walk.
+    if let Ok(entries) = std::fs::read_dir(repo_root) {
+        let mut top_entries: Vec<std::fs::DirEntry> = entries.flatten().collect();
+        top_entries
+            .sort_by(|a, b| a.file_name().to_string_lossy().cmp(&b.file_name().to_string_lossy()));
+        for entry in top_entries {
+            let path = entry.path();
+            let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if SKIP_DIRS.contains(&file_name) {
+                continue;
+            }
+            walk_repo_dir_r2(
+                &path,
+                repo_root,
+                0,
+                MAX_DEPTH,
+                &mut file_list,
+                &mut key_contents,
+                &mut total_key_bytes,
+                MAX_SNAPSHOT_BYTES,
+                &mut skipped_large,
+                &mut unreadable,
+                SKIP_DIRS,
+                KEY_MANIFEST_FILES,
+                ENTRY_FILES,
+                README_FILES,
+                KEY_SOURCE_DIRS,
+                &mut dir_source_counts,
+                MAX_SOURCE_FILES_PER_DIR,
+                MAX_SOURCE_FILE_CHARS,
+            );
+        }
+    }
+
+    file_list.sort();
+    let mut output = String::new();
+    output.push_str("## File tree\n");
+    for f in &file_list {
+        output.push_str(f);
+        output.push('\n');
+    }
+    output.push('\n');
+
+    // R3: snapshot summary with limits info.
+    output.push_str("## Snapshot limits\n");
+    output.push_str(&format!(
+        "Key content cap reached: {}\n",
+        if total_key_bytes >= MAX_SNAPSHOT_BYTES { "yes" } else { "no" }
+    ));
+    output.push_str(&format!("Skipped large files: {skipped_large}\n"));
+    output.push_str(&format!("Unreadable files: {unreadable}\n"));
+    output.push('\n');
+
+    if !key_contents.is_empty() {
+        output.push_str("## Key files\n\n");
+        for block in &key_contents {
+            output.push_str(block);
+            output.push('\n');
+        }
+    }
+
+    Ok(output)
+}
+
+/// R2+R3: recursive directory walker with depth limit, symlink detection, stable ordering,
+/// aggregate byte cap, and unreadable-file tracking.
+#[allow(clippy::too_many_arguments)]
+fn walk_repo_dir_r2(
+    current: &Path,
+    repo_root: &Path,
+    depth: usize,
+    max_depth: usize,
+    file_list: &mut Vec<String>,
+    key_contents: &mut Vec<String>,
+    total_key_bytes: &mut usize,
+    max_snapshot_bytes: usize,
+    skipped_large: &mut usize,
+    unreadable: &mut usize,
+    skip_dirs: &[&str],
+    key_manifest_files: &[&str],
+    entry_files: &[&str],
+    readme_files: &[&str],
+    key_source_dirs: &[&str],
+    dir_source_counts: &mut std::collections::HashMap<String, usize>,
+    max_source_per_dir: usize,
+    max_source_chars: usize,
+) {
+    if depth > max_depth || !current.exists() {
+        return;
+    }
+    // R2: detect and skip symlinks to avoid loops.
+    if let Ok(meta) = current.symlink_metadata() {
+        if meta.file_type().is_symlink() {
+            return;
+        }
+    }
+    if current.is_dir() {
+        let dir_name = current.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if skip_dirs.contains(&dir_name) {
+            return;
+        }
+        // R2: stable ordering — collect entries, sort by name, then recurse.
+        if let Ok(entries) = std::fs::read_dir(current) {
+            let mut children: Vec<std::fs::DirEntry> = entries.flatten().collect();
+            children.sort_by(|a, b| {
+                a.file_name().to_string_lossy().cmp(&b.file_name().to_string_lossy())
+            });
+            for entry in children {
+                walk_repo_dir_r2(
+                    &entry.path(),
+                    repo_root,
+                    depth + 1,
+                    max_depth,
+                    file_list,
+                    key_contents,
+                    total_key_bytes,
+                    max_snapshot_bytes,
+                    skipped_large,
+                    unreadable,
+                    skip_dirs,
+                    key_manifest_files,
+                    entry_files,
+                    readme_files,
+                    key_source_dirs,
+                    dir_source_counts,
+                    max_source_per_dir,
+                    max_source_chars,
+                );
+            }
+        }
+        return;
+    }
+
+    let Ok(relative) = current.strip_prefix(repo_root) else {
+        return;
+    };
+    let rel_str = relative.to_string_lossy().replace('\\', "/");
+    file_list.push(rel_str.clone());
+
+    let file_name = current.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+    let is_manifest = key_manifest_files.contains(&file_name)
+        || rel_str.ends_with("/Cargo.toml")
+        || rel_str.ends_with("/pyproject.toml")
+        || rel_str.ends_with("/package.json")
+        || rel_str.ends_with("/requirements.txt")
+        || rel_str.ends_with("/go.mod")
+        || rel_str.ends_with("/Makefile")
+        || rel_str.ends_with("/Dockerfile");
+
+    // R2: also match .yaml CI workflow files.
+    let is_ci_workflow = rel_str.contains(".github/workflows")
+        && (rel_str.ends_with(".yml") || rel_str.ends_with(".yaml"));
+    let is_readme = readme_files.contains(&file_name);
+    let is_entry = entry_files.contains(&file_name);
+
+    // R2: find the first matching key-source ancestor for the counter key.
+    let counter_key = relative
+        .components()
+        .filter_map(|c| {
+            let s = c.as_os_str().to_string_lossy();
+            key_source_dirs.contains(&s.as_ref()).then(|| s.to_string())
+        })
+        .next()
+        .unwrap_or_else(|| {
+            relative
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_string()
+        });
+
+    let is_in_key_dir = !counter_key.is_empty() && key_source_dirs.contains(&counter_key.as_str());
+
+    let mut should_sample_source = false;
+    if is_in_key_dir && !is_manifest && !is_ci_workflow && !is_readme && !is_entry {
+        let count = dir_source_counts.get(&counter_key).copied().unwrap_or(0);
+        if count < max_source_per_dir {
+            dir_source_counts.insert(counter_key.clone(), count + 1);
+            should_sample_source = true;
+        }
+    }
+
+    if is_manifest || is_ci_workflow || is_readme || is_entry || should_sample_source {
+        // R3: check aggregate cap before reading.
+        if *total_key_bytes >= max_snapshot_bytes {
+            return;
+        }
+        // R3: check file size before reading; skip very large files.
+        let file_size = current.metadata().map(|m| m.len()).unwrap_or(0);
+        const MAX_SINGLE_FILE_BYTES: u64 = 1_000_000;
+        if file_size > MAX_SINGLE_FILE_BYTES {
+            *skipped_large += 1;
+            key_contents.push(format!("### {} [skipped: {} bytes]\n", rel_str, file_size));
+            return;
+        }
+        match std::fs::read_to_string(current) {
+            Ok(content) => {
+                let max_chars = if should_sample_source { max_source_chars } else { 4000 };
+                let truncated = truncate_file_content(&content, max_chars);
+                let status =
+                    if content.chars().count() > max_chars { " [truncated]" } else { " [full]" };
+                let block = format!("### {}{}\n```\n{}\n```", rel_str, status, truncated);
+                *total_key_bytes += block.len();
+                key_contents.push(block);
+            }
+            Err(e) => {
+                *unreadable += 1;
+                key_contents.push(format!("### {} [unreadable: {}]\n", rel_str, e.kind()));
+            }
+        }
+    }
+}
+
+fn truncate_file_content(content: &str, max_chars: usize) -> String {
+    if content.chars().count() <= max_chars {
+        return content.to_string();
+    }
+    let truncated: String = content.chars().take(max_chars).collect();
+    format!("{truncated}\n\n[truncated: file exceeded {max_chars} characters]")
 }
 
 fn run_code_review_cli(
@@ -5109,11 +5460,13 @@ fn run_code_review_cli(
     scope: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let cwd = env::current_dir()?;
-    if !is_git_worktree(&cwd) {
+    let review_scope = ReviewScope::parse(scope)?;
+    let is_full_repo = matches!(&review_scope, ReviewScope::FullRepo(_));
+    // Full repo audit works on non-Git directories too (C20).
+    if !is_full_repo && !is_git_worktree(&cwd) {
         eprintln!("{}", non_git_review_error(&cwd));
         std::process::exit(1);
     }
-    let review_scope = ReviewScope::parse(scope)?;
     let target = collect_review_target(&cwd, review_scope)?;
     if target.is_empty() {
         print_clean_review_scope(&target);


### PR DESCRIPTION
## EN Summary

This PR adds C20 Full Repository Audit mode for Sego review.

### What changed

- Add a new FullRepo review scope for `sego review --full <path>`.
- Support clean Git repositories and ordinary directories, not only dirty Git diffs.
- Validate missing paths and non-directory paths with clear errors before model execution.
- Persist full-repo review artifacts under the target repository's `.sego/reviews/` directory.
- Collect a bounded repository snapshot:
  - file tree
  - manifests
  - README files
  - entry files
  - bounded key source samples
- Add snapshot limits to prevent prompt bloat:
  - aggregate key-content cap
  - skipped large-file tracking
  - unreadable-file tracking
  - lock files excluded from key content
- Add FullRepo-specific prompt evidence guidance.
- Add FullRepo hash / prompt / scope test coverage.
- Preserve existing diff review behavior.

### Validation

Local verification passed:

```text
cargo fmt --check
git diff --check
cargo test -p rusty-claude-cli review
cargo test -p runtime code_review
cargo build -p rusty-claude-cli
```

Sego review loop:

- R1/R2/R3 findings were triaged and fixed.
- Final R4 review only reported low/info polish.
- BOM and redundant canonicalize-path cleanup were fixed after R4.

### Notes

Full repository audit is intentionally a bounded evidence snapshot, not an exhaustive static analyzer. It is designed to make clean third-party repositories and customer project directories reviewable through Sego's standard artifact flow.

---

## 中文摘要

本 PR 实现 C20：Sego Full Repository Audit 全仓审阅模式。

### 变更内容

- 新增 FullRepo review scope，支持 `sego review --full <path>`。
- 支持审阅干净 Git 仓库和普通目录，不再只依赖 dirty Git diff。
- 对不存在路径、非目录路径给出清晰错误，并在调用模型前停止。
- FullRepo 审阅产物落到目标仓库 `.sego/reviews/`，而不是调用者当前目录。
- 收集受控仓库快照：
  - 文件树
  - manifest 文件
  - README 文件
  - 入口文件
  - 有上限的关键源码采样
- 增加 snapshot 上限，避免 prompt 膨胀：
  - key content 总量上限
  - 大文件跳过计数
  - 不可读文件计数
  - lock files 不进入 key content
- 增加 FullRepo 专用 evidence guidance。
- 补充 FullRepo hash / prompt / scope 测试。
- 保持原有 diff review 行为不变。

### 验证

本地验证已通过：

```text
cargo fmt --check
git diff --check
cargo test -p rusty-claude-cli review
cargo test -p runtime code_review
cargo build -p rusty-claude-cli
```

Sego 审阅闭环：

- R1/R2/R3 findings 已分流并修复。
- 最终 R4 review 只剩 low/info 级别建议。
- R4 后已清理 BOM 和 canonicalize 路径冗余检查。

### 说明

Full repository audit 是“受控证据快照”，不是完整静态分析器。目标是让干净第三方仓库和客户项目目录能够进入 Sego 标准 review artifact 流程。
