### PR TITLE
fix(review): land mitigation awareness prompt (FP reduction)

### DIFF
--- a/rust/crates/runtime/src/code_review/prompt.rs
+++ b/rust/crates/runtime/src/code_review/prompt.rs
@@ -51,6 +51,17 @@ pub fn build_review_prompt(context: &ReviewContext, options: ReviewPromptOptions
     prompt.push("- For generated or optimized code, actively look for newly introduced regressions and include verification commands in each finding when practical.".to_string());
     prompt.push(String::new());
 
+    prompt.push("Mitigation awareness (reduce false positives):".to_string());
+    prompt.push("- Before reporting a security vulnerability, check whether the code already contains a mitigation that neutralizes the risk. Common mitigations to look for:".to_string());
+    prompt.push("  * Parameterized queries / prepared statements (e.g., cursor.execute(sql, (params,)) with placeholder syntax like %s, ?, :name) — NOT string concatenation.".to_string());
+    prompt.push("  * Allowlist / denylist validation (e.g., netloc allowlist for redirects, event-type allowlist for webhooks, input regex validation).".to_string());
+    prompt.push("  * Cryptographic authentication replacing a relaxed check (e.g., HMAC-SHA256 signature verification on webhook endpoints that are @csrf_exempt, JWT verification, constant-time comparison).".to_string());
+    prompt.push("  * Sandboxed or restricted eval/exec (e.g., __builtins__ cleared, globals/locals allowlist, input sanitized to a strict character set).".to_string());
+    prompt.push("  * Shell=False with argument-list form (e.g., subprocess.run([\"cmd\", arg]) without shell=True, plus input validation).".to_string());
+    prompt.push("- If a mitigation is present and correctly implemented, do NOT report the 'vulnerable pattern' as a high/critical finding. At most, report it as info with a note like 'Mitigated by <mechanism>; verify the mitigation is correctly applied.'".to_string());
+    prompt.push("- If the mitigation appears incomplete or bypassable (e.g., allowlist uses startswith instead of exact match, or eval sandbox has a known escape), THEN report it — but explain the specific bypass in the evidence.".to_string());
+    prompt.push(String::new());
+
     if is_full_repo {
         prompt.push("Evidence gate (full repository audit):".to_string());
         prompt.push("- Every file path mentioned in a finding MUST appear in the file tree below. If you cannot locate a file, label it as unverified.".to_string());


### PR DESCRIPTION
## Summary

Lands the 'Mitigation awareness' review prompt improvement (cherry-pick of 9866978, originally developed 2026-07-30, verified in Gate 1 H1 calibration).

## What it does
Adds a 'Mitigation awareness (reduce false positives)' section to the code review prompt: before reporting a security vulnerability, the model must check for existing mitigations (parameterized queries, allowlists, HMAC/JWT auth, sandboxed eval, shell=False). If a mitigation is present, downgrade to info; if incomplete/bypassable, report with the specific bypass explained.

## Verified (Gate 1 offline calibration, 40-diff golden set)
- Security recall: 10/10 maintained
- fp-05 (redirect with netloc allowlist): 5 high false findings → **0 findings**
- fp-04 (CSRF-exempt webhook with HMAC): 7 medium → 8 low (severity downgraded)

## Context
- PR #74 (default permission → ReadOnly) already merged; this commit was authored on top of it but never pushed due to a network failure on 2026-07-30.
- Reference: FOUNDER-PMF-BATCH1-AUTHORIZATION (Gate 1 optimization), golden-set/H1-CALIBRATION-RESULT.md