### PR TITLE
chore(release): Sego v0.1.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,35 +136,27 @@ jobs:
 
             ### 中文
 
-            Sego v0.1.8 重点强化了代码审查工作流的可靠性和可解释性。
+            Sego v0.1.9 将本地代码审查进一步收敛为可被人和 Agent 共同消费的受治理审查证明。
 
-            这次更新让 review 结果更容易判断：当模型输出中看起来包含 findings 但结构化解析失败时，Sego 会明确显示解析失败状态，并引导用户打开 Markdown 报告查看原始输出，而不是把结果误读成"没有问题"。导出审查报告时，CLI 也会给出更清晰的导出类型和字节信息，降低用户保存、转发、复盘报告时的歧义。
+            新增稳定的 `sego review show latest --json` / `/review show latest --json` 接口、Agent handoff 文档与集成模板，使调用方能够读取最新审查证明，而不必解析面向人的终端文本。ReviewArtifact 现在携带 `reviewer`、`engine_version`、`review_mode` 等本地身份元数据，并扩展了 parse/evidence 状态 schema。
 
-            v0.1.8 也加入了更明确的证据状态和恢复提示。审查结果会尽量标注证据是否可定位、路径是否可信；当非 Git 目录、恢复会话、工作区路径等场景出现问题时，Sego 会给出更直接的下一步建议，帮助用户从失败状态回到可继续操作的状态。
+            本版本还加入离线 Review Card、任务级 AcceptanceRecord、全范围审查 preflight、安全路径范围、evidence coverage、finding disposition、provider cache 可观测性和工作流事件恢复改进。默认权限由完全访问收紧为 `ReadOnly`，需要写权限时必须显式授予。
 
-            另一个重要变化是任务文件中的 review 命令执行逻辑。如果任务文件明确要求运行 `/review staged`、`/review workspace` 或允许的 full review 命令，Sego 会执行这些受支持的审查命令；对于 `/commit`、`dotnet build` 等非 review 命令，Sego 会明确阻断，并说明原因和下一步建议。这让"按任务文件执行审查"更接近真实开发协作流程，同时保持边界清晰。
+            Windows 插件生命周期与 hook 路径现在使用显式、同步的平台执行器，不再依赖文件关联；不支持的脚本、缺失解释器和非零退出都会按失败关闭。
 
-            需要说明的是，`sego review --full <path>` 会读取关键 manifest、入口文件和目录上下文快照，帮助发现项目级风险，但它不是穷尽式静态分析，也不承诺发现所有问题。高风险发布仍需要开发者结合测试、CI、人工判断和业务上下文一起决策。
-
-            自然语言导出也更强调安全边界：当用户说“保存刚才的报告”“导出上一条响应”时，Sego 会围绕最近一次或上一条可确认响应处理，而不是把任意自然语言误当成不受限制的文件写入命令。
-
-            Windows 路径和命令组合也有更清晰的提示：类似 `/cd E:\\Sego\\source && /review staged` 的 shell 风格组合命令不会被当成一条 review 命令直接执行，建议先切换目录，再单独运行 `/review staged`，减少路径转义和误执行问题。
+            边界保持不变：reviewer 元数据不是密码学签名或远程证明；Review Card、AcceptanceRecord 和 ReviewArtifact 是审查证据，不是发布批准、安全认证或 Founder verdict。模型驱动审查也不是穷尽式静态分析，高风险发布仍需要测试、CI 与人工裁决。
 
             ### English
 
-            Sego v0.1.8 focuses on making the code-review workflow more reliable, diagnosable, and usable in real development loops.
+            Sego v0.1.9 advances local code review into a governed proof surface that can be consumed by both humans and coding agents.
 
-            Review output is now easier to interpret. When model output appears to contain findings but structured parsing fails, Sego reports a clear parse-failure state and points the user to the Markdown report instead of letting the result look like a clean review. Export output is also clearer, including the export kind and byte count so reports are easier to save, share, and audit.
+            The new stable `sego review show latest --json` and `/review show latest --json` interfaces, agent handoff guidance, and integration templates let callers consume the latest review proof without scraping human-oriented terminal output. ReviewArtifact now carries local `reviewer`, `engine_version`, and `review_mode` metadata, together with expanded parse and evidence status schemas.
 
-            This release also improves evidence status and recovery guidance. Findings now carry clearer evidence signals where possible, and recovery messages give more actionable next steps when users are working in non-Git directories, restored sessions, or path-sensitive workspaces.
+            This release also adds offline Review Cards, task-level AcceptanceRecord aggregation, full-scope review preflight, safe path scoping, evidence coverage, finding disposition, provider-cache observability, and workflow-event recovery improvements. The default permission is tightened from full access to `ReadOnly`; write authority must be granted explicitly.
 
-            Task-file review execution is also improved. When a task file explicitly requires supported review commands such as `/review staged`, `/review workspace`, or allowlisted full-review commands, Sego can execute those review commands directly. Non-review commands such as `/commit` or `dotnet build` are blocked with structured guidance, keeping the workflow useful without silently crossing execution boundaries.
+            Windows plugin lifecycle and hook paths now use explicit synchronous platform runners instead of file associations; unsupported scripts, missing interpreters, and non-zero exits fail closed.
 
-            One important boundary remains: `sego review --full <path>` reviews key manifests, entry points, and a directory context snapshot. It is not exhaustive static analysis and does not guarantee that every issue will be found. High-risk releases should still be gated with tests, CI, human review, and product/business context.
-
-            Natural-language export is also bounded more carefully. Requests such as “save the last report” or “export the previous response” are tied to the latest or previous confirmable response instead of being treated as arbitrary unrestricted file-write commands.
-
-            Windows path and combined-command handling are clearer as well. Shell-style combinations such as `/cd E:\\Sego\\source && /review staged` are not treated as a single review command; users should switch directories first, then run `/review staged` separately to reduce path escaping and accidental execution issues.
+            The trust boundary remains explicit: reviewer metadata is not a cryptographic signature or remote attestation. Review Cards, AcceptanceRecords, and ReviewArtifacts are review evidence, not release approval, security certification, or a Founder verdict. Model-driven review is not exhaustive static analysis, so high-risk releases still require tests, CI, and human judgment.
 
             ### Download
             - **Windows:** `sego-windows.zip` for double-click use, or `sego.exe` for terminal use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Sego Agent project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-08-24
+
 ### Added
 - **Sego Review Card MVP**: `sego review card`, `sego review card latest`, and `sego review card <review-id>` render an existing local review JSON artifact into an escaped, offline HTML card, update `latest-card.html`, print a compact Green/Yellow/Red summary, and request opening it in the default browser. The card is a review proof, not release approval or security certification.
 - **Task acceptance record minimum practice**: adds a locale-neutral `AcceptanceRecord` contract that aggregates node, task-end, and full-review events, remediation trace, unresolved findings, and evidence links. A Chinese/English task-box and compact HTML display adapter localize Sego-owned copy while preserving original artifact evidence.
@@ -14,6 +16,7 @@ All notable changes to the Sego Agent project will be documented in this file.
 
 ### Changed
 - Updated review artifact JSON Schemas to include current parse/evidence status values (`parse_attempted_but_failed`, `evidence_status`) plus optional C21 metadata fields.
+- Plugin lifecycle and hook script paths now use explicit synchronous platform runners instead of Windows file associations; unsupported scripts, missing interpreters, and non-zero exits fail closed.
 
 ## [0.1.8] - 2026-06-23
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "api"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "reqwest",
  "runtime",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "commands"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "plugins",
  "runtime",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "compat-harness"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "commands",
  "runtime",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "mock-anthropic-service"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "api",
  "serde_json",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "getrandom 0.3.4",
  "glob",
@@ -1188,7 +1188,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-claude-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "api",
  "commands",
@@ -1447,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "api",
  "plugins",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/rust/crates/plugins/src/command_runner.rs
+++ b/rust/crates/plugins/src/command_runner.rs
@@ -1,0 +1,186 @@
+use std::io;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn is_literal_command(command: &str) -> bool {
+    !command.starts_with("./") && !command.starts_with("../") && !Path::new(command).is_absolute()
+}
+
+pub(crate) fn plugin_command(command: &str) -> io::Result<Command> {
+    if is_literal_command(command) {
+        return Ok(literal_command(command));
+    }
+
+    let path = Path::new(command);
+    if !path.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("plugin command path `{}` does not exist or is not a file", path.display()),
+        ));
+    }
+
+    path_command(path)
+}
+
+#[cfg(windows)]
+fn literal_command(command: &str) -> Command {
+    let mut process = Command::new("cmd.exe");
+    process.args(["/D", "/S", "/C"]).arg(command);
+    process
+}
+
+#[cfg(not(windows))]
+fn literal_command(command: &str) -> Command {
+    let mut process = Command::new("sh");
+    process.arg("-lc").arg(command);
+    process
+}
+
+#[cfg(windows)]
+fn path_command(path: &Path) -> io::Result<Command> {
+    let extension = path.extension().and_then(|value| value.to_str()).map(str::to_ascii_lowercase);
+
+    let process = match extension.as_deref() {
+        Some("cmd" | "bat") => {
+            let mut process = Command::new("cmd.exe");
+            process.args(["/D", "/S", "/C"]).raw_arg(format!("\"\"{}\"\"", path.display()));
+            process
+        }
+        Some("ps1") => {
+            let mut process = Command::new("powershell.exe");
+            process.args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"]).arg(path);
+            process
+        }
+        Some("sh") => {
+            let mut process = Command::new("sh");
+            process.arg(path);
+            process
+        }
+        Some("exe" | "com") => Command::new(path),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "unsupported Windows plugin command `{}`; expected .cmd, .bat, .ps1, .sh, .exe, or .com",
+                    path.display()
+                ),
+            ));
+        }
+    };
+
+    Ok(process)
+}
+
+#[cfg(not(windows))]
+fn path_command(path: &Path) -> io::Result<Command> {
+    let mut process = Command::new("sh");
+    process.arg(path);
+    Ok(process)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_literal_command, plugin_command};
+    use std::ffi::OsStr;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("plugins-command-runner-{label}-{nanos}"))
+    }
+
+    fn write_file(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("parent directory");
+        }
+        fs::write(path, "probe").expect("probe file");
+    }
+
+    #[test]
+    fn classifies_literal_and_path_commands_without_file_associations() {
+        assert!(is_literal_command("echo hello"));
+        assert!(!is_literal_command("./hooks/pre.sh"));
+        assert!(!is_literal_command("../hooks/pre.sh"));
+    }
+
+    #[test]
+    fn missing_path_fails_closed_before_spawn() {
+        let root = temp_dir("missing");
+        let missing = root.join("missing.sh");
+        let error = plugin_command(missing.to_str().expect("utf8 path"))
+            .expect_err("missing path must fail closed");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_path_commands_select_explicit_synchronous_runners() {
+        let root = temp_dir("windows-runners");
+        let cmd_path = root.join("probe.cmd");
+        let ps1_path = root.join("probe.ps1");
+        let sh_path = root.join("probe.sh");
+        let unsupported_path = root.join("probe.txt");
+        for path in [&cmd_path, &ps1_path, &sh_path, &unsupported_path] {
+            write_file(path);
+        }
+
+        let cmd = plugin_command(cmd_path.to_str().expect("utf8 path")).expect("cmd runner");
+        let ps1 = plugin_command(ps1_path.to_str().expect("utf8 path")).expect("ps1 runner");
+        let sh = plugin_command(sh_path.to_str().expect("utf8 path")).expect("sh runner");
+        let unsupported = plugin_command(unsupported_path.to_str().expect("utf8 path"))
+            .expect_err("unknown extensions must fail closed");
+
+        assert_eq!(cmd.get_program(), OsStr::new("cmd.exe"));
+        assert_eq!(ps1.get_program(), OsStr::new("powershell.exe"));
+        assert_eq!(sh.get_program(), OsStr::new("sh"));
+        assert_eq!(unsupported.kind(), std::io::ErrorKind::Unsupported);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_cmd_paths_with_spaces_execute_synchronously() {
+        let root = temp_dir("windows path with spaces");
+        let script_path = root.join("probe script.cmd");
+        fs::create_dir_all(&root).expect("probe directory");
+        fs::write(&script_path, "@echo off\r\necho synchronous\r\n").expect("probe command");
+
+        let output = plugin_command(script_path.to_str().expect("utf8 path"))
+            .expect("cmd runner")
+            .output()
+            .expect("cmd execution");
+
+        assert!(
+            output.status.success(),
+            "status={} stdout={} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "synchronous");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_path_commands_use_sh_explicitly() {
+        let root = temp_dir("unix-runner");
+        let script_path = root.join("probe.sh");
+        write_file(&script_path);
+
+        let command =
+            plugin_command(script_path.to_str().expect("utf8 path")).expect("shell runner");
+
+        assert_eq!(command.get_program(), OsStr::new("sh"));
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/rust/crates/plugins/src/hooks.rs
+++ b/rust/crates/plugins/src/hooks.rs
@@ -1,11 +1,9 @@
 use std::ffi::OsStr;
-#[cfg(not(windows))]
-use std::path::Path;
-use std::process::Command;
+use std::path::{Path, PathBuf};
 
 use serde_json::json;
 
-use crate::{PluginError, PluginHooks, PluginRegistry};
+use crate::{command_runner::plugin_command, PluginError, PluginHooks, PluginRegistry};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HookEvent {
@@ -53,26 +51,70 @@ impl HookRunResult {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HookCommand {
+    command: String,
+    working_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct HookPlan {
+    pre_tool_use: Vec<HookCommand>,
+    post_tool_use: Vec<HookCommand>,
+    post_tool_use_failure: Vec<HookCommand>,
+}
+
+impl HookPlan {
+    fn without_working_dir(hooks: PluginHooks) -> Self {
+        let commands = |entries: Vec<String>| {
+            entries.into_iter().map(|command| HookCommand { command, working_dir: None }).collect()
+        };
+        Self {
+            pre_tool_use: commands(hooks.pre_tool_use),
+            post_tool_use: commands(hooks.post_tool_use),
+            post_tool_use_failure: commands(hooks.post_tool_use_failure),
+        }
+    }
+
+    fn extend(&mut self, hooks: &PluginHooks, working_dir: Option<&Path>) {
+        let append = |target: &mut Vec<HookCommand>, commands: &[String]| {
+            target.extend(commands.iter().map(|command| HookCommand {
+                command: command.clone(),
+                working_dir: working_dir.map(Path::to_path_buf),
+            }));
+        };
+
+        append(&mut self.pre_tool_use, &hooks.pre_tool_use);
+        append(&mut self.post_tool_use, &hooks.post_tool_use);
+        append(&mut self.post_tool_use_failure, &hooks.post_tool_use_failure);
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct HookRunner {
-    hooks: PluginHooks,
+    plan: HookPlan,
 }
 
 impl HookRunner {
     #[must_use]
     pub fn new(hooks: PluginHooks) -> Self {
-        Self { hooks }
+        Self { plan: HookPlan::without_working_dir(hooks) }
     }
 
     pub fn from_registry(plugin_registry: &PluginRegistry) -> Result<Self, PluginError> {
-        Ok(Self::new(plugin_registry.aggregated_hooks()?))
+        let mut plan = HookPlan::default();
+        for plugin in plugin_registry.plugins().iter().filter(|plugin| plugin.is_enabled()) {
+            plugin.validate()?;
+            plan.extend(plugin.hooks(), plugin.metadata().root.as_deref());
+        }
+        Ok(Self { plan })
     }
 
     #[must_use]
     pub fn run_pre_tool_use(&self, tool_name: &str, tool_input: &str) -> HookRunResult {
         Self::run_commands(
             HookEvent::PreToolUse,
-            &self.hooks.pre_tool_use,
+            &self.plan.pre_tool_use,
             tool_name,
             tool_input,
             None,
@@ -90,7 +132,7 @@ impl HookRunner {
     ) -> HookRunResult {
         Self::run_commands(
             HookEvent::PostToolUse,
-            &self.hooks.post_tool_use,
+            &self.plan.post_tool_use,
             tool_name,
             tool_input,
             Some(tool_output),
@@ -107,7 +149,7 @@ impl HookRunner {
     ) -> HookRunResult {
         Self::run_commands(
             HookEvent::PostToolUseFailure,
-            &self.hooks.post_tool_use_failure,
+            &self.plan.post_tool_use_failure,
             tool_name,
             tool_input,
             Some(tool_error),
@@ -117,7 +159,7 @@ impl HookRunner {
 
     fn run_commands(
         event: HookEvent,
-        commands: &[String],
+        commands: &[HookCommand],
         tool_name: &str,
         tool_input: &str,
         tool_output: Option<&str>,
@@ -164,7 +206,7 @@ impl HookRunner {
 
     #[allow(clippy::too_many_arguments)]
     fn run_command(
-        command: &str,
+        hook_command: &HookCommand,
         event: HookEvent,
         tool_name: &str,
         tool_input: &str,
@@ -172,7 +214,23 @@ impl HookRunner {
         is_error: bool,
         payload: &str,
     ) -> HookCommandOutcome {
-        let mut child = shell_command(command);
+        let command = hook_command.command.as_str();
+        let mut process = match plugin_command(command) {
+            Ok(process) => process,
+            Err(error) => {
+                return HookCommandOutcome::Failed {
+                    message: format!(
+                        "{} hook `{command}` could not be prepared for `{tool_name}`: {error}",
+                        event.as_str()
+                    ),
+                };
+            }
+        };
+        if let Some(working_dir) = &hook_command.working_dir {
+            process.current_dir(working_dir).env("CLAWD_PLUGIN_ROOT", working_dir.as_os_str());
+        }
+
+        let mut child = CommandWithStdin::new(process);
         child.stdin(std::process::Stdio::piped());
         child.stdout(std::process::Stdio::piped());
         child.stderr(std::process::Stdio::piped());
@@ -267,34 +325,12 @@ fn format_hook_warning(command: &str, code: i32, stdout: Option<&str>, stderr: &
     message
 }
 
-fn shell_command(command: &str) -> CommandWithStdin {
-    #[cfg(windows)]
-    let command_builder = {
-        let mut command_builder = Command::new("cmd");
-        command_builder.arg("/C").arg(command);
-        CommandWithStdin::new(command_builder)
-    };
-
-    #[cfg(not(windows))]
-    let command_builder = if Path::new(command).exists() {
-        let mut command_builder = Command::new("sh");
-        command_builder.arg("-c").arg("exec sh \"$1\"").arg("sh").arg(command);
-        CommandWithStdin::new(command_builder)
-    } else {
-        let mut command_builder = Command::new("sh");
-        command_builder.arg("-lc").arg(command);
-        CommandWithStdin::new(command_builder)
-    };
-
-    command_builder
-}
-
 struct CommandWithStdin {
-    command: Command,
+    command: std::process::Command,
 }
 
 impl CommandWithStdin {
-    fn new(command: Command) -> Self {
+    fn new(command: std::process::Command) -> Self {
         Self { command }
     }
 
@@ -388,6 +424,37 @@ mod tests {
         .expect("write plugin manifest");
     }
 
+    fn write_root_probe_hook_plugin(root: &Path, name: &str) {
+        fs::create_dir_all(root.join(".claude-plugin")).expect("manifest dir");
+        fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+        let (script_command, script_body) = root_probe_script();
+        fs::write(root.join(script_command.trim_start_matches("./")), script_body)
+            .expect("write root probe hook");
+        fs::write(
+            root.join(".claude-plugin").join("plugin.json"),
+            format!(
+                "{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\",\n  \"description\": \"root probe hook plugin\",\n  \"hooks\": {{\n    \"PreToolUse\": [\"{script_command}\"]\n  }}\n}}"
+            ),
+        )
+        .expect("write root probe manifest");
+    }
+
+    #[cfg(windows)]
+    fn root_probe_script() -> (String, String) {
+        (
+            "./hooks/root-probe.cmd".to_string(),
+            "@echo off\r\n>> hook-root.log echo rooted\r\necho root ok\r\n".to_string(),
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn root_probe_script() -> (String, String) {
+        (
+            "./hooks/root-probe.sh".to_string(),
+            "#!/bin/sh\nprintf 'rooted\\n' >> hook-root.log\nprintf 'root ok\\n'\n".to_string(),
+        )
+    }
+
     #[cfg(windows)]
     fn hook_script(name: &str, message: &str) -> (String, String) {
         (format!("./hooks/{name}.cmd"), format!("@echo off\r\necho {message}\r\n"))
@@ -464,6 +531,34 @@ mod tests {
         let _ = fs::remove_dir_all(config_home);
         let _ = fs::remove_dir_all(first_source_root);
         let _ = fs::remove_dir_all(second_source_root);
+    }
+
+    #[test]
+    fn registry_hooks_run_synchronously_in_their_plugin_root() {
+        let config_home = temp_dir("root-probe-config");
+        let source_root = temp_dir("root-probe-source");
+        write_root_probe_hook_plugin(&source_root, "root-probe");
+
+        let mut manager = PluginManager::new(PluginManagerConfig::new(&config_home));
+        let install = manager
+            .install(source_root.to_str().expect("utf8 path"))
+            .expect("plugin install should succeed");
+        let registry = manager.plugin_registry().expect("registry should build");
+        let runner = HookRunner::from_registry(&registry).expect("plugin hooks should load");
+
+        let result = runner.run_pre_tool_use("Read", r#"{"path":"README.md"}"#);
+
+        assert_eq!(result, HookRunResult::allow(vec!["root ok".to_string()]));
+        assert_eq!(
+            fs::read_to_string(install.install_path.join("hook-root.log"))
+                .expect("hook root log should exist")
+                .replace("\r\n", "\n"),
+            "rooted\n"
+        );
+        assert!(!source_root.join("hook-root.log").exists());
+
+        let _ = fs::remove_dir_all(config_home);
+        let _ = fs::remove_dir_all(source_root);
     }
 
     #[test]

--- a/rust/crates/plugins/src/lib.rs
+++ b/rust/crates/plugins/src/lib.rs
@@ -1,3 +1,4 @@
+mod command_runner;
 mod hooks;
 
 use std::collections::{BTreeMap, BTreeSet};
@@ -9,6 +10,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
+
+use command_runner::{is_literal_command, plugin_command};
 
 pub use hooks::{HookEvent, HookRunResult, HookRunner};
 
@@ -1859,10 +1862,6 @@ fn resolve_hook_entry(root: &Path, entry: &str) -> String {
     }
 }
 
-fn is_literal_command(entry: &str) -> bool {
-    !entry.starts_with("./") && !entry.starts_with("../") && !Path::new(entry).is_absolute()
-}
-
 fn run_lifecycle_commands(
     metadata: &PluginMetadata,
     lifecycle: &PluginLifecycle,
@@ -1874,29 +1873,21 @@ fn run_lifecycle_commands(
     }
 
     for command in commands {
-        let mut process = if Path::new(command).exists() {
-            if cfg!(windows) {
-                let mut process = Command::new("cmd");
-                process.arg("/C").arg(command);
-                process
-            } else {
-                let mut process = Command::new("sh");
-                process.arg(command);
-                process
-            }
-        } else if cfg!(windows) {
-            let mut process = Command::new("cmd");
-            process.arg("/C").arg(command);
-            process
-        } else {
-            let mut process = Command::new("sh");
-            process.arg("-lc").arg(command);
-            process
-        };
+        let mut process = plugin_command(command).map_err(|error| {
+            PluginError::CommandFailed(format!(
+                "plugin `{}` {} could not prepare `{command}`: {error}",
+                metadata.id, phase
+            ))
+        })?;
         if let Some(root) = &metadata.root {
             process.current_dir(root);
         }
-        let output = process.output()?;
+        let output = process.output().map_err(|error| {
+            PluginError::CommandFailed(format!(
+                "plugin `{}` {} failed to start `{command}`: {error}",
+                metadata.id, phase
+            ))
+        })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -2155,22 +2146,46 @@ mod tests {
 
     fn write_lifecycle_plugin(root: &Path, name: &str, version: &str) -> PathBuf {
         let log_path = root.join("lifecycle.log");
-        write_file(
-            root.join("lifecycle").join("init.sh").as_path(),
-            "#!/bin/sh\nprintf 'init\\n' >> lifecycle.log\n",
-        );
-        write_file(
-            root.join("lifecycle").join("shutdown.sh").as_path(),
-            "#!/bin/sh\nprintf 'shutdown\\n' >> lifecycle.log\n",
-        );
+        let (init_command, init_body) = lifecycle_script("init", 0);
+        let (shutdown_command, shutdown_body) = lifecycle_script("shutdown", 0);
+        write_file(root.join(init_command.trim_start_matches("./")).as_path(), &init_body);
+        write_file(root.join(shutdown_command.trim_start_matches("./")).as_path(), &shutdown_body);
         write_file(
             root.join(MANIFEST_RELATIVE_PATH).as_path(),
             format!(
-                "{{\n  \"name\": \"{name}\",\n  \"version\": \"{version}\",\n  \"description\": \"lifecycle plugin\",\n  \"lifecycle\": {{\n    \"Init\": [\"./lifecycle/init.sh\"],\n    \"Shutdown\": [\"./lifecycle/shutdown.sh\"]\n  }}\n}}"
+                "{{\n  \"name\": \"{name}\",\n  \"version\": \"{version}\",\n  \"description\": \"lifecycle plugin\",\n  \"lifecycle\": {{\n    \"Init\": [\"{init_command}\"],\n    \"Shutdown\": [\"{shutdown_command}\"]\n  }}\n}}"
             )
             .as_str(),
         );
         log_path
+    }
+
+    fn write_failing_lifecycle_plugin(root: &Path, name: &str) {
+        let (init_command, init_body) = lifecycle_script("failing-init", 7);
+        write_file(root.join(init_command.trim_start_matches("./")).as_path(), &init_body);
+        write_file(
+            root.join(MANIFEST_RELATIVE_PATH).as_path(),
+            format!(
+                "{{\n  \"name\": \"{name}\",\n  \"version\": \"1.0.0\",\n  \"description\": \"failing lifecycle plugin\",\n  \"lifecycle\": {{\n    \"Init\": [\"{init_command}\"]\n  }}\n}}"
+            )
+            .as_str(),
+        );
+    }
+
+    #[cfg(windows)]
+    fn lifecycle_script(name: &str, exit_code: i32) -> (String, String) {
+        (
+            format!("./lifecycle/{name}.cmd"),
+            format!("@echo off\r\n>> lifecycle.log echo {name}\r\nexit /B {exit_code}\r\n"),
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn lifecycle_script(name: &str, exit_code: i32) -> (String, String) {
+        (
+            format!("./lifecycle/{name}.sh"),
+            format!("#!/bin/sh\nprintf '{name}\\n' >> lifecycle.log\nexit {exit_code}\n"),
+        )
     }
 
     fn write_tool_plugin(root: &Path, name: &str, version: &str) {
@@ -3039,7 +3054,26 @@ mod tests {
         registry.shutdown().expect("shutdown should succeed");
 
         let log = fs::read_to_string(&log_path).expect("lifecycle log should exist");
-        assert_eq!(log, "init\nshutdown\n");
+        assert_eq!(log.replace("\r\n", "\n"), "init\nshutdown\n");
+
+        let _ = fs::remove_dir_all(config_home);
+        let _ = fs::remove_dir_all(source_root);
+    }
+
+    #[test]
+    fn plugin_registry_propagates_lifecycle_command_failures() {
+        let config_home = temp_dir("failing-lifecycle-home");
+        let source_root = temp_dir("failing-lifecycle-source");
+        write_failing_lifecycle_plugin(&source_root, "failing-lifecycle-demo");
+
+        let mut manager = PluginManager::new(PluginManagerConfig::new(&config_home));
+        manager.install(source_root.to_str().expect("utf8 path")).expect("install should succeed");
+        let registry = manager.plugin_registry().expect("registry should build");
+
+        let error = registry.initialize().expect_err("non-zero lifecycle exit must fail closed");
+        let message = error.to_string();
+        assert!(message.contains("failing-lifecycle-demo@external"), "{message}");
+        assert!(message.contains('7'), "{message}");
 
         let _ = fs::remove_dir_all(config_home);
         let _ = fs::remove_dir_all(source_root);

--- a/rust/crates/rusty-claude-cli/src/main.rs
+++ b/rust/crates/rusty-claude-cli/src/main.rs
@@ -9184,34 +9184,32 @@ mod tests {
 
     fn write_plugin_fixture(root: &Path, name: &str, include_hooks: bool, include_lifecycle: bool) {
         fs::create_dir_all(root.join(".claude-plugin")).expect("manifest dir");
+        let (hook_command, hook_body) = plugin_fixture_hook();
+        let (init_command, init_body, shutdown_command, shutdown_body) = plugin_fixture_lifecycle();
         if include_hooks {
             fs::create_dir_all(root.join("hooks")).expect("hooks dir");
-            fs::write(root.join("hooks").join("pre.sh"), "#!/bin/sh\nprintf 'plugin pre hook'\n")
+            fs::write(root.join(hook_command.trim_start_matches("./")), hook_body)
                 .expect("write hook");
         }
         if include_lifecycle {
             fs::create_dir_all(root.join("lifecycle")).expect("lifecycle dir");
-            fs::write(
-                root.join("lifecycle").join("init.sh"),
-                "#!/bin/sh\nprintf 'init\\n' >> lifecycle.log\n",
-            )
-            .expect("write init lifecycle");
-            fs::write(
-                root.join("lifecycle").join("shutdown.sh"),
-                "#!/bin/sh\nprintf 'shutdown\\n' >> lifecycle.log\n",
-            )
-            .expect("write shutdown lifecycle");
+            fs::write(root.join(init_command.trim_start_matches("./")), init_body)
+                .expect("write init lifecycle");
+            fs::write(root.join(shutdown_command.trim_start_matches("./")), shutdown_body)
+                .expect("write shutdown lifecycle");
         }
 
         let hooks = if include_hooks {
-            ",\n  \"hooks\": {\n    \"PreToolUse\": [\"./hooks/pre.sh\"]\n  }"
+            format!(",\n  \"hooks\": {{\n    \"PreToolUse\": [\"{hook_command}\"]\n  }}")
         } else {
-            ""
+            String::new()
         };
         let lifecycle = if include_lifecycle {
-            ",\n  \"lifecycle\": {\n    \"Init\": [\"./lifecycle/init.sh\"],\n    \"Shutdown\": [\"./lifecycle/shutdown.sh\"]\n  }"
+            format!(
+                ",\n  \"lifecycle\": {{\n    \"Init\": [\"{init_command}\"],\n    \"Shutdown\": [\"{shutdown_command}\"]\n  }}"
+            )
         } else {
-            ""
+            String::new()
         };
         fs::write(
             root.join(".claude-plugin").join("plugin.json"),
@@ -9220,6 +9218,36 @@ mod tests {
             ),
         )
         .expect("write plugin manifest");
+    }
+
+    #[cfg(windows)]
+    fn plugin_fixture_hook() -> (&'static str, &'static str) {
+        ("./hooks/pre.cmd", "@echo off\r\necho plugin pre hook\r\n")
+    }
+
+    #[cfg(not(windows))]
+    fn plugin_fixture_hook() -> (&'static str, &'static str) {
+        ("./hooks/pre.sh", "#!/bin/sh\nprintf 'plugin pre hook'\n")
+    }
+
+    #[cfg(windows)]
+    fn plugin_fixture_lifecycle() -> (&'static str, &'static str, &'static str, &'static str) {
+        (
+            "./lifecycle/init.cmd",
+            "@echo off\r\n>> lifecycle.log echo init\r\n",
+            "./lifecycle/shutdown.cmd",
+            "@echo off\r\n>> lifecycle.log echo shutdown\r\n",
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn plugin_fixture_lifecycle() -> (&'static str, &'static str, &'static str, &'static str) {
+        (
+            "./lifecycle/init.sh",
+            "#!/bin/sh\nprintf 'init\\n' >> lifecycle.log\n",
+            "./lifecycle/shutdown.sh",
+            "#!/bin/sh\nprintf 'shutdown\\n' >> lifecycle.log\n",
+        )
     }
     #[test]
     fn defaults_to_repl_when_no_args() {
@@ -11546,8 +11574,9 @@ UU conflicted.rs",
             .expect("plugin state should load");
         let pre_hooks = state.feature_config.hooks().pre_tool_use();
         assert_eq!(pre_hooks.len(), 1);
+        let (fixture_hook_path, _) = plugin_fixture_hook();
         assert!(
-            pre_hooks[0].ends_with("hooks/pre.sh"),
+            Path::new(&pre_hooks[0]).ends_with(fixture_hook_path.trim_start_matches("./")),
             "expected installed plugin hook path, got {pre_hooks:?}"
         );
 
@@ -11734,12 +11763,15 @@ UU conflicted.rs",
         )
         .expect("runtime should build");
 
-        assert_eq!(fs::read_to_string(&log_path).expect("init log should exist"), "init\n");
+        assert_eq!(
+            fs::read_to_string(&log_path).expect("init log should exist").replace("\r\n", "\n"),
+            "init\n"
+        );
 
         runtime.shutdown_plugins().expect("plugin shutdown should succeed");
 
         assert_eq!(
-            fs::read_to_string(&log_path).expect("shutdown log should exist"),
+            fs::read_to_string(&log_path).expect("shutdown log should exist").replace("\r\n", "\n"),
             "init\nshutdown\n"
         );
 


### PR DESCRIPTION
## Summary
- establish the formal Sego v0.1.9 source and release baseline
- run plugin lifecycle and hook paths through explicit synchronous platform runners
- fail closed for unsupported scripts, missing interpreters, and non-zero exits
- publish updated bilingual release notes

## Local verification
- cargo fmt --all -- --check
- cargo test --workspace --offline
- cargo clippy --workspace --all-targets --offline (repository advisory policy; existing warnings only)
- cargo clippy -p plugins --all-targets --offline -- -D warnings
- cargo build --release --workspace --offline
- rust/target/release/sego.exe --version => 0.1.9