### PR TITLE
chore(release): publish checksum asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,16 +103,24 @@ jobs:
           cp artifacts/windows-zip/sego-windows.zip artifacts/sego-windows.zip
           cp artifacts/linux/sego artifacts/sego
           cp artifacts/macos/sego artifacts/sego-macos
-      - name: Validate release assets
+      - name: Generate release checksums
+        shell: bash
         run: |
           set -euo pipefail
-          for asset in artifacts/sego.exe artifacts/sego-windows.zip artifacts/sego artifacts/sego-macos; do
+          cd artifacts
+          sha256sum sego.exe sego-windows.zip sego sego-macos > checksums.txt
+          cat checksums.txt
+      - name: Validate release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          for asset in artifacts/sego.exe artifacts/sego-windows.zip artifacts/sego artifacts/sego-macos artifacts/checksums.txt; do
             if [ ! -s "$asset" ]; then
               echo "::error file=$asset::Release asset is missing or empty"
               exit 1
             fi
           done
-          ls -lh artifacts/sego.exe artifacts/sego-windows.zip artifacts/sego artifacts/sego-macos
+          ls -lh artifacts/sego.exe artifacts/sego-windows.zip artifacts/sego artifacts/sego-macos artifacts/checksums.txt
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -121,6 +129,7 @@ jobs:
             artifacts/sego-windows.zip
             artifacts/sego
             artifacts/sego-macos
+            artifacts/checksums.txt
           name: Sego Agent ${{ github.ref_name }}
           body: |
             ## Sego Agent ${{ github.ref_name }}
@@ -161,6 +170,7 @@ jobs:
             - **Windows:** `sego-windows.zip` for double-click use, or `sego.exe` for terminal use
             - **Linux:** `sego`
             - **macOS:** `sego-macos`
+            - **Checksums:** `checksums.txt` contains SHA-256 hashes for all release binaries
 
             ### Quick Start
             ```powershell


### PR DESCRIPTION
## Summary
- Generate `artifacts/checksums.txt` with SHA-256 hashes for release binaries before publishing a GitHub Release.
- Validate `checksums.txt` together with release binaries.
- Upload `checksums.txt` as a release asset and mention it in the release notes download section.

## Verification
- `git diff --check -- .github/workflows/release.yml`
- YAML parse via Python `yaml.safe_load`
- Local bash checksum snippet simulation: 4 checksum lines generated
- Sego staged review: `review-1782233137-166c1e3b8234`, no blocking findings

## Notes
- Current `v0.1.8` release has already been manually updated with `checksums.txt`.
- GPG signing / provenance is intentionally left as follow-up hardening.