### PR TITLE
fix(review): harden parse diagnostics and artifact export guidance

### DIFF
--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -66,7 +66,14 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
     prompt.push(String::new());
 
     prompt.push("Output contract:".to_string());
-    prompt.push("- Prefer JSON only. Do not wrap the JSON in prose.".to_string());
+    prompt.push(
+        "- ONLY output a JSON object. No prose before or after JSON. No Markdown fences."
+            .to_string(),
+    );
+    prompt.push(
+        "- All field strings must be valid JSON strings with escaped quotes and newlines."
+            .to_string(),
+    );
     prompt.push("- Shape: {\"findings\":[{\"severity\":\"critical|high|medium|low|info\",\"file\":\"path\",\"line\":123,\"title\":\"short title\",\"evidence\":\"specific diff evidence\",\"risk\":\"why it matters\",\"suggestion\":\"specific fix\",\"confidence\":0.0,\"verification_hint\":\"test or command to run\"}]}.".to_string());
     prompt.push("- Order findings by severity.".to_string());
     prompt.push("- If no issues are found, say exactly: No findings.".to_string());
@@ -164,7 +171,8 @@ mod tests {
 
         assert!(prompt.contains("You are Sego Review Agent."));
         assert!(prompt.contains("Mode: read-only code review."));
-        assert!(prompt.contains("Prefer JSON only."));
+        assert!(prompt.contains("ONLY output a JSON object"));
+        assert!(prompt.contains("All field strings must be valid JSON strings"));
         assert!(prompt.contains("\"severity\":\"critical|high|medium|low|info\""));
         assert!(prompt.contains("diff --git a/src/lib.rs b/src/lib.rs"));
     }

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -51,6 +51,12 @@ pub struct ReviewReport {
     pub findings: Vec<ReviewFinding>,
     pub raw_text: String,
     pub parse_status: ReviewParseStatus,
+    /// C20.6-A UX-B: parse error detail for auditability.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub parse_error: String,
+    /// C20.6-A UX-B: whether a JSON repair was attempted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parse_repair: Option<String>,
 }
 
 impl ReviewReport {
@@ -60,6 +66,8 @@ impl ReviewReport {
             findings: Vec::new(),
             raw_text: raw_text.into(),
             parse_status: ReviewParseStatus::FallbackRawText,
+            parse_error: String::new(),
+            parse_repair: None,
         }
     }
 
@@ -74,6 +82,8 @@ impl ReviewReport {
                 findings: Vec::new(),
                 raw_text,
                 parse_status: ReviewParseStatus::Structured,
+                parse_error: String::new(),
+                parse_repair: None,
             };
         }
 
@@ -84,11 +94,16 @@ impl ReviewReport {
                     findings: Vec::new(),
                     raw_text,
                     parse_status: ReviewParseStatus::ParseAttemptedButFailed,
+                    parse_error: String::from("no valid JSON candidate found in model output"),
+                    parse_repair: None,
                 };
             }
             return Self::no_findings(raw_text);
         };
 
+        // C20.6-A R3: source-based repair tracking.
+        let extraction_source = json_candidate.source;
+        let json_candidate = json_candidate.text;
         let parsed = serde_json::from_str::<ReviewReportWire>(json_candidate)
             .map(|wire| wire.findings)
             .or_else(|_| serde_json::from_str::<Vec<ReviewFinding>>(json_candidate));
@@ -98,17 +113,32 @@ impl ReviewReport {
                 findings: assign_finding_ids(findings),
                 raw_text,
                 parse_status: ReviewParseStatus::Structured,
+                parse_error: String::new(),
+                parse_repair: if extraction_source != ExtractionSource::Direct {
+                    Some(format!("{extraction_source:?}"))
+                } else {
+                    None
+                },
             },
-            Err(_) => {
+            Err(e) => {
                 // C20.5-A: parsing failed but candidate text was found.
+                let parse_err = format!("serde parse error: {e}");
                 if trimmed.contains("\"findings\"") || trimmed.contains("\"findings\":") {
                     return Self {
                         findings: Vec::new(),
                         raw_text,
                         parse_status: ReviewParseStatus::ParseAttemptedButFailed,
+                        parse_error: parse_err,
+                        parse_repair: if extraction_source != ExtractionSource::Direct {
+                            Some(format!("{extraction_source:?}"))
+                        } else {
+                            None
+                        },
                     };
                 }
-                Self::no_findings(raw_text)
+                let mut r = Self::no_findings(raw_text);
+                r.parse_error = parse_err;
+                r
             }
         }
     }
@@ -138,6 +168,12 @@ struct ReviewArtifact {
     finding_count: usize,
     highest_severity: Option<ReviewSeverity>,
     parse_status: ReviewParseStatus,
+    /// C20.6-A R2: parse diagnostics persisted for auditability.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    parse_error: String,
+    /// C20.6-A R2: whether JSON repair/extraction was used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parse_repair: Option<String>,
     git_status: String,
     findings: Vec<ReviewFinding>,
     raw_text: String,
@@ -224,6 +260,9 @@ pub fn persist_review_artifact(
         finding_count: report.findings.len(),
         highest_severity: report.highest_severity(),
         parse_status: report.parse_status,
+        // C20.6-A R2: persist parse diagnostics in artifacts.
+        parse_error: report.parse_error.clone(),
+        parse_repair: report.parse_repair.clone(),
         git_status: target.git_status.clone(),
         findings: report.findings.clone(),
         raw_text: report.raw_text.clone(),
@@ -246,7 +285,7 @@ pub fn load_review_index(workspace_root: &Path) -> io::Result<Vec<ReviewIndexEnt
         return Ok(Vec::new());
     }
 
-    let contents = fs::read_to_string(index_path)?;
+    let contents = std::fs::read_to_string(index_path)?;
     contents
         .lines()
         .enumerate()
@@ -301,7 +340,7 @@ pub fn load_review_finding_statuses(
         return Ok(Vec::new());
     }
 
-    let contents = fs::read_to_string(status_path)?;
+    let contents = std::fs::read_to_string(status_path)?;
     contents
         .lines()
         .enumerate()
@@ -355,6 +394,13 @@ fn render_review_markdown(artifact: &ReviewArtifact, report: &ReviewReport) -> S
     let _ = writeln!(output, "- Diff hash: `{}`", artifact.diff_hash);
     let _ = writeln!(output, "- Findings: `{}`", artifact.finding_count);
     let _ = writeln!(output, "- Parse status: `{}`", artifact.parse_status.label());
+    // C20.6-A R2: render parse diagnostics in Markdown.
+    if !artifact.parse_error.is_empty() {
+        let _ = writeln!(output, "- Parse error: `{}`", artifact.parse_error);
+        if let Some(ref repair) = artifact.parse_repair {
+            let _ = writeln!(output, "- Parse repair: `{}`", repair);
+        }
+    }
     if let Some(severity) = artifact.highest_severity {
         let _ = writeln!(output, "- Highest severity: `{}`", severity.label());
     }
@@ -479,10 +525,23 @@ fn stable_finding_id(finding: &ReviewFinding) -> String {
     format!("finding-{}", short_hash(&format!("{:x}", hasher.finalize())))
 }
 
-fn extract_json_candidate(text: &str) -> Option<&str> {
+/// C20.6-A R3: tracks where a JSON candidate was extracted from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExtractionSource {
+    Direct,
+    Fenced,
+    Prose,
+}
+
+struct ExtractedJson<'a> {
+    text: &'a str,
+    source: ExtractionSource,
+}
+
+fn extract_json_candidate(text: &str) -> Option<ExtractedJson<'_>> {
     let trimmed = text.trim();
     if trimmed.starts_with('{') || trimmed.starts_with('[') {
-        return Some(trimmed);
+        return Some(ExtractedJson { text: trimmed, source: ExtractionSource::Direct });
     }
 
     // Check for fenced JSON block: ```json ... ```
@@ -496,7 +555,10 @@ fn extract_json_candidate(text: &str) -> Option<&str> {
             for content_line in content.split_inclusive('\n') {
                 let candidate = content_line.trim_end_matches(&['\r', '\n'][..]).trim();
                 if candidate == "```" {
-                    return Some(content[..content_offset].trim());
+                    return Some(ExtractedJson {
+                        text: content[..content_offset].trim(),
+                        source: ExtractionSource::Fenced,
+                    });
                 }
                 content_offset += content_line.len();
             }
@@ -507,6 +569,7 @@ fn extract_json_candidate(text: &str) -> Option<&str> {
 
     // C20.5-A: fallback — search for a JSON object containing "findings" in prose text.
     extract_json_from_prose(trimmed)
+        .map(|text| ExtractedJson { text, source: ExtractionSource::Prose })
 }
 
 /// C20.5-A: Search for a `{...}` JSON object in arbitrary prose text.
@@ -640,6 +703,8 @@ mod tests {
             finding_count: 1,
             highest_severity: Some(ReviewSeverity::High),
             parse_status: ReviewParseStatus::Structured,
+            parse_error: String::new(),
+            parse_repair: None,
             git_status: "## main...origin/main".to_string(),
             findings: vec![ReviewFinding {
                 id: "f-001".to_string(),
@@ -698,6 +763,8 @@ mod tests {
             finding_count: 0,
             highest_severity: None,
             parse_status: ReviewParseStatus::FallbackRawText,
+            parse_error: String::new(),
+            parse_repair: None,
             git_status: String::new(),
             findings: vec![],
             raw_text: "No findings.".to_string(),
@@ -889,6 +956,67 @@ mod tests {
         assert_eq!(report.parse_status, ReviewParseStatus::Structured);
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].title, "After noise");
+    }
+
+    #[test]
+    fn parse_failed_artifact_persists_diagnostics() {
+        // R3: parse-failed review must persist parse_error in JSON + Markdown artifacts.
+        let report = ReviewReport::from_model_output(
+            "{\"findings\": [{\"severity\": \"bad\", \"title\": \"unclosed string}",
+        );
+        assert_eq!(report.parse_status, ReviewParseStatus::ParseAttemptedButFailed);
+        assert!(!report.parse_error.is_empty());
+
+        let root = temp_path("review-parse-failed");
+        let _ = std::fs::create_dir_all(&root);
+        let target = target_with_diff(
+            "diff --git a/src/lib.rs b/src/lib.rs
+",
+        );
+        let artifact = persist_review_artifact(&root, &target, &report).expect("persist");
+
+        // JSON artifact must contain diagnostics.
+        let json = std::fs::read_to_string(&artifact.json_path).expect("json");
+        assert!(json.contains("parse_attempted_but_failed"));
+        assert!(json.contains("parse_error"));
+
+        // Markdown artifact must contain diagnostics.
+        let md = std::fs::read_to_string(&artifact.markdown_path).expect("md");
+        assert!(md.contains("Parse status"));
+        assert!(md.contains("Parse error"));
+
+        // Index still writes.
+        let index = std::fs::read_to_string(&artifact.index_path).expect("index");
+        assert!(index.contains("parse_attempted_but_failed"));
+
+        std::fs::remove_dir_all(root).expect("cleanup");
+    }
+
+    #[test]
+    fn parse_success_repair_marker_absent_for_direct_json() {
+        let report = ReviewReport::from_model_output(
+            r#"{"findings":[{"severity":"low","file":"a.rs","line":1,"title":"ok","evidence":"e","risk":"r","suggestion":"s","confidence":0.5}]}"#,
+        );
+        assert_eq!(report.parse_status, ReviewParseStatus::Structured);
+        assert!(report.parse_repair.is_none(), "Direct JSON must have no repair marker");
+    }
+
+    #[test]
+    fn parse_success_repair_marker_present_for_fenced_json() {
+        let report = ReviewReport::from_model_output(
+            "```json\n{\"findings\":[{\"severity\":\"low\",\"file\":\"a.rs\",\"line\":1,\"title\":\"fenced\",\"evidence\":\"e\",\"risk\":\"r\",\"suggestion\":\"s\",\"confidence\":0.5}]}\n```",
+        );
+        assert_eq!(report.parse_status, ReviewParseStatus::Structured);
+        assert!(report.parse_repair.is_some(), "Fenced JSON must have repair marker");
+    }
+
+    #[test]
+    fn parse_success_repair_marker_present_for_prose_json() {
+        let report = ReviewReport::from_model_output(
+            "Here is output:\n{\"findings\":[{\"severity\":\"low\",\"file\":\"a.rs\",\"line\":1,\"title\":\"prose\",\"evidence\":\"e\",\"risk\":\"r\",\"suggestion\":\"s\",\"confidence\":0.5}]}\nEnd.",
+        );
+        assert_eq!(report.parse_status, ReviewParseStatus::Structured);
+        assert!(report.parse_repair.is_some(), "Prose JSON must have repair marker");
     }
 
     #[test]

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -3848,6 +3848,15 @@ fn format_review_completion_summary(
             ));
         }
     }
+    // C20.6-A UX-B: surface parse error details.
+    if !report.parse_error.is_empty() {
+        lines.push(String::new());
+        lines.push(format!("  Parse error: {}", report.parse_error));
+        if let Some(ref repair) = report.parse_repair {
+            lines.push(format!("  Parse repair: {repair}"));
+        }
+        lines.push("  Open the Markdown report to inspect the raw output.".to_string());
+    }
     if report.parse_status == runtime::ReviewParseStatus::FallbackRawText {
         lines.push(
             "  Structured parsing failed; open the Markdown report to inspect raw output."
@@ -6305,7 +6314,16 @@ fn load_review_report_from_index_entry(
         .transpose()?
         .unwrap_or(runtime::ReviewParseStatus::FallbackRawText);
 
-    Ok(ReviewReport { findings, raw_text, parse_status })
+    // C20.6-A R2: restore parse diagnostics from persisted artifact JSON.
+    let parse_error = artifact
+        .get("parse_error")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let parse_repair =
+        artifact.get("parse_repair").and_then(serde_json::Value::as_str).map(String::from);
+
+    Ok(ReviewReport { findings, raw_text, parse_status, parse_error, parse_repair })
 }
 
 fn resolve_review_json_path(workspace_root: &Path, entry: &ReviewIndexEntry) -> PathBuf {
@@ -9961,6 +9979,8 @@ UU conflicted.rs",
             }],
             raw_text: String::new(),
             parse_status: runtime::ReviewParseStatus::Structured,
+            parse_error: String::new(),
+            parse_repair: None,
         };
         let artifact = runtime::PersistedReviewArtifact {
             id: "review-abc123".into(),
@@ -10009,6 +10029,8 @@ UU conflicted.rs",
             findings,
             raw_text: String::new(),
             parse_status: runtime::ReviewParseStatus::Structured,
+            parse_error: String::new(),
+            parse_repair: None,
         };
         let artifact = runtime::PersistedReviewArtifact {
             id: "review-limit".into(),
@@ -10030,6 +10052,8 @@ UU conflicted.rs",
             findings: vec![],
             raw_text: String::new(),
             parse_status: runtime::ReviewParseStatus::FallbackRawText,
+            parse_error: String::new(),
+            parse_repair: None,
         };
         let artifact = runtime::PersistedReviewArtifact {
             id: "review-empty".into(),
@@ -10051,6 +10075,8 @@ UU conflicted.rs",
             findings: vec![],
             raw_text: String::new(),
             parse_status: runtime::ReviewParseStatus::ParseAttemptedButFailed,
+            parse_error: String::new(),
+            parse_repair: None,
         };
         let artifact = runtime::PersistedReviewArtifact {
             id: "review-parse-failed".into(),

--- a/rust/crates/rusty-claude-cli/src/nl_intent.rs
+++ b/rust/crates/rusty-claude-cli/src/nl_intent.rs
@@ -40,6 +40,15 @@ pub fn classify_nl_intent_miss(input: &str) -> Option<NlIntentMiss> {
     }
     let normalized = strip_polite_prefix(trimmed);
     let lower = normalized.to_ascii_lowercase();
+    // R4: check export-like phrases before generation requests so that
+    // "generate PR draft" / "生成 issue" route to NeedsMoreDetail, not model.
+    if mentions_export_without_target(normalized, &lower) {
+        return Some(NlIntentMiss::NeedsMoreDetail {
+            action: "导出/保存",
+            example: "把刚才的审查结果写成 E:\\code\\review.md",
+        });
+    }
+
     if is_generation_request(normalized, &lower)
         || has_explanation_verb(normalized, &lower)
         || has_how_to_question(normalized, &lower)
@@ -51,12 +60,6 @@ pub fn classify_nl_intent_miss(input: &str) -> Option<NlIntentMiss> {
         return Some(NlIntentMiss::NeedsMoreDetail {
             action: "切换工作区",
             example: "切换到 D:\\YourProject",
-        });
-    }
-    if mentions_export_without_target(normalized, &lower) {
-        return Some(NlIntentMiss::NeedsMoreDetail {
-            action: "导出/保存",
-            example: "把刚才的审查结果写成 E:\\code\\review.md",
         });
     }
     if mentions_update_without_target(normalized, &lower) {
@@ -403,8 +406,9 @@ fn mentions_workspace_switch_without_path(input: &str, lower: &str) -> bool {
 }
 
 fn mentions_export_without_target(input: &str, lower: &str) -> bool {
-    // C20.5-B: catch fuzzy save/export intents that lack explicit target.
-    // Provide /dir guidance instead of silently routing to model.
+    // C20.6-A R3: catch fuzzy save/export intents that lack explicit target.
+    // Space variants handled by stripping spaces before matching.
+    let compact = input.replace(' ', "");
     matches!(
         lower,
         "export"
@@ -418,8 +422,10 @@ fn mentions_export_without_target(input: &str, lower: &str) -> bool {
             | "write review"
             | "save result"
             | "export result"
+            | "write issue draft"
+            | "generate pr draft"
     ) || matches!(
-        input,
+        compact.as_str(),
         "导出"
             | "保存报告"
             | "导出报告"
@@ -434,9 +440,12 @@ fn mentions_export_without_target(input: &str, lower: &str) -> bool {
             | "写成md"
             | "写成markdown"
             | "输出审查报告"
+            | "输出审查结果"
             | "输出报告"
             | "输出为md"
             | "生成报告"
+            | "生成issue"
+            | "生成PR草稿"
             | "保存全部"
             | "导出全部"
             | "保存所有"
@@ -645,6 +654,45 @@ mod tests {
         assert_eq!(parse_nl_intent("save last_report.md"), None,);
         assert_eq!(parse_nl_intent("what was the last review for this module?"), None);
         assert_eq!(parse_nl_intent("what was the last review for this module"), None);
+    }
+
+    #[test]
+    fn generic_artifact_writing_requests_produce_safe_guidance() {
+        // C20.6-A R2: file-writing requests route to NeedsMoreDetail, not model.
+        for input in [
+            "保存报告",
+            "写成 md",
+            "输出审查结果",
+            "保存为 markdown",
+            "导出为 md",
+            "输出报告",
+            "save report",
+            "export report",
+            "生成 issue",
+            "生成 PR 草稿",
+            "write issue draft",
+            "generate PR draft",
+        ] {
+            let intent = parse_nl_intent(input);
+            assert!(!matches!(intent, Some(NlIntent::ExportLastResponse { .. })));
+            let miss = classify_nl_intent_miss(input);
+            assert!(miss.is_some(), "input {input:?}: Expected NeedsMoreDetail");
+        }
+        // Explicit previous-response markers must still work:
+        assert!(matches!(
+            parse_nl_intent("save the last review to PR43.md"),
+            Some(NlIntent::ExportLastResponse { .. })
+        ));
+    }
+
+    #[test]
+    fn explicit_previous_response_export_with_windows_paths() {
+        assert_eq!(
+            parse_nl_intent(r"把刚才的审查结果写成 E:\code\review-draft-中文报告.md"),
+            Some(NlIntent::ExportLastResponse {
+                path: Some(r"E:\code\review-draft-中文报告.md".to_string())
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- tighten review prompt output contract to require JSON-only output and valid escaped JSON strings
- persist and render review parse diagnostics in JSON/Markdown artifacts
- preserve parse diagnostics when loading review reports
- record JSON candidate extraction source for fenced/prose review output
- add safe guidance coverage for fuzzy report / issue / PR draft artifact-writing requests

## Verification

- cargo fmt --check
- git -C E:\Sego\source diff --check
- cargo test -p runtime code_review
- cargo test -p rusty-claude-cli nl_intent
- cargo test -p rusty-claude-cli export
- cargo test -p rusty-claude-cli review
- cargo build -p rusty-claude-cli

## Reviews

- Codex R5 review: passed
- Sego staged review: review-1782195541-45f8ac535918
- Sego findings disposition: no blocking findings