### PR TITLE
docs: tighten public project positioning

### DIFF
--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,114 +1,107 @@
 # Sego Agent Philosophy
 
-This document describes the design philosophy and ecosystem behind the Sego Agent project — an AI coding agent that learns from every session.
+This document describes the design philosophy of Sego — a local-first AI code review and engineering trust layer that sits after AI coding tools.
 
-## Stop Staring at the Files
+It is not a technical manual. It explains *why* Sego exists and what it is — and is not — trying to be.
 
-If you only look at the generated files in this repository, you are looking at the wrong layer.
+---
 
-The Python rewrite was a byproduct. The Rust rewrite was also a byproduct. The real thing worth studying is the **system that produced them**: a coordination loop where humans give direction and autonomous agents execute the work.
+## AI code generation needs independent review
 
-Sego is not just a codebase. It is a public demonstration of what happens when:
+AI coding tools (Cursor, Claude Code, Codex, Copilot, and others) generate code faster than ever. That speed has a side effect:
 
-- a human provides clear direction,
-- multiple coding agents coordinate in parallel,
-- notification routing is pushed out of the agent context window,
-- planning, execution, review, and retry loops are automated,
-- and the human does **not** sit in a terminal micromanaging every step.
+> The bottleneck has moved from "writing code" to "deciding whether the code is safe to ship."
 
-## The Human Interface
+Generated code can be syntactically correct, look reasonable, and still contain real risks — SQL injection, hardcoded credentials, broken access control, unsafe shell, brittle architectural assumptions. The tools that write the code are not the best judges of whether the code should be committed:
 
-The important interface here is not tmux, Vim, SSH, or a terminal multiplexer.
+- They have an inherent conflict of interest (they wrote it).
+- They run inside a single session context, not across the whole project.
+- Their "self-review" mode is often a comment, not a structured audit.
 
-The real human interface can be a chat channel. A person can type a sentence from a phone, walk away, sleep, or do something else. The agents read the directive, break it into tasks, assign roles, write code, run tests, argue over failures, recover, and push when the work passes.
+Sego is an **independent** review layer. It does not write the code. Its job is to look at the code AI tools just produced and give a structured opinion on whether the change is ready to commit.
 
-That is the philosophy: **humans set direction; agents perform the labor.**
+---
 
-## The Three-Part System
+## Local-first trust matters for private codebases
 
-### 1. OmX (`oh-my-codex`)
-[oh-my-codex](https://github.com/Yeachan-Heo/oh-my-codex) provides the workflow layer.
+Most code that actually matters is private — internal services, customer projects, in-house libraries, regulated codebases. For that code, "send it to a third-party cloud service to review" is not always acceptable.
 
-It turns short directives into structured execution:
-- planning keywords
-- execution modes
-- persistent verification loops
-- parallel multi-agent workflows
+Sego is local-first:
 
-This is the layer that converts a sentence into a repeatable work protocol.
+- The CLI runs on your machine.
+- Reviews execute against your local working tree.
+- Artifacts are written to your project's `.sego/` directory.
+- No source code, diff, or finding is implicitly shipped off-device by the tool itself.
 
-### 2. clawhip
-[clawhip](https://github.com/Yeachan-Heo/clawhip) is the event and notification router.
+You still pick the model provider (DeepSeek, Anthropic, etc.) for the actual review reasoning, and that provider sees the diff you submit to it — Sego is honest about that boundary. But everything around the model — the orchestration, the artifact, the recovery state — stays on your machine by default.
 
-It watches:
-- git commits
-- tmux sessions
-- GitHub issues and PRs
-- agent lifecycle events
-- channel delivery
+---
 
-Its job is to keep monitoring and delivery **outside** the coding agent's context window so the agents can stay focused on implementation instead of status formatting and notification routing.
+## Artifacts beat chat-only output
 
-### 3. OmO (`oh-my-openagent`)
-[oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) handles multi-agent coordination.
+A "looks fine" reply from a chatbot is not an audit. You cannot file it, link to it from a PR, compare it with a later review, or feed it into a CI gate.
 
-This is where planning, handoffs, disagreement resolution, and verification loops happen across agents.
+Sego treats every review as a real artifact:
 
-When Architect, Executor, and Reviewer disagree, OmO provides the structure for that loop to converge instead of collapse.
+- Structured **findings** (severity, file, line, evidence, risk, suggestion, confidence).
+- A **Markdown report** that a human can read.
+- A **JSON document** that another tool can consume.
+- An **index** so reviews accumulate over time and can be inspected later.
 
-## The Real Bottleneck Changed
+When a review fails to parse cleanly, Sego says so explicitly (`parse_attempted_but_failed`) and points to the raw output. It does not silently present a broken review as "0 findings".
 
-The bottleneck is no longer typing speed.
+The artifact is the unit of trust. Anything that does not produce an artifact does not really exist.
 
-When agent systems can rebuild a codebase in hours, the scarce resource becomes:
-- architectural clarity
-- task decomposition
-- judgment
-- taste
-- conviction about what is worth building
-- knowing which parts can be parallelized and which parts must stay constrained
+---
 
-A fast agent team does not remove the need for thinking. It makes clear thinking even more valuable.
+## Human developers keep final judgment
 
-## What Sego Demonstrates
+Sego does not approve releases. It does not merge PRs. It does not decide that a change is "production ready."
 
-Sego demonstrates that a repository can be:
+A Sego review is **an input** to a human decision. It surfaces what looks risky and explains why; the developer (and, on team projects, the reviewer / release owner) decides what to do with it.
 
-- **autonomously built in public**
-- coordinated by agents rather than human pair-programming alone
-- operated through a chat interface
-- continuously improved by structured planning/execution/review loops
-- maintained as a showcase of the coordination layer, not just the output files
+This is intentional. AI review can:
 
-The code is evidence.
-The coordination system is the product lesson.
+- Miss issues that need real product or business context.
+- Flag things that look risky in isolation but are fine in the larger system.
+- Disagree with itself across runs.
 
-## What Still Matters
+Treating Sego output as advisory keeps responsibility where it belongs — with the people shipping the software.
 
-As coding intelligence gets cheaper and more available, the durable differentiators are not raw coding output.
+---
 
-What still matters:
-- product taste
-- direction
-- system design
-- human trust
-- operational stability
-- judgment about what to build next
+## Sego is an engineering trust layer, not a replacement for developers
 
-In that world, the job of the human is not to out-type the machine.
-The job of the human is to decide what deserves to exist.
+There is a common narrative that AI will "replace developers." Sego is built on the opposite view:
+
+> As AI generates more code, the scarce resource becomes judgment, taste, system design, and accountability — not raw typing speed.
+
+In that world, the durable value of a developer is no longer "can write the code." It is:
+
+- knowing what is worth building,
+- recognizing what is risky to commit,
+- understanding the system the code lives in,
+- and standing behind the result.
+
+Sego is a tool to make that judgment cheaper to exercise — by giving developers an independent, structured, local review they can actually trust as a starting point.
+
+---
+
+## What Sego is not
+
+To make the boundary clear, Sego is intentionally not:
+
+- **Not an IDE or code generator.** It does not autocomplete, refactor, or write features. Use your favorite AI coding tool for that.
+- **Not a static analyzer.** It is a model-driven review. It is complementary to lint, SAST, fuzzing, and formal verification — not a replacement.
+- **Not a guarantee of bug-free code.** A clean Sego review is one input among several (tests, CI, human review, security tooling). It is never the only gate.
+- **Not a cloud platform.** It runs locally. Any future team or cloud features will be opt-in, on top of the local-first baseline.
+
+---
 
 ## Short Version
 
-**Sego is a demo of autonomous software development.**
+AI writes code. Sego helps you decide whether it is safe to commit.
 
-Humans provide direction.
-Agents coordinate, build, test, recover, and push.
-The repository is the artifact.
-The philosophy is the system behind it.
-
-## Related explanation
-
-For the longer public explanation behind this philosophy, see:
-
-- https://x.com/realsigridjin/status/2039472968624185713
+The code is the AI tool's output.
+The judgment is still yours.
+Sego is the structured layer in between.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ sego /review safety staged # staged 安全锁
 切换到 D:\YourProject
 帮我 review 当前改动
 检查安全问题
-把刚才的审查结果写成 E:\code\review.md
+把刚才的审查结果写成 ./review.md
 导出当前会话
 检查更新
 退出
@@ -175,7 +175,7 @@ sego --permission-profile review-trust
 
 `--permission-mode` 和 `--permission-profile` 互斥（不能同时使用）。
 
-### 5. Sidecar JSON 接口（PoC）
+### 5. Sidecar JSON 接口（PoC / experimental）
 
 ```bash
 echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' \
@@ -185,10 +185,10 @@ echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' 
 让外部工具通过 stdin/stdout JSON 调用 Sego 的审查能力：
 
 - stdin 接收 JSON request → stdout 返回 JSON response
-- skill 包（`skills/sego-review/`）可被 Claude Code / Codex / Cursor / 任何 SKILL.md 兼容工具调用
+- skill 包（`skills/sego-review/`）可被支持 SKILL.md 协议的 AI 编码工具调用
 - 错误时返回结构化 error envelope（不崩溃）
 
-> **PoC 状态**：sidecar 当前仅支持 `review` action；stdout 保持 JSON 输出，诊断信息走 stderr。
+> **PoC 状态**：sidecar 当前仅支持 `review` action；stdout 保持 JSON 输出，诊断信息走 stderr。协议与 schema 仍可能调整，不承诺向后兼容。
 
 ### 6. 验证计划
 
@@ -201,7 +201,7 @@ sego /verify         # 完整验证
 
 ### 7. 接入 AI 编码工具（Sidecar skill PoC）
 
-Sego 提供一个 sidecar skill 包，让你的 AI 编码工具（Claude Code、Codex、Cursor 等）能自动调用 Sego review。
+Sego 提供一个 sidecar skill 包，让支持 SKILL.md 协议的 AI 编码工具能调用 Sego review。
 
 **一键安装**：
 
@@ -213,16 +213,16 @@ bash skills/sego-review/install.sh
 powershell -File skills\sego-review\install.ps1
 ```
 
-脚本会自动检测已安装的 AI 工具（Claude Code / Codex / Zcode / Cursor），复制 skill 包到对应目录。安装后重启你的 AI 编码工具即可。
+脚本会检测已安装的兼容 AI 工具并复制 skill 包到对应目录，安装后重启目标工具即可。
 
-**手动调用**（不依赖 IDE）：
+**手动调用**（不依赖任何 IDE）：
 
 ```bash
 echo '{"schema_version":1,"action":"review","cwd":"/your/project","scope":"staged"}' \
   | sego sidecar review
 ```
 
-> **PoC 状态**：sidecar skill 当前仅支持 `review` action。这是早期集成（early integration），不承诺完整 IDE 插件生态。
+> **PoC 状态**：sidecar skill 当前仅支持 `review` action。这是早期集成（experimental），不承诺完整 IDE 插件生态，也不承诺与任何具体外部工具的稳定契约。
 
 ---
 
@@ -268,31 +268,30 @@ def check_access(user, action):
 
 ## 架构
 
+Sego 是一套本地优先的代码审查与工程信任层，公开层面可以分为以下几层：
+
 ```
-Sego Agent (Rust workspace, 9 crates)
-├── rusty-claude-cli    CLI 主入口 + sidecar JSON 接口
-├── runtime             核心运行时（session / permissions / code_review / recovery）
-├── api                 多模型 provider（DeepSeek / Anthropic）
-├── commands            slash 命令注册
-├── tools               工具注册
-├── plugins             插件系统
-└── telemetry / compat-harness / mock-anthropic-service
+Sego Agent (local-first, Rust-native)
+├── Local CLI 层         交互入口、slash 命令、自然语言本地动作、会话恢复
+├── Review 运行时        代码审查执行、permissions、verification、recovery
+├── 模型 Provider 层     DeepSeek / Anthropic 等多模型 provider 抽象
+├── Artifact 层          `.sego/reviews/` 结构化产物（JSON + Markdown + index）
+└── Integration 层       Sidecar / JSON Schema / Skill 包（experimental, PoC）
 
-.sego/ artifact（运行时产物，git 忽略）
-├── reviews/            审查 artifact（JSON + MD + index）
-└── recovery/           崩溃恢复状态
+.sego/                   运行时产物，默认 git 忽略
+├── reviews/             审查 artifact（JSON + MD + index）
+└── recovery/            崩溃恢复状态
 
-schema/                 JSON Schema 公开契约（仓库根，进 GitHub）
+schema/                  JSON Schema 公开契约（仓库根，进 GitHub）
 ├── review-artifact.schema.json
 ├── review-index-entry.schema.json
 └── sidecar-request-response.schema.json
-
-skills/sego-review/     Sidecar skill 包（SKILL.md + 脚本）
 ```
 
-- **纯 Rust**，`unsafe_code = "forbid"`，clippy pedantic
-- **本地优先**：所有 artifact 存在项目 `.sego/` 目录，数据不出域
-- **diff_hash 绑定**：review/verify 指向同一代码差异，防止"审查 A 提交 B"
+- **纯 Rust，本地优先**：`unsafe_code = "forbid"`，clippy pedantic。
+- **数据不出域**：所有 artifact 存在项目 `.sego/` 目录。
+- **diff_hash 绑定**：review/verify 指向同一代码差异，防止"审查 A 提交 B"。
+- **Integration 层目前是 experimental / PoC**：sidecar 协议、JSON Schema、skill 包属于早期集成，不承诺稳定生态契约，后续可能演进。
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,366 +1,77 @@
-# ROADMAP.md
-
 # Sego Agent Roadmap
 
-## Goal
-
-Turn claw-code into the most **clawable** coding harness:
-- no human-first terminal assumptions
-- no fragile prompt injection timing
-- no opaque session state
-- no hidden plugin or MCP failures
-- no manual babysitting for routine recovery
-
-This roadmap assumes the primary users are **claws wired through hooks, plugins, sessions, and channel events**.
-
-## Definition of "clawable"
-
-A clawable harness is:
-- deterministic to start
-- machine-readable in state and failure modes
-- recoverable without a human watching the terminal
-- branch/test/worktree aware
-- plugin/MCP lifecycle aware
-- event-first, not log-first
-- capable of autonomous next-step execution
-
-## Current Pain Points
-
-### 1. Session boot is fragile
-- trust prompts can block TUI startup
-- prompts can land in the shell instead of the coding agent
-- "session exists" does not mean "session is ready"
-
-### 2. Truth is split across layers
-- tmux state
-- clawhip event stream
-- git/worktree state
-- test state
-- gateway/plugin/MCP runtime state
-
-### 3. Events are too log-shaped
-- claws currently infer too much from noisy text
-- important states are not normalized into machine-readable events
-
-### 4. Recovery loops are too manual
-- restart worker
-- accept trust prompt
-- re-inject prompt
-- detect stale branch
-- retry failed startup
-- classify infra vs code failures manually
-
-### 5. Branch freshness is not enforced enough
-- side branches can miss already-landed main fixes
-- broad test failures can be stale-branch noise instead of real regressions
-
-### 6. Plugin/MCP failures are under-classified
-- startup failures, handshake failures, config errors, partial startup, and degraded mode are not exposed cleanly enough
-
-### 7. Human UX still leaks into claw workflows
-- too much depends on terminal/TUI behavior instead of explicit agent state transitions and control APIs
-
-## Product Principles
-
-1. **State machine first** — every worker has explicit lifecycle states.
-2. **Events over scraped prose** — channel output should be derived from typed events.
-3. **Recovery before escalation** — known failure modes should auto-heal once before asking for help.
-4. **Branch freshness before blame** — detect stale branches before treating red tests as new regressions.
-5. **Partial success is first-class** — e.g. MCP startup can succeed for some servers and fail for others, with structured degraded-mode reporting.
-6. **Terminal is transport, not truth** — tmux/TUI may remain implementation details, but orchestration state must live above them.
-7. **Policy is executable** — merge, retry, rebase, stale cleanup, and escalation rules should be machine-enforced.
-
-## Roadmap
-
-## Phase 1 — Reliable Worker Boot
-
-### 1. Ready-handshake lifecycle for coding workers
-Add explicit states:
-- `spawning`
-- `trust_required`
-- `ready_for_prompt`
-- `prompt_accepted`
-- `running`
-- `blocked`
-- `finished`
-- `failed`
-
-Acceptance:
-- prompts are never sent before `ready_for_prompt`
-- trust prompt state is detectable and emitted
-- shell misdelivery becomes detectable as a first-class failure state
-
-### 2. Trust prompt resolver
-Add allowlisted auto-trust behavior for known repos/worktrees.
-
-Acceptance:
-- trusted repos auto-clear trust prompts
-- events emitted for `trust_required` and `trust_resolved`
-- non-allowlisted repos remain gated
-
-### 3. Structured session control API
-Provide machine control above tmux:
-- create worker
-- await ready
-- send task
-- fetch state
-- fetch last error
-- restart worker
-- terminate worker
-
-Acceptance:
-- a claw can operate a coding worker without raw send-keys as the primary control plane
-
-## Phase 2 — Event-Native Clawhip Integration
-
-### 4. Canonical lane event schema
-Define typed events such as:
-- `lane.started`
-- `lane.ready`
-- `lane.prompt_misdelivery`
-- `lane.blocked`
-- `lane.red`
-- `lane.green`
-- `lane.commit.created`
-- `lane.pr.opened`
-- `lane.merge.ready`
-- `lane.finished`
-- `lane.failed`
-- `branch.stale_against_main`
-
-Acceptance:
-- clawhip consumes typed lane events
-- Discord summaries are rendered from structured events instead of pane scraping alone
-
-### 5. Failure taxonomy
-Normalize failure classes:
-- `prompt_delivery`
-- `trust_gate`
-- `branch_divergence`
-- `compile`
-- `test`
-- `plugin_startup`
-- `mcp_startup`
-- `mcp_handshake`
-- `gateway_routing`
-- `tool_runtime`
-- `infra`
-
-Acceptance:
-- blockers are machine-classified
-- dashboards and retry policies can branch on failure type
-
-### 6. Actionable summary compression
-Collapse noisy event streams into:
-- current phase
-- last successful checkpoint
-- current blocker
-- recommended next recovery action
-
-Acceptance:
-- channel status updates stay short and machine-grounded
-- claws stop inferring state from raw build spam
-
-## Phase 3 — Branch/Test Awareness and Auto-Recovery
-
-### 7. Stale-branch detection before broad verification
-Before broad test runs, compare current branch to `main` and detect if known fixes are missing.
-
-Acceptance:
-- emit `branch.stale_against_main`
-- suggest or auto-run rebase/merge-forward according to policy
-- avoid misclassifying stale-branch failures as new regressions
-
-### 8. Recovery recipes for common failures
-Encode known automatic recoveries for:
-- trust prompt unresolved
-- prompt delivered to shell
-- stale branch
-- compile red after cross-crate refactor
-- MCP startup handshake failure
-- partial plugin startup
-
-Acceptance:
-- one automatic recovery attempt occurs before escalation
-- the attempted recovery is itself emitted as structured event data
-
-### 9. Green-ness contract
-Workers should distinguish:
-- targeted tests green
-- package green
-- workspace green
-- merge-ready green
-
-Acceptance:
-- no more ambiguous "tests passed" messaging
-- merge policy can require the correct green level for the lane type
-
-## Phase 4 — Claws-First Task Execution
-
-### 10. Typed task packet format
-Define a structured task packet with fields like:
-- objective
-- scope
-- repo/worktree
-- branch policy
-- acceptance tests
-- commit policy
-- reporting contract
-- escalation policy
-
-Acceptance:
-- claws can dispatch work without relying on long natural-language prompt blobs alone
-- task packets can be logged, retried, and transformed safely
-
-### 11. Policy engine for autonomous coding
-Encode automation rules such as:
-- if green + scoped diff + review passed -> merge to dev
-- if stale branch -> merge-forward before broad tests
-- if startup blocked -> recover once, then escalate
-- if lane completed -> emit closeout and cleanup session
-
-Acceptance:
-- doctrine moves from chat instructions into executable rules
-
-### 12. Claw-native dashboards / lane board
-Expose a machine-readable board of:
-- repos
-- active claws
-- worktrees
-- branch freshness
-- red/green state
-- current blocker
-- merge readiness
-- last meaningful event
-
-Acceptance:
-- claws can query status directly
-- human-facing views become a rendering layer, not the source of truth
-
-## Phase 5 — Plugin and MCP Lifecycle Maturity
-
-### 13. First-class plugin/MCP lifecycle contract
-Each plugin/MCP integration should expose:
-- config validation contract
-- startup healthcheck
-- discovery result
-- degraded-mode behavior
-- shutdown/cleanup contract
-
-Acceptance:
-- partial-startup and per-server failures are reported structurally
-- successful servers remain usable even when one server fails
-
-### 14. MCP end-to-end lifecycle parity
-Close gaps from:
-- config load
-- server registration
-- spawn/connect
-- initialize handshake
-- tool/resource discovery
-- invocation path
-- error surfacing
-- shutdown/cleanup
-
-Acceptance:
-- parity harness and runtime tests cover healthy and degraded startup cases
-- broken servers are surfaced as structured failures, not opaque warnings
-
-## Immediate Backlog (from current real pain)
-
-Priority order: P0 = blocks CI/green state, P1 = blocks integration wiring, P2 = clawability hardening, P3 = swarm-efficiency improvements.
-
-**P0 — Fix first (CI reliability)**
-1. Isolate `render_diff_report` tests into tmpdir — flaky under `cargo test --workspace`; reads real working-tree state; breaks CI during active worktree ops
-2. Expand GitHub CI from single-crate coverage to workspace-grade verification — current `rust-ci.yml` runs `cargo fmt` and `cargo test -p rusty-claude-cli`, but misses broader `cargo test --workspace` coverage that already passes locally
-3. Add release-grade binary workflow — repo has a Rust CLI and release intent, but no GitHub Actions path that builds tagged artifacts / checks release packaging before a publish step
-4. Add container-first test/run docs — runtime detects Docker/Podman/container state, but docs do not show a canonical container workflow for `cargo test --workspace`, binary execution, or bind-mounted repo usage
-5. Surface `doctor` / preflight diagnostics in onboarding docs and help — the CLI already has setup-diagnosis commands and branch preflight machinery, but they are not prominent enough in README/USAGE, so new users still ask manual setup questions instead of running a built-in health check first
-6. Add branding/source-of-truth residue checks for docs — after repo migration, old org names can survive in badges, star-history URLs, and copied snippets; docs need a consistency pass or CI lint to catch stale branding automatically
-7. Reconcile README product narrative with current repo reality — top-level docs now say the active workspace is Rust, but later sections still describe the repo as Python-first; users should not have to infer which implementation is canonical
-8. Eliminate warning spam from first-run help/build path — `cargo run -p rusty-claude-cli -- --help` currently prints a wall of compile warnings before the actual help text, which pollutes the first-touch UX and hides the product surface behind unrelated noise
-9. Promote `doctor` from slash-only to top-level CLI entrypoint — users naturally try `claw doctor`, but today it errors and tells them to enter a REPL or resume path first; healthcheck flows should be callable directly from the shell
-10. Make machine-readable status commands actually machine-readable — `status` and `sandbox` accept the global `--output-format json` flag path, but currently still render prose tables, which breaks shell automation and agent-friendly health polling
-11. Unify legacy config/skill namespaces in user-facing output — `skills` currently surfaces mixed project roots like `.codex` and `.claude`, which leaks historical layers into the current product and makes it unclear which config namespace is canonical
-12. Honor JSON output on inventory commands like `skills` and `mcp` — these are exactly the commands agents and shell scripts want to inspect programmatically, but `--output-format json` still yields prose, forcing text scraping where structured inventory should exist
-13. Audit `--output-format` contract across the whole CLI surface — current behavior is inconsistent by subcommand, so agents cannot trust the global flag without command-by-command probing; the format contract itself needs to become deterministic
-
-**P1 — Next (integration wiring, unblocks verification)**
-2. Add cross-module integration tests — **done**: 12 integration tests covering worker→recovery→policy, stale_branch→policy, green_contract→policy, reconciliation flows
-3. Wire lane-completion emitter — **done**: `lane_completion` module with `detect_lane_completion()` auto-sets `LaneContext::completed` from session-finished + tests-green + push-complete → policy closeout
-4. Wire `SummaryCompressor` into the lane event pipeline — **done**: `compress_summary_text()` feeds into `LaneEvent::Finished` detail field in `tools/src/lib.rs`
-
-**P2 — Clawability hardening (original backlog)**
-5. Worker readiness handshake + trust resolution — **done**: `WorkerStatus` state machine with `Spawning` → `TrustRequired` → `ReadyForPrompt` → `PromptAccepted` → `Running` lifecycle, `trust_auto_resolve` + `trust_gate_cleared` gating
-6. Prompt misdelivery detection and recovery — **done**: `prompt_delivery_attempts` counter, `PromptMisdelivery` event detection, `auto_recover_prompt_misdelivery` + `replay_prompt` recovery arm
-7. Canonical lane event schema in clawhip — **done**: `LaneEvent` enum with `Started/Blocked/Failed/Finished` variants, `LaneEvent::new()` typed constructor, `tools/src/lib.rs` integration
-8. Failure taxonomy + blocker normalization — **done**: `WorkerFailureKind` enum (`TrustGate/PromptDelivery/Protocol/Provider`), `FailureScenario::from_worker_failure_kind()` bridge to recovery recipes
-9. Stale-branch detection before workspace tests — **done**: `stale_branch.rs` module with freshness detection, behind/ahead metrics, policy integration
-10. MCP structured degraded-startup reporting — **done**: `McpManager` degraded-startup reporting (+183 lines in `mcp_stdio.rs`), failed server classification (startup/handshake/config/partial), structured `failed_servers` + `recovery_recommendations` in tool output
-11. Structured task packet format — **done**: `task_packet.rs` module with `TaskPacket` struct, validation, serialization, `TaskScope` resolution (workspace/module/single-file/custom), integrated into `tools/src/lib.rs`
-12. Lane board / machine-readable status API — **done**: Lane completion hardening + `LaneContext::completed` auto-detection + MCP degraded reporting surface machine-readable state
-13. **Session completion failure classification** — **done**: `WorkerFailureKind::Provider` + `observe_completion()` + recovery recipe bridge landed
-14. **Config merge validation gap** — **done**: `config.rs` hook validation before deep-merge (+56 lines), malformed entries fail with source-path context instead of merged parse errors
-15. **MCP manager discovery flaky test** — `manager_discovery_report_keeps_healthy_servers_when_one_server_fails` has intermittent timing issues in CI; temporarily ignored, needs root cause fix
-
-16. **Commit provenance / worktree-aware push events** — clawhip build stream shows duplicate-looking commit messages and worktree-originated pushes without clear supersession indicators; add worktree/branch metadata to push events and de-dup superseded commits in build stream display
-17. **Orphaned module integration audit** — `session_control` is `pub mod` exported from `runtime` but has zero consumers across the entire workspace (no import, no call site outside its own file). `trust_resolver` types are re-exported from `lib.rs` but never instantiated outside unit tests. These modules implement core clawability contracts (session management, trust resolution) that are structurally dead — built but not wired into the CLI or tools crate. **Action:** audit all `pub mod` / `pub use` exports from `runtime` for actual call sites; either wire orphaned modules into the real execution path or demote to `pub(crate)` / `cfg(test)` to prevent false clawability surface.
-18. **Context-window preflight gap** — claw-code auto-compacts only after cumulative input crosses a static `100_000`-token threshold, while provider requests derive `max_tokens` from a naive model-name heuristic (`opus` => 32k, else 64k) and do not appear to preflight `estimated_prompt_tokens + requested_output_tokens` against the selected model’s actual context window. Result: giant sessions can be sent upstream and fail hard with provider-side `input_exceeds_context_by_*` errors instead of local preflight compaction/rejection. **Action:** add a model-context registry + request-size preflight before provider call; if projected request exceeds context, emit a structured `context_window_blocked` event and auto-compact or force `/compact` before retry.
-19. **Subcommand help falls through into runtime/API path** — direct dogfood shows `./target/debug/claw doctor --help` and `./target/debug/claw status --help` do not render local subcommand help. Instead they enter the request path, show `🦀 Thinking...`, then fail with `api returned 500 ... auth_unavailable: no auth available`. Help/usage surfaces must be pure local parsing and never require auth or provider reachability. **Action:** fix argv dispatch so `<subcommand> --help` is intercepted before runtime startup/API client initialization; add regression tests for `doctor --help`, `status --help`, and similar local-info commands.
-
-**P3 — Swarm efficiency**
-13. Swarm branch-lock protocol — detect same-module/same-branch collision before parallel workers drift into duplicate implementation
-14. Commit provenance / worktree-aware push events — emit branch, worktree, superseded-by, and canonical commit lineage so parallel sessions stop producing duplicate-looking push summaries
-
-## Suggested Session Split
-
-### Session A — worker boot protocol
-Focus:
-- trust prompt detection
-- ready-for-prompt handshake
-- prompt misdelivery detection
-
-### Session B — clawhip lane events
-Focus:
-- canonical lane event schema
-- failure taxonomy
-- summary compression
-
-### Session C — branch/test intelligence
-Focus:
-- stale-branch detection
-- green-level contract
-- recovery recipes
-
-### Session D — MCP lifecycle hardening
-Focus:
-- startup/handshake reliability
-- structured failed server reporting
-- degraded-mode runtime behavior
-- lifecycle tests/harness coverage
-
-### Session E — typed task packets + policy engine
-Focus:
-- structured task format
-- retry/merge/escalation rules
-- autonomous lane closure behavior
-
-## MVP Success Criteria
-
-We should consider claw-code materially more clawable when:
-- a claw can start a worker and know with certainty when it is ready
-- claws no longer accidentally type tasks into the shell
-- stale-branch failures are identified before they waste debugging time
-- clawhip reports machine states, not just tmux prose
-- MCP/plugin startup failures are classified and surfaced cleanly
-- a coding lane can self-recover from common startup and branch issues without human babysitting
-
-## Short Version
-
-claw-code should evolve from:
-- a CLI a human can also drive
-
-to:
-- a **claw-native execution runtime**
-- an **event-native orchestration substrate**
-- a **plugin/hook-first autonomous coding harness**
+This is the public roadmap for Sego — a local-first code review and engineering trust layer that sits after AI coding tools.
+
+The intent of this roadmap is to give users, contributors, and integrators a clear view of where Sego is going, without making promises about exact dates or feature ordering. Items move based on user feedback and real release readiness, not pre-set timelines.
+
+For what is already shipped today, see the [CHANGELOG](CHANGELOG.md) and the [latest GitHub Release](https://github.com/007M7/Sego-Agent/releases/latest).
+
+---
+
+## Recently Shipped (v0.1.8)
+
+The `v0.1.8` release focused on review reliability, diagnosability, and task-file safety:
+
+- **Review parser hardening** — structured findings, fenced JSON / pretty JSON / raw JSON parsing, and an explicit `parse_attempted_but_failed` state so an unparsable review never silently looks like "0 findings".
+- **Evidence gate and recovery guidance** — review findings carry clearer evidence status; non-Git directories, recovered sessions, and path-sensitive workspaces get structured next-step hints instead of opaque errors.
+- **Task-file review command execution** — task files that explicitly require `/review staged`, `/review workspace`, or allowlisted `--full <path>` review can have the review executed directly; unsupported commands (`/commit`, `dotnet build`, free-form prose, combined `/cd ... && /review ...`) are blocked with structured guidance instead of silently entering model conversation.
+- **Natural-language export safety boundary** — phrases like "save the last report" or "export the previous response" are bound to the latest / previous confirmable response, not treated as arbitrary file-write commands.
+- **Release packaging** — release workflow generates, validates, uploads, and documents `checksums.txt` so users can verify downloaded binaries.
+
+---
+
+## Near-Term Focus
+
+Quality and trust on top of the existing review workflow.
+
+- **Review artifact contract / schema** — keep `.sego/reviews/` artifacts forward-compatible; tighten the JSON Schema so external tools can rely on the format.
+- **Install verification and tag-pinned install guidance** — make it easier for new users to verify they installed a real Sego release and pin to a known version.
+- **Release provenance and signing** — improve integrity of release artifacts beyond the current checksum file.
+- **Windows / macOS CI matrix** — extend pre-merge CI coverage so platform-specific regressions are caught earlier.
+- **CI quality gate hardening** — turn currently advisory checks into blocking ones as the warning baseline becomes clean.
+- **Public docs cleanup** — keep README, USAGE, and the Chinese user guide aligned with the latest release behavior; avoid stale wording or internal vocabulary leaking into public docs.
+
+---
+
+## Mid-Term Direction
+
+Make Sego review trustworthy enough to live inside team and enterprise workflows.
+
+- **Reviewer identity in review artifacts** — record which agent, which model, and which Sego version produced a review so artifacts are clearly attributable.
+- **Review artifact signing** — optional integrity signing (for example sigstore-style) so a downstream consumer can verify a review artifact was not modified after the fact.
+- **GitHub Actions / CI integration** — first-class support for running Sego review inside common CI systems and consuming structured findings.
+- **Enterprise local-first documentation** — Windows execution-policy, proxy / TLS, offline / air-gapped setup, and audit-log expectations.
+- **Session persistence hardening** — better handling of sensitive content in persisted session state.
+
+---
+
+## Long-Term Direction
+
+Position Sego as the "review and trust" layer that other AI coding tools can plug into, while staying local-first by default.
+
+- **Sidecar integrations and ecosystem compatibility** — make the sidecar JSON contract and skill packaging stable enough for AI coding tools and editors that want to call Sego review through a documented interface.
+- **Review output JSON contract precision** — reduce `parse_attempted_but_failed` frequency by tightening the contract the model is asked to honor.
+- **Cross-tool review artifact format** — explore whether the `.sego/reviews/` artifact format can become a public reference that other reviewers and CI tools can consume, not just Sego itself.
+
+These items are exploratory. They depend on user demand, ecosystem maturity, and engineering capacity — they will not be added to a release just to expand surface area.
+
+---
+
+## What Sego Will Not Do
+
+- **Replace developers or human review for high-risk releases.** Sego is a trust layer that helps developers judge AI-generated code; it does not remove the need for human judgment.
+- **Promise exhaustive static analysis or bug completeness.** `sego review` (including `--full`) reviews key manifests, entry points, and a directory context snapshot. It is model-driven and is not a substitute for proven static analyzers, security scanners, or formal verification.
+- **Execute arbitrary unsupported commands from task files.** Only allowlisted review commands run; everything else is blocked with structured guidance.
+- **Force a cloud-first workflow.** Sego stays local-first by default. Any future cloud or team-collaboration mode will be opt-in.
+
+---
+
+## Feedback And Direction
+
+Roadmap direction is driven by:
+
+- real user feedback and audit reports,
+- release-blocker findings from Sego's own pre-release review,
+- contributor input through GitHub Issues and PRs.
+
+If a use case you care about is missing, please open an issue with concrete context (project type, AI coding tool you are using, what you wanted Sego to confirm). Concrete usage stories move items up the roadmap faster than feature requests in the abstract.

--- a/docs/LAUNCH.md
+++ b/docs/LAUNCH.md
@@ -31,14 +31,13 @@ Do not include secrets, credentials, private customer data, or private source co
 
 ## Private AI Code Audit
 
-For private projects, paid audits start at:
+For private projects, audits are available **by scope confirmation only**.
 
-- $19 / RMB 99 for a basic private audit
-- $99 / RMB 699 for a launch check
+Before sending any private code:
 
-Overseas payments are currently accepted through BNB Chain only. Please request
-scope confirmation first; do not send payment before the audit scope, price,
-delivery window, and payment details are confirmed.
+1. Request scope confirmation through the link below.
+2. Wait for the audit scope, delivery window, and handling process to be confirmed in writing.
+3. Do not send private code, credentials, or payment before that confirmation.
 
 Request scope confirmation here:
 


### PR DESCRIPTION
## Summary
- tighten public README architecture wording to avoid unnecessary internal module detail
- remove early pricing/payment details from launch docs
- rewrite roadmap and philosophy as external-readable Sego product docs
- remove internal collaboration vocabulary from public docs

## Verification
- git diff --check
- rg public-overdisclosure guard terms across README, LAUNCH, ROADMAP, PHILOSOPHY
