### PR TITLE
feat(review): document agent-callable proof contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Sego Agent project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **C21 agent-callable review proof**: documented the public review artifact contract, agent handoff workflow, and integration templates so AI coding agents can call Sego after code generation and explain the resulting proof to users.
+- **Reviewer identity metadata**: new review artifacts now include local trust metadata (`reviewer`, `engine_version`, `review_mode`). These fields are attribution/debug metadata, not cryptographic signatures or provenance attestations.
+
+### Changed
+- Updated review artifact JSON Schemas to include current parse/evidence status values (`parse_attempted_but_failed`, `evidence_status`) plus optional C21 metadata fields.
+
 ## [0.1.8] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -175,7 +175,17 @@ sego --permission-profile review-trust
 
 `--permission-mode` 和 `--permission-profile` 互斥（不能同时使用）。
 
-### 5. Sidecar JSON 接口（PoC / experimental）
+### 5. Review artifact contract
+
+Every Sego review writes machine-readable and human-readable proof artifacts under `.sego/reviews/`:
+
+- `review-<id>.json` — machine-readable review artifact
+- `review-<id>.md` — human-readable report
+- `index.jsonl` — append-only index so agents can find the latest review
+
+See [`docs/REVIEW_ARTIFACT_CONTRACT.md`](docs/REVIEW_ARTIFACT_CONTRACT.md) for the public field contract and [`docs/AGENT_REVIEW_HANDOFF.md`](docs/AGENT_REVIEW_HANDOFF.md) for the recommended agent handoff workflow.
+
+### 6. Sidecar JSON 接口（PoC / experimental）
 
 ```bash
 echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' \
@@ -190,7 +200,7 @@ echo '{"schema_version":1,"action":"review","cwd":"/project","scope":"staged"}' 
 
 > **PoC 状态**：sidecar 当前仅支持 `review` action；stdout 保持 JSON 输出，诊断信息走 stderr。协议与 schema 仍可能调整，不承诺向后兼容。
 
-### 6. 验证计划
+### 7. 验证计划
 
 ```bash
 sego /verify fast    # 快速验证计划
@@ -199,7 +209,7 @@ sego /verify         # 完整验证
 
 根据项目类型识别验证命令（Rust: cargo build/test，Node: npm test/build）。
 
-### 7. 接入 AI 编码工具（Sidecar skill PoC）
+### 8. 接入 AI 编码工具（Sidecar skill PoC）
 
 Sego 提供一个 sidecar skill 包，让支持 SKILL.md 协议的 AI 编码工具能调用 Sego review。
 

--- a/docs/AGENT_INTEGRATION_TEMPLATES.md
+++ b/docs/AGENT_INTEGRATION_TEMPLATES.md
@@ -1,0 +1,101 @@
+# Agent Integration Templates
+
+Copy one of these templates into the instruction file used by your AI coding tool. Adjust paths and commands for your project.
+
+These templates are intentionally generic. They do not depend on a private Sego setup or maintainer machine path.
+
+---
+
+## 1. Minimal `AGENTS.md` snippet
+
+````md
+## Sego review handoff
+
+After generating or modifying code, especially before a PR or release, run an independent Sego review when possible:
+
+```bash
+sego /review staged
+```
+
+If changes are not staged, use:
+
+```bash
+sego /review workspace
+```
+
+After the review, read `.sego/reviews/index.jsonl`, open the latest JSON artifact, and summarize:
+
+- review id,
+- scope,
+- finding count,
+- highest severity,
+- parse status,
+- top findings with file/line evidence,
+- Markdown report path.
+
+Do not claim Sego approved the code. Sego is an independent review signal, not a guarantee. Ask the user whether each finding is confirmed, false positive, accepted risk, or deferred.
+````
+
+---
+
+## 2. Claude / Codex / Cursor-style instruction snippet
+
+```text
+When you complete a non-trivial code change, run Sego review before presenting the change as ready.
+
+Preferred command:
+  sego /review staged
+
+If there are unstaged workspace changes:
+  sego /review workspace
+
+Then read the latest entry from .sego/reviews/index.jsonl and parse the referenced JSON artifact.
+Explain the result to the user with:
+  - review id
+  - finding count
+  - highest severity
+  - parse status
+  - top findings and evidence
+  - Markdown report path
+
+Never say "Sego approved this". Say "Sego produced a review proof" and ask the user how to handle findings.
+```
+
+---
+
+## 3. Risk-trigger snippet
+
+```text
+If a change touches authentication, authorization, billing, database migrations, secrets, dependency versions, filesystem access, network calls, or data-flow logic, run Sego before marking the task complete.
+```
+
+---
+
+## 4. Finding disposition snippet
+
+```text
+For each Sego finding, record one disposition:
+
+- confirmed: valid finding, fix or add tests
+- false_positive: not valid, explain why
+- accepted_risk: valid risk accepted by user
+- deferred: valid or unresolved, moved to later task
+
+Do not silently drop findings.
+```
+
+---
+
+## 5. Review artifact contract
+
+For field meanings and stable/experimental status, see:
+
+```text
+docs/REVIEW_ARTIFACT_CONTRACT.md
+```
+
+For the recommended handoff workflow, see:
+
+```text
+docs/AGENT_REVIEW_HANDOFF.md
+```

--- a/docs/AGENT_REVIEW_HANDOFF.md
+++ b/docs/AGENT_REVIEW_HANDOFF.md
@@ -1,0 +1,160 @@
+# Agent Review Handoff Playbook
+
+This document explains when and how an AI coding agent should call Sego and how it should present Sego review proof to a user.
+
+Sego is an independent proof engine. It is meant to run **after** an agent generates or changes code, and **before** the user accepts risk, opens a PR, or ships.
+
+---
+
+## 1. When to call Sego
+
+An AI coding agent should consider calling Sego:
+
+- after generating or modifying code,
+- before opening a pull request,
+- before a release or deployment step,
+- after a major refactor,
+- after changing authentication, authorization, billing, database, filesystem, network, dependency, or security-sensitive code,
+- after changing tests that are intended to prove safety,
+- when a task file explicitly requires `/review staged`, `/review workspace`, or an allowlisted full review.
+
+Sego should not be called as a substitute for tests or human judgment. It is an additional independent review signal.
+
+---
+
+## 2. Recommended command flow
+
+### Review staged changes
+
+```bash
+sego /review staged
+```
+
+Use when the agent has staged a focused change.
+
+### Review workspace changes
+
+```bash
+sego /review workspace
+```
+
+Use when changes are present but not staged.
+
+### Review a repository snapshot
+
+```bash
+sego review --full /path/to/project
+```
+
+Use for clean cloned repositories or non-Git directories. This is a manifest / entry-point / context snapshot review, not exhaustive static analysis.
+
+---
+
+## 3. How to read the latest proof
+
+Recommended machine-readable path:
+
+1. Open `.sego/reviews/index.jsonl`.
+2. Read the last non-empty line.
+3. Parse `json_path` and open the referenced JSON artifact.
+4. Use the artifact fields documented in `docs/REVIEW_ARTIFACT_CONTRACT.md`.
+5. Link the user to `markdown_path` for human-readable details.
+
+If `index.jsonl` is missing, no review artifact has been written in this workspace yet.
+
+---
+
+## 4. What to summarize to the user
+
+A calling agent should present the result in a short, conservative form:
+
+```text
+Sego review: <id>
+Scope: <scope>
+Findings: <finding_count>
+Highest severity: <highest_severity or none>
+Parse status: <parse_status>
+Report: <markdown_path>
+```
+
+Then list only the most important findings, preserving file/line/evidence details.
+
+Example:
+
+```text
+Sego produced review review-1782600000-ab12cd34ef56.
+It found 2 findings; highest severity is high.
+The most important finding is in src/auth.rs:42: missing authorization check before account update.
+Please review .sego/reviews/review-1782600000-ab12cd34ef56.md before accepting or shipping the change.
+```
+
+---
+
+## 5. Finding disposition template
+
+When a user responds to a finding, keep the disposition explicit:
+
+```text
+Finding: <finding id or title>
+Disposition: confirmed | false_positive | accepted_risk | deferred
+Reason: <short explanation>
+Next action: <fix now | add test | document risk | defer to ticket>
+Owner: <optional>
+```
+
+Suggested meanings:
+
+| Disposition | Meaning |
+|---|---|
+| `confirmed` | The finding is valid and should be fixed or tested. |
+| `false_positive` | The finding is not valid; record why. |
+| `accepted_risk` | The finding is valid, but the user intentionally accepts the risk. |
+| `deferred` | The finding is valid or unresolved, but action is moved to a later task. |
+
+Do not silently ignore Sego findings. If the user decides not to fix one, record the reason.
+
+---
+
+## 6. Standard prompt snippets for AI coding agents
+
+### After code generation
+
+```text
+I changed the code. Before I ask you to accept it, I will run Sego review on the changed scope and summarize the review proof. I will not treat Sego as an automatic approval; I will show findings and ask you to decide what to do.
+```
+
+### Before PR
+
+```text
+Before opening a PR, run Sego on the staged changes. Then read the latest `.sego/reviews/index.jsonl` entry, open the JSON artifact, and summarize finding count, highest severity, parse status, and the top findings with file/line evidence.
+```
+
+### After risky changes
+
+```text
+This change touches a sensitive area (auth, billing, database, dependency, filesystem, network, or data flow). Run Sego review before presenting the change as ready.
+```
+
+---
+
+## 7. What not to claim
+
+A calling agent must not claim:
+
+- "Sego approved this code."
+- "Sego guarantees this is safe."
+- "All issues are fixed" unless the fixes and tests are actually present.
+- "No risk" when `parse_status` is `fallback_raw_text` or `parse_attempted_but_failed`.
+- "Verified" unless evidence is present in the captured review target and the artifact says so.
+
+Safer wording:
+
+```text
+Sego found no structured findings in this run, but this is not a guarantee. Please still review tests and behavior before shipping.
+```
+
+---
+
+## 8. Integration templates
+
+External users can copy the examples in `docs/AGENT_INTEGRATION_TEMPLATES.md` into an `AGENTS.md`, `CLAUDE.md`, Cursor rule file, or another AI coding tool instruction file.

--- a/docs/REVIEW_ARTIFACT_CONTRACT.md
+++ b/docs/REVIEW_ARTIFACT_CONTRACT.md
@@ -1,0 +1,174 @@
+# Sego Review Artifact Contract
+
+This document describes the public, agent-readable review proof artifacts written by Sego under `.sego/reviews/`.
+
+Sego is not a code generator. Sego is an independent review/proof engine that can be called after another AI coding agent generates or changes code. The review artifact is the handoff object that another agent can read and explain to a user.
+
+---
+
+## 1. Artifact locations
+
+A review run writes files under the current project's `.sego/reviews/` directory:
+
+```text
+.sego/reviews/
+├── review-<epoch>-<hash>.json   machine-readable review artifact
+├── review-<epoch>-<hash>.md     human-readable Markdown report
+├── index.jsonl                  append-only review index, one JSON object per line
+└── status.jsonl                 optional finding disposition updates
+```
+
+The `.sego/` directory is runtime output and is normally git-ignored. Do not commit private review artifacts unless you intentionally want to publish them.
+
+---
+
+## 2. Which file should an agent read?
+
+For an agent integration, the recommended read path is:
+
+1. Read `.sego/reviews/index.jsonl`.
+2. Select the last non-empty line.
+3. Read `json_path` from that index entry.
+4. Parse that JSON artifact.
+5. Explain the summary and findings to the user.
+
+Agents should use the JSON artifact for machine-readable data and link to the Markdown report for human details.
+
+---
+
+## 3. Stability policy
+
+| Field / file | Stability | Notes |
+|---|---|---|
+| `.sego/reviews/index.jsonl` line format | stable | Agents may use it to find the latest artifact. |
+| `schema_version` | stable | Current value: `1`. |
+| `id`, `created_at_epoch_seconds`, `scope`, `diff_hash` | stable | Core artifact identity fields. |
+| `finding_count`, `highest_severity`, `parse_status`, `findings` | stable | Core summary and finding fields. |
+| `reviewer`, `engine_version`, `review_mode` | stable-additive | Added in C21; absent in older artifacts. They are local trust metadata, not signatures. |
+| `parse_error`, `parse_repair` | stable-additive | Optional parser diagnostics. |
+| `evidence_status` | stable-additive | Optional per-finding deterministic evidence status. |
+| `raw_text` | stable but human-oriented | Useful for debugging; agents should not rely on its prose format. |
+| `status.jsonl` | experimental | Finding lifecycle/disposition updates may evolve. |
+| Markdown report formatting | human-readable, not machine contract | Do not parse the Markdown table as the primary API. |
+
+Stable-additive means a field can be added or absent without breaking old artifacts. Consumers should tolerate missing optional fields.
+
+---
+
+## 4. Minimal review artifact example
+
+```json
+{
+  "schema_version": 1,
+  "id": "review-1782600000-ab12cd34ef56",
+  "created_at_epoch_seconds": 1782600000,
+  "reviewer": "sego",
+  "engine_version": "0.1.9",
+  "review_mode": "model_code_review",
+  "scope": "staged",
+  "diff_hash": "ab12cd34ef56...",
+  "finding_count": 1,
+  "highest_severity": "medium",
+  "parse_status": "structured",
+  "git_status": "## main...origin/main",
+  "findings": [
+    {
+      "id": "finding-123456789abc",
+      "severity": "medium",
+      "file": "src/auth.rs",
+      "line": 42,
+      "title": "Missing authorization check before account update",
+      "evidence": "The update handler writes account data before checking the caller role.",
+      "risk": "A non-admin caller may update another user's account.",
+      "suggestion": "Check the caller role and account ownership before performing the write.",
+      "confidence": 0.82,
+      "verification_hint": "Add an integration test for a non-admin caller updating another account.",
+      "evidence_status": "verified"
+    }
+  ],
+  "raw_text": "..."
+}
+```
+
+---
+
+## 5. Important field meanings
+
+### `parse_status`
+
+| Value | Meaning |
+|---|---|
+| `structured` | Sego parsed structured findings from model output. |
+| `fallback_raw_text` | Sego did not get structured findings and preserved raw output. |
+| `parse_attempted_but_failed` | The output looked findings-like, but structured parsing failed. Do not treat this as a clean "0 findings" review. Read the Markdown/raw output. |
+
+### `evidence_status`
+
+| Value | Meaning |
+|---|---|
+| `verified` | The cited file/line evidence was found in the captured review target. |
+| `unverified_file` | The cited file was not present in the captured target. |
+| `unverified_line` | The file existed, but the cited line was outside captured range. |
+| `unverified_dependency` | The finding depends on dependency/manifest evidence that was not captured. |
+| `scope_not_captured` | The finding refers to content outside the review scope. |
+| absent / null | Legacy artifact or no deterministic evidence status attached. |
+
+### `highest_severity`
+
+The highest severity among findings, or `null` if there are no findings. Supported values:
+
+```text
+critical, high, medium, low, info
+```
+
+### `reviewer`, `engine_version`, `review_mode`
+
+These identify the local review engine and mode that produced the artifact. They are useful for attribution and debugging.
+
+They are **not** a cryptographic signature, provenance attestation, or certification. Future releases may add signing/provenance separately.
+
+---
+
+## 6. How an agent should explain a Sego proof
+
+A calling agent should explain:
+
+- the review ID,
+- scope,
+- finding count,
+- highest severity,
+- parse status,
+- whether any finding has weak/unverified evidence,
+- where to open the Markdown report,
+- that Sego is an independent review signal, not an automatic approval.
+
+Suggested wording:
+
+```text
+Sego reviewed the latest staged changes and produced review <id>.
+It found <n> finding(s); highest severity is <severity>.
+Parse status is <parse_status>. Evidence status is attached per finding when available.
+Please review the Markdown report before accepting or shipping the changes.
+```
+
+---
+
+## 7. Boundaries
+
+A Sego review artifact is a review proof, not a guarantee.
+
+- It does not replace human review.
+- It does not replace tests, CI, static analysis, or compliance processes.
+- It does not certify that code is safe to ship.
+- It may contain model-driven findings that require human disposition.
+
+Recommended dispositions for each finding:
+
+```text
+confirmed
+false_positive
+accepted_risk
+deferred
+```
+
+See `docs/AGENT_REVIEW_HANDOFF.md` for the recommended agent workflow.

--- a/rust/crates/runtime/src/code_review/report.rs
+++ b/rust/crates/runtime/src/code_review/report.rs
@@ -396,6 +396,16 @@ struct ReviewArtifact {
     schema_version: u32,
     id: String,
     created_at_epoch_seconds: u64,
+    /// C21: local trust metadata identifying the engine that produced this artifact.
+    /// This is not a cryptographic signature or provenance attestation.
+    #[serde(default)]
+    reviewer: String,
+    /// C21: Sego engine version that wrote the artifact. Legacy artifacts default to empty.
+    #[serde(default)]
+    engine_version: String,
+    /// C21: review mode used to produce the artifact (for example, model_code_review).
+    #[serde(default)]
+    review_mode: String,
     scope: String,
     diff_hash: String,
     finding_count: usize,
@@ -488,6 +498,9 @@ pub fn persist_review_artifact(
         schema_version: 1,
         id: id.clone(),
         created_at_epoch_seconds,
+        reviewer: "sego".to_string(),
+        engine_version: env!("CARGO_PKG_VERSION").to_string(),
+        review_mode: "model_code_review".to_string(),
         scope: target.scope.label().clone(),
         diff_hash: diff_hash.clone(),
         finding_count: report.findings.len(),
@@ -624,6 +637,15 @@ fn render_review_markdown(artifact: &ReviewArtifact, report: &ReviewReport) -> S
     output.push_str("# Sego Review Report\n\n");
     let _ = writeln!(output, "- ID: `{}`", artifact.id);
     let _ = writeln!(output, "- Scope: `{}`", artifact.scope);
+    if !artifact.reviewer.is_empty() {
+        let _ = writeln!(output, "- Reviewer: `{}`", artifact.reviewer);
+    }
+    if !artifact.engine_version.is_empty() {
+        let _ = writeln!(output, "- Engine version: `{}`", artifact.engine_version);
+    }
+    if !artifact.review_mode.is_empty() {
+        let _ = writeln!(output, "- Review mode: `{}`", artifact.review_mode);
+    }
     let _ = writeln!(output, "- Diff hash: `{}`", artifact.diff_hash);
     let _ = writeln!(output, "- Findings: `{}`", artifact.finding_count);
     let _ = writeln!(output, "- Parse status: `{}`", artifact.parse_status.label());
@@ -934,6 +956,9 @@ mod tests {
             schema_version: 1,
             id: "rev-test-001".to_string(),
             created_at_epoch_seconds: 1_719_849_600,
+            reviewer: "sego".to_string(),
+            engine_version: "0.1.9-test".to_string(),
+            review_mode: "model_code_review".to_string(),
             scope: "staged".to_string(),
             diff_hash: "sha256:abc123".to_string(),
             finding_count: 1,
@@ -964,6 +989,9 @@ mod tests {
         // Field-by-field round-trip verification.
         assert_eq!(parsed.schema_version, 1);
         assert_eq!(parsed.id, "rev-test-001");
+        assert_eq!(parsed.reviewer, "sego");
+        assert_eq!(parsed.engine_version, "0.1.9-test");
+        assert_eq!(parsed.review_mode, "model_code_review");
         assert_eq!(parsed.scope, "staged");
         assert_eq!(parsed.diff_hash, "sha256:abc123");
         assert_eq!(parsed.finding_count, 1);
@@ -982,6 +1010,12 @@ mod tests {
             "parse_status must be snake_case: {json}"
         );
 
+        assert!(json.contains(r#""reviewer":"sego""#), "reviewer must be serialized: {json}");
+        assert!(
+            json.contains(r#""review_mode":"model_code_review""#),
+            "review_mode must be serialized: {json}"
+        );
+
         // schema_version must be present in JSON (schema required field).
         assert!(json.contains(r#""schema_version":1"#), "schema_version must be in JSON: {json}");
 
@@ -995,6 +1029,9 @@ mod tests {
             schema_version: 1,
             id: "rev-test-002".to_string(),
             created_at_epoch_seconds: 1_719_849_600,
+            reviewer: "sego".to_string(),
+            engine_version: "0.1.9-test".to_string(),
+            review_mode: "model_code_review".to_string(),
             scope: "workspace".to_string(),
             diff_hash: "sha256:none".to_string(),
             finding_count: 0,

--- a/schema/review-artifact.schema.json
+++ b/schema/review-artifact.schema.json
@@ -48,8 +48,12 @@
     "highest_severity": {
       "description": "Highest severity among findings, or null if no findings. Optional in older artifacts.",
       "oneOf": [
-        { "$ref": "#/$defs/severity" },
-        { "type": "null" }
+        {
+          "$ref": "#/$defs/severity"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "parse_status": {
@@ -62,23 +66,58 @@
     "findings": {
       "type": "array",
       "description": "Structured review findings.",
-      "items": { "$ref": "#/$defs/finding" }
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
     },
     "raw_text": {
       "type": "string",
       "description": "Raw model output text before parsing into findings."
+    },
+    "reviewer": {
+      "type": "string",
+      "description": "Local trust metadata identifying the review engine that produced this artifact (for example, sego). Optional for older artifacts. This is not a cryptographic signature."
+    },
+    "engine_version": {
+      "type": "string",
+      "description": "Sego engine version that wrote the artifact. Optional for older artifacts."
+    },
+    "review_mode": {
+      "type": "string",
+      "description": "Review mode used to produce the artifact, for example model_code_review. Optional for older artifacts."
+    },
+    "parse_error": {
+      "type": "string",
+      "description": "Optional parse error diagnostic when parsing was attempted but failed or repaired."
+    },
+    "parse_repair": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Optional parse repair/extraction mode used while parsing model output."
     }
   },
   "$defs": {
     "severity": {
       "type": "string",
       "description": "Review finding severity (snake_case, aligned with Rust ReviewSeverity).",
-      "enum": ["critical", "high", "medium", "low", "info"]
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info"
+      ]
     },
     "parse_status": {
       "type": "string",
       "description": "How the model output was parsed (aligned with Rust ReviewParseStatus).",
-      "enum": ["structured", "fallback_raw_text"]
+      "enum": [
+        "structured",
+        "fallback_raw_text",
+        "parse_attempted_but_failed"
+      ]
     },
     "finding": {
       "type": "object",
@@ -98,13 +137,18 @@
           "description": "Finding identifier (e.g. 'f-001'). Has serde default; may be absent in legacy artifacts.",
           "default": ""
         },
-        "severity": { "$ref": "#/$defs/severity" },
+        "severity": {
+          "$ref": "#/$defs/severity"
+        },
         "file": {
           "type": "string",
           "description": "File path relative to workspace root."
         },
         "line": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "Line number, or null if not applicable.",
           "minimum": 0
         },
@@ -131,10 +175,35 @@
           "maximum": 1
         },
         "verification_hint": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional hint for how to verify the finding."
+        },
+        "evidence_status": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/evidence_status"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional evidence gate status. Absent or null for legacy artifacts."
         }
       }
+    },
+    "evidence_status": {
+      "type": "string",
+      "description": "Evidence gate status attached by Sego when deterministic validation was possible.",
+      "enum": [
+        "verified",
+        "unverified_file",
+        "unverified_line",
+        "unverified_dependency",
+        "scope_not_captured"
+      ]
     }
   }
 }

--- a/schema/review-index-entry.schema.json
+++ b/schema/review-index-entry.schema.json
@@ -7,16 +7,31 @@
   "$defs": {
     "severity": {
       "type": "string",
-      "enum": ["critical", "high", "medium", "low", "info"]
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low",
+        "info"
+      ]
     },
     "parse_status": {
       "type": "string",
-      "enum": ["structured", "fallback_raw_text"]
+      "enum": [
+        "structured",
+        "fallback_raw_text",
+        "parse_attempted_but_failed"
+      ]
     },
     "finding_status": {
       "type": "string",
       "description": "Lifecycle status of a finding (aligned with Rust ReviewFindingStatus).",
-      "enum": ["open", "acknowledged", "fixed", "ignored"]
+      "enum": [
+        "open",
+        "acknowledged",
+        "fixed",
+        "ignored"
+      ]
     },
     "review_index_entry": {
       "type": "object",
@@ -40,19 +55,29 @@
           "type": "integer",
           "minimum": 0
         },
-        "scope": { "type": "string" },
-        "diff_hash": { "type": "string" },
+        "scope": {
+          "type": "string"
+        },
+        "diff_hash": {
+          "type": "string"
+        },
         "finding_count": {
           "type": "integer",
           "minimum": 0
         },
         "highest_severity": {
           "oneOf": [
-            { "$ref": "#/$defs/severity" },
-            { "type": "null" }
+            {
+              "$ref": "#/$defs/severity"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "parse_status": { "$ref": "#/$defs/parse_status" },
+        "parse_status": {
+          "$ref": "#/$defs/parse_status"
+        },
         "json_path": {
           "type": "string",
           "description": "Path to the full review artifact JSON."
@@ -73,11 +98,20 @@
         "updated_at_epoch_seconds"
       ],
       "properties": {
-        "report_id": { "type": "string" },
-        "finding_id": { "type": "string" },
-        "status": { "$ref": "#/$defs/finding_status" },
+        "report_id": {
+          "type": "string"
+        },
+        "finding_id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/finding_status"
+        },
         "note": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "description": "Optional note explaining the status change."
         },
         "updated_at_epoch_seconds": {


### PR DESCRIPTION
## Summary

Adds public documentation for Sego review artifacts so external AI coding agents can run Sego after code generation and explain the resulting review proof to users.

This PR makes the `.sego/reviews/` output easier to consume by tools without changing the normal review workflow.

## Changes

- Add a public review artifact contract for `.sego/reviews/` JSON, Markdown, and index files.
- Add an agent handoff guide describing when to call Sego and how to summarize review results safely.
- Add generic integration snippets for AI coding tool instruction files.
- Add additive review metadata fields for attribution/debugging.
- Update JSON Schemas to match current review artifact behavior.
- Link the new docs from README.

## Boundaries

- Metadata is local attribution/debug information, not a signature, provenance attestation, or safety certification.
- No user workflow is removed or made incompatible.
- Existing review commands and artifacts continue to work.

## Verification

- `cargo fmt --check`
- `cargo test -p runtime code_review`
- `cargo test -p rusty-claude-cli review`
- `cargo build -p rusty-claude-cli`
- JSON schema parse checks
- Sego review completed: `review-1782466461-c22865bb5a16`