### PR TITLE
fix(permission): default to ReadOnly instead of DangerFullAccess [PMF Gate 2]

### DIFF
--- a/rust/crates/rusty-claude-cli/src/args.rs
+++ b/rust/crates/rusty-claude-cli/src/args.rs
@@ -101,8 +101,8 @@ mod tests {
     }
 
     #[test]
-    fn defaults_to_danger_full_access_permission_mode() {
+    fn defaults_to_read_only_permission_mode() {
         let cli = Cli::parse_from(["rusty-claude-cli"]);
-        assert_eq!(cli.permission_mode, PermissionMode::DangerFullAccess);
+        assert_eq!(cli.permission_mode, PermissionMode::ReadOnly);
     }
 }

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -1196,7 +1196,7 @@ fn default_permission_mode() -> PermissionMode {
         .and_then(normalize_permission_mode)
         .map(permission_mode_from_label)
         .or_else(config_permission_mode_for_current_dir)
-        .unwrap_or(PermissionMode::DangerFullAccess)
+        .unwrap_or(PermissionMode::ReadOnly)
 }
 
 fn config_permission_mode_for_current_dir() -> Option<PermissionMode> {
@@ -9230,7 +9230,7 @@ mod tests {
             CliAction::Repl {
                 model: default_model(),
                 allowed_tools: None,
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }
@@ -9315,7 +9315,7 @@ mod tests {
                 model: default_model(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }
@@ -9338,7 +9338,7 @@ mod tests {
                 model: "claude-opus".to_string(),
                 output_format: CliOutputFormat::Json,
                 allowed_tools: None,
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }
@@ -9361,7 +9361,7 @@ mod tests {
                 model: "claude-opus-4-7".to_string(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }
@@ -9478,7 +9478,7 @@ mod tests {
                         .map(str::to_string)
                         .collect()
                 ),
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }
@@ -9557,7 +9557,7 @@ mod tests {
             parse_args(&["status".to_string()]).expect("status should parse"),
             CliAction::Status {
                 model: default_model(),
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
                 output_format: CliOutputFormat::Text,
             }
         );
@@ -9586,7 +9586,7 @@ mod tests {
                 model: default_model(),
                 output_format: CliOutputFormat::Text,
                 allowed_tools: None,
-                permission_mode: PermissionMode::DangerFullAccess,
+                permission_mode: PermissionMode::ReadOnly,
             }
         );
     }


### PR DESCRIPTION
## Summary

PMF Gate 2 (`PMF-G2-DEFAULT-SAFE-PERMISSION`): Change the default permission mode fallback from `DangerFullAccess` to `ReadOnly`, so a plain `sego` launch no longer grants unrestricted write/bash/agent access by default.

This aligns the product default with the **user-side safety layer** positioning (PA safety layer thesis; current product wedge = code review/acceptance proof).

## Changes
- `main.rs` `default_permission_mode()` fallback: `DangerFullAccess` → `ReadOnly`
- 8 test assertions migrated (Repl/Prompt/Status default-value assertions in `parse_args` tests)
- `args.rs` `defaults_to_*_permission_mode` test renamed and updated

## Why
A product positioning itself as a "user-side safety/trust layer" must not default to the most permissive mode. `sego review` already enforces ReadOnly, but the generic REPL/Prompt path defaulted to DangerFullAccess — making the "independent, user-aligned safety" narrative inconsistent with the code.

## Backward compatibility
Explicit override still available via:
- `--permission-mode danger-full-access` flag
- `RUSTY_CLAUDE_PERMISSION_MODE` env var
- project config (`.toml`)

## Verification
- `cargo fmt --all --check` ✅
- `cargo test --workspace` ✅ (510 passed; 1 intermittent Windows file-lock failure unrelated, passes on rerun)
- `cargo clippy --workspace --all-targets` ✅ (no new warnings; pre-existing warnings unchanged)

## Scope (per authorization)
- **Authorization**: `FOUNDER-PMF-BATCH1-AUTHORIZATION` (D8), Founder-signed
- **Executor**: ZCode
- **Reviewer**: Codex (final review pending)
- **Base**: `origin/main` @ `b3a5365`
- **Not in scope**: autonomy-explicit-opt-in (Agent/MCP/RemoteTrigger capability gating — separate receipt); RemoteTrigger network boundary; migration prompt

## Risk
Existing generic CLI users who rely on default write/bash/MCP/agent access will now need to pass `--permission-mode danger-full-access` explicitly. This is intentional (safety-first default) and documented in the commit message.